### PR TITLE
4.x: Unit test lambdaification 16 of N

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableNullTests.java
@@ -71,7 +71,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(just1), _ -> null).blockingLast();
+        Flowable.combineLatestDelayError(Collections.singletonList(just1), _ -> null).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)
@@ -387,7 +387,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void flatMapIterableCombinerReturnsNull() {
-        just1.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1),
+        just1.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> List.of(1),
                 (_, _) -> null).blockingSubscribe();
     }
 
@@ -633,7 +633,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableCombinerReturnsNull() {
-        just1.zipWith(Arrays.asList(1), (_, _) -> null)
+        just1.zipWith(List.of(1), (_, _) -> null)
         .blockingSubscribe();
     }
 
@@ -735,7 +735,7 @@ public class FlowableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionReturnsNull() {
-        Flowable.combineLatestDelayError(Arrays.asList(just1), _ -> null, 128).blockingLast();
+        Flowable.combineLatestDelayError(Collections.singletonList(just1), _ -> null, 128).blockingLast();
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -617,7 +617,7 @@ public class FlowableSubscriberTest {
 
         Flowable.<Integer>error(new TestException()).subscribe(v -> list.add(v), _ -> list.add(100));
 
-        assertEquals(Arrays.asList(100), list);
+        assertEquals(List.of(100), list);
     }
 
     @Test
@@ -652,7 +652,7 @@ public class FlowableSubscriberTest {
 
         Flowable.just(1).subscribe(v -> list.add(v), _ -> list.add(100));
 
-        assertEquals(Arrays.asList(1), list);
+        assertEquals(List.of(1), list);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
@@ -76,7 +76,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+        assertEquals(List.<Object>of("OnComplete"), events);
 
     }
 
@@ -111,7 +111,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+        assertEquals(List.<Object>of("OnComplete"), events);
 
     }
 
@@ -208,7 +208,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
                 }
             }.subscribe(this, this, composite);
 
-            assertEquals(Arrays.<Object>asList("OnComplete"), events);
+            assertEquals(List.<Object>of("OnComplete"), events);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
@@ -84,7 +84,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
     }
 
@@ -101,7 +101,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
     }
 
@@ -136,7 +136,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList("OnComplete"), events);
+        assertEquals(List.<Object>of("OnComplete"), events);
 
     }
 
@@ -254,7 +254,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
                     }, composite, this, this, this
                 );
 
-            assertEquals(Arrays.<Object>asList("OnComplete"), events);
+            assertEquals(List.<Object>of("OnComplete"), events);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/ObservableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/ObservableConsumersTest.java
@@ -85,11 +85,11 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         assertEquals(0, composite.size());
     }
@@ -107,11 +107,11 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         assertEquals(0, composite.size());
     }
@@ -131,7 +131,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onError(new IOException());
 
@@ -154,7 +154,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
@@ -176,7 +176,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onError(new IOException());
 
@@ -276,7 +276,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
             processor.onNext(1);
             processor.onComplete();
 
-            assertEquals(Arrays.asList(1), events);
+            assertEquals(List.of(1), events);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/SingleConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/SingleConsumersTest.java
@@ -79,7 +79,7 @@ public class SingleConsumersTest implements Consumer<Object> {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
     }
 
@@ -96,7 +96,7 @@ public class SingleConsumersTest implements Consumer<Object> {
 
         assertEquals(0, composite.size());
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
     }
 
@@ -176,7 +176,7 @@ public class SingleConsumersTest implements Consumer<Object> {
                     }, composite, this, this
                 );
 
-            assertEquals(Arrays.<Object>asList(1), events);
+            assertEquals(List.<Object>of(1), events);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
@@ -446,7 +446,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorIterableCancel() {
-        Completable.mergeDelayError(Arrays.asList(Completable.complete()))
+        Completable.mergeDelayError(Collections.singletonList(Completable.complete()))
         .test(true)
         .assertEmpty();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
@@ -280,7 +280,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         scheduler.advanceTimeBy(1001, TimeUnit.MILLISECONDS);
 
-        inOrder.verify(subscriber, times(5)).onNext(Arrays.<Integer> asList());
+        inOrder.verify(subscriber, times(5)).onNext(List.<Integer>of());
 
         ts.cancel();
 
@@ -317,7 +317,7 @@ public class FlowableBufferTest extends RxJavaTest {
         source.onNext(6);
         boundary.onComplete();
 
-        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList(6));
+        inOrder.verify(subscriber, times(1)).onNext(List.of(6));
 
         inOrder.verify(subscriber).onComplete();
 
@@ -336,7 +336,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         boundary.onComplete();
 
-        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(List.of());
 
         inOrder.verify(subscriber).onComplete();
 
@@ -355,7 +355,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         source.onComplete();
 
-        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(List.of());
 
         inOrder.verify(subscriber).onComplete();
 
@@ -375,7 +375,7 @@ public class FlowableBufferTest extends RxJavaTest {
         source.onComplete();
         boundary.onComplete();
 
-        inOrder.verify(subscriber, times(1)).onNext(Arrays.asList());
+        inOrder.verify(subscriber, times(1)).onNext(List.of());
 
         inOrder.verify(subscriber).onComplete();
 
@@ -495,8 +495,8 @@ public class FlowableBufferTest extends RxJavaTest {
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(subscriber).onNext(Arrays.asList(0L));
-        inOrder.verify(subscriber).onNext(Arrays.asList(1L));
+        inOrder.verify(subscriber).onNext(List.of(0L));
+        inOrder.verify(subscriber).onNext(List.of(1L));
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
 
@@ -546,7 +546,7 @@ public class FlowableBufferTest extends RxJavaTest {
         inOrder.verify(subscriber).onNext(Arrays.asList(1, 2));
         inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(subscriber, never()).onNext(Arrays.asList(3));
+        verify(subscriber, never()).onNext(List.of(3));
         verify(subscriber, never()).onComplete();
 
     }
@@ -572,7 +572,7 @@ public class FlowableBufferTest extends RxJavaTest {
         inOrder.verify(subscriber).onNext(Arrays.asList(1, 2));
         inOrder.verify(subscriber).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(subscriber, never()).onNext(Arrays.asList(3));
+        verify(subscriber, never()).onNext(List.of(3));
         verify(subscriber, never()).onComplete();
 
     }
@@ -591,7 +591,7 @@ public class FlowableBufferTest extends RxJavaTest {
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
         inOrder.verify(subscriber).onNext(Arrays.asList(0L, 1L));
-        inOrder.verify(subscriber).onNext(Arrays.asList(2L));
+        inOrder.verify(subscriber).onNext(List.of(2L));
         inOrder.verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
     }
@@ -872,7 +872,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         cdl.await();
 
-        verify(subscriber).onNext(Arrays.asList(1));
+        verify(subscriber).onNext(List.of(1));
         verify(subscriber).onComplete();
         verify(subscriber, never()).onError(any(Throwable.class));
 
@@ -948,7 +948,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 Arrays.asList(7, 8, 9),
                 Arrays.asList(8, 9, 10),
                 Arrays.asList(9, 10),
-                Arrays.asList(10)
+                List.of(10)
         );
         ts.assertComplete();
         ts.assertNoErrors();
@@ -985,7 +985,7 @@ public class FlowableBufferTest extends RxJavaTest {
                 Arrays.asList(1, 2),
                 Arrays.asList(2, 3),
                 Arrays.asList(3, 4),
-                Arrays.asList(4),
+                List.of(4),
                 Collections.<Integer>emptyList()
         );
 
@@ -1022,7 +1022,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         ts.assertValues(
                 Arrays.asList(1, 2),
-                Arrays.asList(4)
+                List.of(4)
         );
 
         ts.assertNoErrors();
@@ -1063,7 +1063,7 @@ public class FlowableBufferTest extends RxJavaTest {
                     Arrays.asList(1, 2),
                     Arrays.asList(2, 3),
                     Arrays.asList(3, 4),
-                    Arrays.asList(4),
+                    List.of(4),
                     Collections.<Integer>emptyList()
             );
 
@@ -1106,7 +1106,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
             ts.assertValues(
                     Arrays.asList(1, 2),
-                    Arrays.asList(4)
+                    List.of(4)
             );
 
             ts.assertNoErrors();
@@ -1324,7 +1324,7 @@ public class FlowableBufferTest extends RxJavaTest {
         Flowable.range(1, 5)
         .buffer(1, TimeUnit.DAYS, Schedulers.single(), 2, Functions.<Integer>createArrayList(16), true)
         .test()
-        .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5));
+        .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), List.of(5));
     }
 
     @Test
@@ -1349,7 +1349,7 @@ public class FlowableBufferTest extends RxJavaTest {
             }
         })
         .test()
-        .assertFailure(TestException.class, Arrays.asList(1));
+        .assertFailure(TestException.class, List.of(1));
     }
 
     @Test
@@ -1396,7 +1396,7 @@ public class FlowableBufferTest extends RxJavaTest {
             Arrays.asList(2, 3, 4, 5),
             Arrays.asList(3, 4, 5),
             Arrays.asList(4, 5),
-            Arrays.asList(5)
+                List.of(5)
         );
     }
 
@@ -1475,7 +1475,7 @@ public class FlowableBufferTest extends RxJavaTest {
         pp.onNext(2);
 
         ts
-        .assertFailure(TestException.class, Arrays.asList(1));
+        .assertFailure(TestException.class, List.of(1));
     }
 
     @Test
@@ -1496,11 +1496,11 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(f -> f.buffer(1), false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(1), false, 1, 1, List.of(1));
 
-        TestHelper.checkBadSourceFlowable(f -> f.buffer(1, 2), false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(1, 2), false, 1, 1, List.of(1));
 
-        TestHelper.checkBadSourceFlowable(f -> f.buffer(2, 1), false, 1, 1, Arrays.asList(1));
+        TestHelper.checkBadSourceFlowable(f -> f.buffer(2, 1), false, 1, 1, List.of(1));
     }
 
     @Test
@@ -1534,7 +1534,7 @@ public class FlowableBufferTest extends RxJavaTest {
         Flowable.just(1)
         .buffer(2, 3)
         .test()
-        .assertResult(Arrays.asList(1));
+        .assertResult(List.of(1));
     }
 
     @Test
@@ -1543,7 +1543,7 @@ public class FlowableBufferTest extends RxJavaTest {
         .buffer(2, 3)
         .rebatchRequests(1)
         .test()
-        .assertResult(Arrays.asList(1, 2), Arrays.asList(4, 5), Arrays.asList(7, 8), Arrays.asList(10));
+        .assertResult(Arrays.asList(1, 2), Arrays.asList(4, 5), Arrays.asList(7, 8), List.of(10));
     }
 
     @Test
@@ -2205,7 +2205,7 @@ public class FlowableBufferTest extends RxJavaTest {
                     () -> pp.onComplete()
             );
 
-            ts.assertResult(Arrays.asList(1));
+            ts.assertResult(List.of(1));
         }
     }
 
@@ -2225,7 +2225,7 @@ public class FlowableBufferTest extends RxJavaTest {
         .buffer(BehaviorProcessor.createDefault(2), _ -> Flowable.just(1))
         .takeUntil(_ -> true)
         .test()
-        .assertResult(Arrays.asList());
+        .assertResult(List.of());
     }
 
     @Test
@@ -2242,7 +2242,7 @@ public class FlowableBufferTest extends RxJavaTest {
         BehaviorProcessor.createDefault(1)
         .buffer(BehaviorProcessor.createDefault(2), _ -> Flowable.just(1))
         .test(1L)
-        .assertValuesOnly(Arrays.asList());
+        .assertValuesOnly(List.of());
     }
 
     @Test
@@ -2265,6 +2265,6 @@ public class FlowableBufferTest extends RxJavaTest {
         bp.onNext(1);
 
         ts
-        .assertValuesOnly(Arrays.asList());
+        .assertValuesOnly(List.of());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -593,7 +593,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void concatEagerOne() {
-        Flowable.concatEager(Arrays.asList(Flowable.just(1)))
+        Flowable.concatEager(Collections.singletonList(Flowable.just(1)))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -338,7 +338,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
             }
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
-            .concatMap(t -> Flowable.fromIterable(Arrays.asList(t)), 2, ImmediateThinScheduler.INSTANCE)
+            .concatMap(t -> Flowable.fromIterable(Collections.singletonList(t)), 2, ImmediateThinScheduler.INSTANCE)
             .observeOn(Schedulers.computation()).subscribe(ts);
 
             ts.awaitDone(2500, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
@@ -782,7 +782,7 @@ public class FlowableConcatTest {
             }
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.range(0, 1000)
-            .concatMap(t -> Flowable.fromIterable(Arrays.asList(t)))
+            .concatMap(t -> Flowable.fromIterable(Collections.singletonList(t)))
             .observeOn(Schedulers.computation()).subscribe(ts);
 
             ts.awaitDone(2500, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
@@ -78,7 +78,7 @@ public class FlowableElementAtTest extends RxJavaTest {
             .elementAt(2)
             .blockingGet()
                 .intValue();
-        assertEquals(Arrays.asList(3L), requests);
+        assertEquals(List.of(3L), requests);
     }
 
     @Test
@@ -89,7 +89,7 @@ public class FlowableElementAtTest extends RxJavaTest {
             .elementAt(2, 100)
             .blockingGet()
                 .intValue();
-        assertEquals(Arrays.asList(3L), requests);
+        assertEquals(List.of(3L), requests);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -127,8 +127,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsNormal() {
         Flowable<Integer> onNext = Flowable.fromIterable(Arrays.asList(1, 2, 3));
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -149,8 +149,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsException() {
         Flowable<Integer> onNext = Flowable.fromIterable(Arrays.asList(1, 2, 3));
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
         Flowable<Integer> source = Flowable.concat(
                 Flowable.fromIterable(Arrays.asList(10, 20, 30)),
@@ -187,8 +187,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void flatMapTransformsOnNextFuncThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-            Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+            Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+            Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
             Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -209,8 +209,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsOnErrorFuncThrows() {
         Flowable<Integer> onNext = Flowable.fromIterable(Arrays.asList(1, 2, 3));
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
         Flowable<Integer> source = Flowable.error(new TestException());
 
@@ -226,10 +226,10 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsOnCompletedFuncThrows() {
         Flowable<Integer> onNext = Flowable.fromIterable(Arrays.asList(1, 2, 3));
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
-        Flowable<Integer> source = Flowable.fromIterable(Arrays.<Integer> asList());
+        Flowable<Integer> source = Flowable.fromIterable(List.<Integer>of());
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -243,8 +243,8 @@ public class FlowableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsMergeException() {
         Flowable<Integer> onNext = Flowable.error(new TestException());
-        Flowable<Integer> onComplete = Flowable.fromIterable(Arrays.asList(4));
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onComplete = Flowable.fromIterable(List.of(4));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -338,10 +338,10 @@ public class FlowableFlatMapTest extends RxJavaTest {
                 .subscribeOn(Schedulers.computation())
                 ;
 
-        Flowable<Integer> onComplete = composer(Flowable.fromIterable(Arrays.asList(4)), subscriptionCount, m)
+        Flowable<Integer> onComplete = composer(Flowable.fromIterable(List.of(4)), subscriptionCount, m)
                 .subscribeOn(Schedulers.computation());
 
-        Flowable<Integer> onError = Flowable.fromIterable(Arrays.asList(5));
+        Flowable<Integer> onError = Flowable.fromIterable(List.of(5));
 
         Flowable<Integer> source = Flowable.fromIterable(Arrays.asList(10, 20, 30));
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -456,7 +456,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void flatMapIterablePrefetch() {
         Flowable.just(1, 2)
-        .flatMapIterable((Function<Integer, Iterable<Integer>>) t -> Arrays.asList(t * 10), 1)
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) t -> List.of(t * 10), 1)
         .test()
         .assertResult(10, 20);
     }
@@ -599,7 +599,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
             if ((v & 1) == 0) {
                 return Collections.emptyList();
             }
-            return Arrays.asList(v);
+            return List.of(v);
         })
         .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
@@ -652,7 +652,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void take() {
         Flowable.range(1, 3)
-        .flatMapIterable(Functions.justFunction(Arrays.asList(1)), 1)
+        .flatMapIterable(Functions.justFunction(List.of(1)), 1)
         .take(1)
         .test()
         .assertResult(1);
@@ -669,7 +669,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
                 s.onNext(3);
             }
         }
-        .flatMapIterable(Functions.justFunction(Arrays.asList(1)), 1)
+        .flatMapIterable(Functions.justFunction(List.of(1)), 1)
         .test(0L)
         .assertFailure(QueueOverflowException.class);
     }
@@ -677,7 +677,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     @Test
     public void oneByOne() {
         Flowable.range(1, 3).hide()
-        .flatMapIterable(Functions.justFunction(Arrays.asList(1)), 1)
+        .flatMapIterable(Functions.justFunction(List.of(1)), 1)
         .rebatchRequests(1)
         .test()
         .assertResult(1, 1, 1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
@@ -992,7 +992,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     public void fusedPoll() throws Throwable {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
-        Flowable.fromIterable(Arrays.asList(1))
+        Flowable.fromIterable(List.of(1))
         .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -61,7 +61,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList("one", "two", "six").toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList("four", "five").toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList("three").toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of("three").toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -74,7 +74,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList(3, 3, 3).toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList(4, 4).toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList(5).toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of(5).toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList(3, 3, 3).toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList(4, 4).toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList(5).toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of(5).toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -942,9 +942,9 @@ public class FlowableGroupByTest extends RxJavaTest {
                     subscriber.onError(e);
                 }
         ).groupBy(i -> i % 2).subscribe(outer);
-        assertEquals(Arrays.asList(e), outer.errors());
-        assertEquals(Arrays.asList(e), inner1.errors());
-        assertEquals(Arrays.asList(e), inner2.errors());
+        assertEquals(List.of(e), outer.errors());
+        assertEquals(List.of(e), inner1.errors());
+        assertEquals(List.of(e), inner2.errors());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
@@ -160,7 +160,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
     public void backpressureWithEmissionThenError() {
         TestSubscriber<Notification<Integer>> ts = new TestSubscriber<>(0L);
         IllegalArgumentException ex = new IllegalArgumentException();
-        Flowable.fromIterable(Arrays.asList(1)).concatWith(Flowable.<Integer> error(ex)).materialize()
+        Flowable.fromIterable(List.of(1)).concatWith(Flowable.<Integer> error(ex)).materialize()
                 .subscribe(ts);
         ts.assertNoValues();
         ts.request(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
-import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -1005,7 +1004,7 @@ public class FlowableMergeTest extends RxJavaTest {
         subscriber.request(3); // 1, 2, <error>
         subscriber.assertValues(1, 2);
         subscriber.assertTerminated();
-        assertEquals(asList(exception), subscriber.errors());
+        assertEquals(List.of(exception), subscriber.errors());
     }
 
     @Test
@@ -1017,7 +1016,7 @@ public class FlowableMergeTest extends RxJavaTest {
         subscriber.request(2); // 1, <error>
         subscriber.assertValue(1);
         subscriber.assertTerminated();
-        assertEquals(asList(exception), subscriber.errors());
+        assertEquals(List.of(exception), subscriber.errors());
     }
 
     @Test
@@ -1041,7 +1040,7 @@ public class FlowableMergeTest extends RxJavaTest {
         assertEquals(Collections.<Throwable>emptyList(), subscriber.errors());
         subscriber.request(1);
         subscriber.assertValues(1, 2);
-        assertEquals(asList(exception), subscriber.errors());
+        assertEquals(List.of(exception), subscriber.errors());
     }
 
     @Test
@@ -1055,7 +1054,7 @@ public class FlowableMergeTest extends RxJavaTest {
         assertEquals(Collections.<Throwable>emptyList(), subscriber.errors());
         subscriber.request(2);
         subscriber.assertValues(1, 2, 3, 4);
-        assertEquals(asList(exception), subscriber.errors());
+        assertEquals(List.of(exception), subscriber.errors());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -695,7 +695,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
                 });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         // FIXME observeOn requests bufferSize at first always
-        assertEquals(Arrays.asList(128L), requests);
+        assertEquals(List.of(128L), requests);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -709,7 +709,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -722,7 +722,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);
         buf.complete();
@@ -1450,7 +1450,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -1463,7 +1463,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -726,7 +726,7 @@ public class FlowableReplayTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -739,7 +739,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);
         buf.complete();
@@ -1515,7 +1515,7 @@ public class FlowableReplayTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -1528,7 +1528,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
@@ -105,7 +105,7 @@ public class FlowableSingleTest extends RxJavaTest {
                     }
                 });
         // FIXME single now triggers fast-path
-        assertEquals(Arrays.asList(Long.MAX_VALUE), requests);
+        assertEquals(List.of(Long.MAX_VALUE), requests);
     }
 
     @Test
@@ -140,7 +140,7 @@ public class FlowableSingleTest extends RxJavaTest {
                     }
                 });
         // FIXME single now triggers fast-path
-        assertEquals(Arrays.asList(Long.MAX_VALUE), requests);
+        assertEquals(List.of(Long.MAX_VALUE), requests);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class FlowableSingleTest extends RxJavaTest {
                     }
                 });
         // FIXME single now triggers fast-path
-        assertEquals(Arrays.asList(Long.MAX_VALUE), requests);
+        assertEquals(List.of(Long.MAX_VALUE), requests);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -43,7 +44,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void switchWhenEmpty() throws Exception {
         final Flowable<Integer> flowable = Flowable.<Integer>empty()
-                .switchIfEmpty(Flowable.fromIterable(Arrays.asList(42)));
+                .switchIfEmpty(Flowable.fromIterable(List.of(42)));
 
         assertEquals(42, flowable.blockingSingle().intValue());
     }
@@ -124,7 +125,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
         Flowable.<Integer>empty().switchIfEmpty(Flowable.just(1, 2, 3)).subscribe(ts);
 
-        assertEquals(Arrays.asList(1), ts.values());
+        assertEquals(List.of(1), ts.values());
         ts.assertNoErrors();
         ts.request(1);
         ts.assertValueCount(2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -52,21 +52,15 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWhenOuterCompleteBeforeInner() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 70, "one");
-                        publishNext(subscriber, 100, "two");
-                        publishCompleted(subscriber, 200);
-                    }
-                }));
-                publishCompleted(subscriber, 60);
-            }
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 50, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 70, "one");
+                publishNext(subscriber1, 100, "two");
+                publishCompleted(subscriber1, 200);
+            }));
+            publishCompleted(subscriber, 60);
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -81,31 +75,22 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWhenInnerCompleteBeforeOuter() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 10, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 0, "one");
-                        publishNext(subscriber, 10, "two");
-                        publishCompleted(subscriber, 20);
-                    }
-                }));
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 10, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 0, "one");
+                publishNext(subscriber1, 10, "two");
+                publishCompleted(subscriber1, 20);
+            }));
 
-                publishNext(subscriber, 100, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 0, "three");
-                        publishNext(subscriber, 10, "four");
-                        publishCompleted(subscriber, 20);
-                    }
-                }));
-                publishCompleted(subscriber, 200);
-            }
+            publishNext(subscriber, 100, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber2, 0, "three");
+                publishNext(subscriber2, 10, "four");
+                publishCompleted(subscriber2, 20);
+            }));
+            publishCompleted(subscriber, 200);
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -127,30 +112,21 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWithComplete() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(final Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 60, "one");
-                        publishNext(subscriber, 100, "two");
-                    }
-                }));
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 50, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 60, "one");
+                publishNext(subscriber1, 100, "two");
+            }));
 
-                publishNext(subscriber, 200, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(final Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 0, "three");
-                        publishNext(subscriber, 100, "four");
-                    }
-                }));
+            publishNext(subscriber, 200, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber2, 0, "three");
+                publishNext(subscriber2, 100, "four");
+            }));
 
-                publishCompleted(subscriber, 250);
-            }
+            publishCompleted(subscriber, 250);
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -186,30 +162,21 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWithError() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(final Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 50, "one");
-                        publishNext(subscriber, 100, "two");
-                    }
-                }));
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 50, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 50, "one");
+                publishNext(subscriber1, 100, "two");
+            }));
 
-                publishNext(subscriber, 200, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 0, "three");
-                        publishNext(subscriber, 100, "four");
-                    }
-                }));
+            publishNext(subscriber, 200, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber2, 0, "three");
+                publishNext(subscriber2, 100, "four");
+            }));
 
-                publishError(subscriber, 250, new TestException());
-            }
+            publishError(subscriber, 250, new TestException());
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -245,35 +212,23 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWithSubsequenceComplete() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 50, "one");
-                        publishNext(subscriber, 100, "two");
-                    }
-                }));
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 50, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 50, "one");
+                publishNext(subscriber1, 100, "two");
+            }));
 
-                publishNext(subscriber, 130, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishCompleted(subscriber, 0);
-                    }
-                }));
+            publishNext(subscriber, 130, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishCompleted(subscriber2, 0);
+            }));
 
-                publishNext(subscriber, 150, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 50, "three");
-                    }
-                }));
-            }
+            publishNext(subscriber, 150, Flowable.unsafeCreate(subscriber3 -> {
+                subscriber3.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber3, 50, "three");
+            }));
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -299,36 +254,24 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void switchWithSubsequenceError() {
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 50, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 50, "one");
-                        publishNext(subscriber, 100, "two");
-                    }
-                }));
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 50, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 50, "one");
+                publishNext(subscriber1, 100, "two");
+            }));
 
-                publishNext(subscriber, 130, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishError(subscriber, 0, new TestException());
-                    }
-                }));
+            publishNext(subscriber, 130, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishError(subscriber2, 0, new TestException());
+            }));
 
-                publishNext(subscriber, 150, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 50, "three");
-                    }
-                }));
+            publishNext(subscriber, 150, Flowable.unsafeCreate(subscriber3 -> {
+                subscriber3.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber3, 50, "three");
+            }));
 
-            }
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -353,62 +296,38 @@ public class FlowableSwitchTest extends RxJavaTest {
     }
 
     private <T> void publishCompleted(final Subscriber<T> subscriber, long delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Subscriber<T> subscriber, long delay, final Throwable error) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onError(error);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onError(error), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Subscriber<T> subscriber, long delay, final T value) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void switchIssue737() {
         // https://github.com/ReactiveX/RxJava/issues/737
-        Flowable<Flowable<String>> source = Flowable.unsafeCreate(new Publisher<Flowable<String>>() {
-            @Override
-            public void subscribe(Subscriber<? super Flowable<String>> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 0, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 10, "1-one");
-                        publishNext(subscriber, 20, "1-two");
-                        // The following events will be ignored
-                        publishNext(subscriber, 30, "1-three");
-                        publishCompleted(subscriber, 40);
-                    }
-                }));
-                publishNext(subscriber, 25, Flowable.unsafeCreate(new Publisher<String>() {
-                    @Override
-                    public void subscribe(Subscriber<? super String> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        publishNext(subscriber, 10, "2-one");
-                        publishNext(subscriber, 20, "2-two");
-                        publishNext(subscriber, 30, "2-three");
-                        publishCompleted(subscriber, 40);
-                    }
-                }));
-                publishCompleted(subscriber, 30);
-            }
+        Flowable<Flowable<String>> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 0, Flowable.unsafeCreate(subscriber1 -> {
+                subscriber1.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber1, 10, "1-one");
+                publishNext(subscriber1, 20, "1-two");
+                // The following events will be ignored
+                publishNext(subscriber1, 30, "1-three");
+                publishCompleted(subscriber1, 40);
+            }));
+            publishNext(subscriber, 25, Flowable.unsafeCreate(subscriber2 -> {
+                subscriber2.onSubscribe(new BooleanSubscription());
+                publishNext(subscriber2, 10, "2-one");
+                publishNext(subscriber2, 20, "2-two");
+                publishNext(subscriber2, 30, "2-three");
+                publishCompleted(subscriber2, 40);
+            }));
+            publishCompleted(subscriber, 30);
         });
 
         Flowable<String> sampled = Flowable.switchOnNext(source);
@@ -492,14 +411,11 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void unsubscribe() {
         final AtomicBoolean isUnsubscribed = new AtomicBoolean();
         Flowable.switchOnNext(
-                Flowable.unsafeCreate(new Publisher<Flowable<Integer>>() {
-                    @Override
-                    public void subscribe(final Subscriber<? super Flowable<Integer>> subscriber) {
-                        BooleanSubscription bs = new BooleanSubscription();
-                        subscriber.onSubscribe(bs);
-                        subscriber.onNext(Flowable.just(1));
-                        isUnsubscribed.set(bs.isCancelled());
-                    }
+                Flowable.unsafeCreate((Publisher<Flowable<Integer>>) subscriber -> {
+                    BooleanSubscription bs = new BooleanSubscription();
+                    subscriber.onSubscribe(bs);
+                    subscriber.onNext(Flowable.just(1));
+                    isUnsubscribed.set(bs.isCancelled());
                 })
         ).take(1).subscribe();
         assertTrue("Switch doesn't propagate 'unsubscribe'", isUnsubscribed.get());
@@ -509,19 +425,9 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void issue2654() {
         Flowable<String> oneItem = Flowable.just("Hello").mergeWith(Flowable.<String>never());
 
-        Flowable<String> src = oneItem.switchMap(new Function<String, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(final String s) {
-                return Flowable.just(s)
-                        .mergeWith(Flowable.interval(10, TimeUnit.MILLISECONDS)
-                        .map(new Function<Long, String>() {
-                            @Override
-                            public String apply(Long i) {
-                                return s + " " + i;
-                            }
-                        })).take(250);
-            }
-        })
+        Flowable<String> src = oneItem.switchMap((Function<String, Flowable<String>>) s -> Flowable.just(s)
+                .mergeWith(Flowable.interval(10, TimeUnit.MILLISECONDS)
+                .map(i -> s + " " + i)).take(250))
         .share()
         ;
 
@@ -553,12 +459,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
                           .map(
-                                new Function<Long, Flowable<Long>>() {
-                                    @Override
-                                    public Flowable<Long> apply(Long t) {
-                                        return Flowable.just(1L, 2L, 3L);
-                                    }
-                                }
+                                  _ -> Flowable.just(1L, 2L, 3L)
                           ).take(3))
                           .subscribe(ts);
         ts.request(Long.MAX_VALUE - 100);
@@ -571,12 +472,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
-                        .map(new Function<Long, Flowable<Long>>() {
-                            @Override
-                            public Flowable<Long> apply(Long t) {
-                                return Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)).hide();
-                            }
-                        }).take(3)).subscribe(ts);
+                        .map(_ -> Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)).hide()).take(3)).subscribe(ts);
         ts.request(Long.MAX_VALUE - 1);
         ts.request(2);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -588,12 +484,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.switchOnNext(
                 Flowable.interval(100, TimeUnit.MILLISECONDS)
-                        .map(new Function<Long, Flowable<Long>>() {
-                            @Override
-                            public Flowable<Long> apply(Long t) {
-                                return Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)).hide();
-                            }
-                        }).take(3)).subscribe(ts);
+                        .map(_ -> Flowable.fromIterable(Arrays.asList(1L, 2L, 3L)).hide()).take(3)).subscribe(ts);
         ts.request(1);
         //we will miss two of the first observable
         Thread.sleep(250);
@@ -641,12 +532,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void switchOnNextPrefetch() {
         final List<Integer> list = new ArrayList<>();
 
-        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(v -> list.add(v));
 
         Flowable.switchOnNext(Flowable.just(source).hide(), 2)
         .test(1);
@@ -658,12 +544,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void switchOnNextDelayError() {
         final List<Integer> list = new ArrayList<>();
 
-        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(v -> list.add(v));
 
         Flowable.switchOnNextDelayError(Flowable.just(source).hide())
         .test(1);
@@ -675,12 +556,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void switchOnNextDelayErrorPrefetch() {
         final List<Integer> list = new ArrayList<>();
 
-        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 10).hide().doOnNext(v -> list.add(v));
 
         Flowable.switchOnNextDelayError(Flowable.just(source).hide(), 2)
         .test(1);
@@ -718,23 +594,13 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapDelayErrorEmptySource() {
         assertSame(Flowable.empty(), Flowable.<Object>empty()
-                .switchMapDelayError(new Function<Object, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Object v) throws Exception {
-                        return Flowable.just(1);
-                    }
-                }, 16));
+                .switchMapDelayError((Function<Object, Publisher<Integer>>) _ -> Flowable.just(1), 16));
     }
 
     @Test
     public void switchMapDelayErrorJustSource() {
         Flowable.just(0)
-        .switchMapDelayError(new Function<Object, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, 16)
+        .switchMapDelayError((Function<Object, Publisher<Integer>>) _ -> Flowable.just(1), 16)
         .test()
         .assertResult(1);
 
@@ -743,23 +609,13 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapErrorEmptySource() {
         assertSame(Flowable.empty(), Flowable.<Object>empty()
-                .switchMap(new Function<Object, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Object v) throws Exception {
-                        return Flowable.just(1);
-                    }
-                }, 16));
+                .switchMap((Function<Object, Publisher<Integer>>) _ -> Flowable.just(1), 16));
     }
 
     @Test
     public void switchMapJustSource() {
         Flowable.just(0)
-        .switchMap(new Function<Object, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Object v) throws Exception {
-                return Flowable.just(1);
-            }
-        }, 16)
+        .switchMap((Function<Object, Publisher<Integer>>) _ -> Flowable.just(1), 16)
         .test()
         .assertResult(1);
 
@@ -795,32 +651,19 @@ public class FlowableSwitchTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
                 final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Exception {
-                        if (v == 1) {
-                            return pp2;
-                        }
-                        return Flowable.never();
+                pp1.switchMap((Function<Integer, Flowable<Integer>>) v -> {
+                    if (v == 1) {
+                        return pp2;
                     }
+                    return Flowable.never();
                 })
                 .test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onNext(2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onNext(2);
 
                 final TestException ex = new TestException();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -842,34 +685,21 @@ public class FlowableSwitchTest extends RxJavaTest {
                 final PublishProcessor<Integer> pp1 = PublishProcessor.create();
                 final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-                pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) throws Exception {
-                        if (v == 1) {
-                            return pp2;
-                        }
-                        return Flowable.never();
+                pp1.switchMap((Function<Integer, Flowable<Integer>>) v -> {
+                    if (v == 1) {
+                        return pp2;
                     }
+                    return Flowable.never();
                 })
                 .test();
 
                 final TestException ex1 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
 
                 final TestException ex2 = new TestException();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -887,27 +717,12 @@ public class FlowableSwitchTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
 
-            final TestSubscriber<Integer> ts = pp1.switchMap(new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer v) throws Exception {
-                    return Flowable.never();
-                }
-            })
+            final TestSubscriber<Integer> ts = pp1.switchMap((Function<Integer, Flowable<Integer>>) _ -> Flowable.never())
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onNext(2);
-                }
-            };
+            Runnable r1 = () -> pp1.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -916,11 +731,8 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void mapperThrows() {
         Flowable.just(1).hide()
-        .switchMap(new Function<Integer, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .switchMap((Function<Integer, Flowable<Object>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1055,12 +867,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return f.switchMap(Functions.justFunction(Flowable.just(1)));
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> f.switchMap(Functions.justFunction(Flowable.just(1))), false, 1, 1, 1);
     }
 
     @Test
@@ -1090,19 +897,9 @@ public class FlowableSwitchTest extends RxJavaTest {
             .switchMap(Functions.justFunction(pp))
             .subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> ts.cancel();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r2 = () -> pp.onNext(1);
 
             TestHelper.race(r1, r2);
         }
@@ -1112,11 +909,8 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void fusedInnerCrash() {
         Flowable.just(1).hide()
         .switchMap(Functions.justFunction(Flowable.just(1)
-                .map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) throws Exception {
-                        throw new TestException();
-                    }
+                .map(_ -> {
+                    throw new TestException();
                 })
                 .compose(TestHelper.<Object>flowableStripBoundary())
             )
@@ -1151,20 +945,11 @@ public class FlowableSwitchTest extends RxJavaTest {
         String thread = Thread.currentThread().getName();
 
         Flowable.range(1, 10000)
-        .switchMap(new Function<Integer, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Integer v)
-                    throws Exception {
-                return Flowable.just(2).hide()
-                .observeOn(Schedulers.single())
-                .map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer w) throws Exception {
-                        return Thread.currentThread().getName();
-                    }
-                });
-            }
-        })
+        .switchMap((Function<Integer, Flowable<Object>>) _ -> Flowable.just(2).hide()
+        .observeOn(Schedulers.single())
+        .map((Function<Integer, Object>) _ -> {
+            return Thread.currentThread().getName();
+        }))
         .to(TestHelper.<Object>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertNever(thread)
@@ -1179,19 +964,11 @@ public class FlowableSwitchTest extends RxJavaTest {
             final TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
             Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    ts.cancel();
-                    throw new TestException();
-                }
+            .map((Function<Integer, Integer>) _ -> {
+                ts.cancel();
+                throw new TestException();
             })
-            .switchMap(new Function<Integer, Publisher<Integer>>() {
-                @Override
-                public Publisher<Integer> apply(Integer v) throws Throwable {
-                    return Flowable.just(v).hide();
-                }
-            })
+            .switchMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v).hide())
             .subscribe(ts);
 
             ts.assertEmpty();
@@ -1205,13 +982,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapFusedIterable() {
         Flowable.range(1, 2)
-        .switchMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Throwable {
-                return Flowable.fromIterable(Arrays.asList(v * 10));
-            }
-        })
+        .switchMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(List.of(v * 10)))
         .test()
         .assertResult(10, 20);
     }
@@ -1219,13 +990,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapHiddenIterable() {
         Flowable.range(1, 2)
-        .switchMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v)
-                    throws Throwable {
-                return Flowable.fromIterable(Arrays.asList(v * 10)).hide();
-            }
-        })
+        .switchMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(List.of(v * 10)).hide())
         .test()
         .assertResult(10, 20);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
@@ -70,23 +70,17 @@ public class FlowableTakeTest extends RxJavaTest {
     @Test(expected = IllegalArgumentException.class)
     public void takeWithError() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3)).take(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1) {
-                throw new IllegalArgumentException("some error");
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new IllegalArgumentException("some error");
         }).blockingSingle();
     }
 
     @Test
     public void takeWithErrorHappeningInOnNext() {
         Flowable<Integer> w = Flowable.fromIterable(Arrays.asList(1, 2, 3))
-                .take(2).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1) {
-                throw new IllegalArgumentException("some error");
-            }
-        });
+                .take(2).map(_ -> {
+                    throw new IllegalArgumentException("some error");
+                });
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         w.subscribe(subscriber);
@@ -98,11 +92,8 @@ public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void takeWithErrorHappeningInTheLastOnNext() {
-        Flowable<Integer> w = Flowable.fromIterable(Arrays.asList(1, 2, 3)).take(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1) {
-                throw new IllegalArgumentException("some error");
-            }
+        Flowable<Integer> w = Flowable.fromIterable(Arrays.asList(1, 2, 3)).take(1).map(_ -> {
+            throw new IllegalArgumentException("some error");
         });
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
@@ -117,13 +108,10 @@ public class FlowableTakeTest extends RxJavaTest {
     public void takeDoesntLeakErrors() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-                @Override
-                public void subscribe(Subscriber<? super String> subscriber) {
-                    subscriber.onSubscribe(new BooleanSubscription());
-                    subscriber.onNext("one");
-                    subscriber.onError(new Throwable("test failed"));
-                }
+            Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onError(new Throwable("test failed"));
             });
 
             Subscriber<String> subscriber = TestHelper.mockSubscriber();
@@ -196,42 +184,22 @@ public class FlowableTakeTest extends RxJavaTest {
     @Test
     public void unsubscribeFromSynchronousInfiniteFlowable() {
         final AtomicLong count = new AtomicLong();
-        INFINITE_OBSERVABLE.take(10).subscribe(new Consumer<Long>() {
-
-            @Override
-            public void accept(Long l) {
-                count.set(l);
-            }
-
-        });
+        INFINITE_OBSERVABLE.take(10).subscribe(l -> count.set(l));
         assertEquals(10, count.get());
     }
 
     @Test
     public void multiTake() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription bs = new BooleanSubscription();
-                s.onSubscribe(bs);
-                for (int i = 0; !bs.isCancelled(); i++) {
-                    System.out.println("Emit: " + i);
-                    count.incrementAndGet();
-                    s.onNext(i);
-                }
+        Flowable.unsafeCreate((Publisher<Integer>) s -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            s.onSubscribe(bs);
+            for (int i = 0; !bs.isCancelled(); i++) {
+                System.out.println("Emit: " + i);
+                count.incrementAndGet();
+                s.onNext(i);
             }
-
-        }).take(100).take(1).blockingForEach(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                System.out.println("Receive: " + t1);
-
-            }
-
-        });
+        }).take(100).take(1).blockingForEach(t1 -> System.out.println("Receive: " + t1));
 
         assertEquals(1, count.get());
     }
@@ -249,22 +217,17 @@ public class FlowableTakeTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestFlowable subscribed to ...");
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestFlowable thread");
-                        for (String s : values) {
-                            System.out.println("TestFlowable onNext: " + s);
-                            subscriber.onNext(s);
-                        }
-                        subscriber.onComplete();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestFlowable thread");
+                    for (String s : values) {
+                        System.out.println("TestFlowable onNext: " + s);
+                        subscriber.onNext(s);
                     }
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
-
             });
             System.out.println("starting TestFlowable thread");
             t.start();
@@ -272,19 +235,14 @@ public class FlowableTakeTest extends RxJavaTest {
         }
     }
 
-    private static Flowable<Long> INFINITE_OBSERVABLE = Flowable.unsafeCreate(new Publisher<Long>() {
-
-        @Override
-        public void subscribe(Subscriber<? super Long> op) {
-            BooleanSubscription bs = new BooleanSubscription();
-            op.onSubscribe(bs);
-            long l = 1;
-            while (!bs.isCancelled()) {
-                op.onNext(l++);
-            }
-            op.onComplete();
+    private static Flowable<Long> INFINITE_OBSERVABLE = Flowable.unsafeCreate(op -> {
+        BooleanSubscription bs = new BooleanSubscription();
+        op.onSubscribe(bs);
+        long l = 1;
+        while (!bs.isCancelled()) {
+            op.onNext(l++);
         }
-
+        op.onComplete();
     });
 
     @Test
@@ -307,25 +265,18 @@ public class FlowableTakeTest extends RxJavaTest {
     public void producerRequestThroughTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).take(3).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+        })).take(3).subscribe(ts);
         assertEquals(3, requested.get());
     }
 
@@ -333,25 +284,18 @@ public class FlowableTakeTest extends RxJavaTest {
     public void producerRequestThroughTakeIsModified() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() {
 
             @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                s.onSubscribe(new Subscription() {
-
-                    @Override
-                    public void request(long n) {
-                        requested.set(n);
-                    }
-
-                    @Override
-                    public void cancel() {
-
-                    }
-                });
+            public void request(long n) {
+                requested.set(n);
             }
 
-        }).take(1).subscribe(ts);
+            @Override
+            public void cancel() {
+
+            }
+        })).take(1).subscribe(ts);
         //FIXME take triggers fast path if downstream requests more than the limit
         assertEquals(1, requested.get());
     }
@@ -361,20 +305,15 @@ public class FlowableTakeTest extends RxJavaTest {
         final AtomicReference<Object> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         Flowable.just(1).subscribeOn(Schedulers.computation()).take(1)
-        .subscribe(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                try {
-                    Thread.sleep(100);
-                } catch (Exception e) {
-                    exception.set(e);
-                    e.printStackTrace();
-                } finally {
-                    latch.countDown();
-                }
+        .subscribe(_ -> {
+            try {
+                Thread.sleep(100);
+            } catch (Exception e) {
+                exception.set(e);
+                e.printStackTrace();
+            } finally {
+                latch.countDown();
             }
-
         });
 
         latch.await();
@@ -387,12 +326,10 @@ public class FlowableTakeTest extends RxJavaTest {
         TestSubscriber<Long> ts = new TestSubscriber<>(0L);
         Flowable.interval(100, TimeUnit.MILLISECONDS)
             //
-            .doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) {
-                    System.out.println(n);
-                    requests.addAndGet(n);
-            }})
+            .doOnRequest(n -> {
+                System.out.println(n);
+                requests.addAndGet(n);
+        })
             //
             .take(2)
             //
@@ -431,12 +368,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        source.take(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) {
-                source.onNext(2);
-            }
-        }).subscribe(ts);
+        source.take(1).doOnNext(_ -> source.onNext(2)).subscribe(ts);
 
         source.onNext(1);
 
@@ -470,12 +402,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.take(2);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.take(2));
     }
 
     @Test
@@ -489,12 +416,7 @@ public class FlowableTakeTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = Flowable.range(1, 2).take(2).test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
 
             TestHelper.race(r1, r1);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -37,12 +37,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhile1() {
         Flowable<Integer> w = Flowable.just(1, 2, 3);
-        Flowable<Integer> take = w.takeWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer input) {
-                return input < 3;
-            }
-        });
+        Flowable<Integer> take = w.takeWhile(input -> input < 3);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         take.subscribe(subscriber);
@@ -57,12 +52,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhileOnSubject1() {
         FlowableProcessor<Integer> s = PublishProcessor.create();
-        Flowable<Integer> take = s.takeWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer input) {
-                return input < 3;
-            }
-        });
+        Flowable<Integer> take = s.takeWhile(input -> input < 3);
 
         Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
         take.subscribe(subscriber);
@@ -109,21 +99,13 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     public void takeWhileDoesntLeakErrors() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-                @Override
-                public void subscribe(Subscriber<? super String> subscriber) {
-                    subscriber.onSubscribe(new BooleanSubscription());
-                    subscriber.onNext("one");
-                    subscriber.onError(new TestException("test failed"));
-                }
+            Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+                subscriber.onSubscribe(new BooleanSubscription());
+                subscriber.onNext("one");
+                subscriber.onError(new TestException("test failed"));
             });
 
-            source.takeWhile(new Predicate<String>() {
-                @Override
-                public boolean test(String s) {
-                    return false;
-                }
-            }).blockingLast("");
+            source.takeWhile(_ -> false).blockingLast("");
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "test failed");
         } finally {
@@ -138,12 +120,9 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> take = Flowable.unsafeCreate(source)
-                .takeWhile(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                throw testException;
-            }
-        });
+                .takeWhile(_ -> {
+                    throw testException;
+                });
         take.subscribe(subscriber);
 
         // wait for the Flowable to complete
@@ -205,22 +184,17 @@ public class FlowableTakeWhileTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             System.out.println("TestFlowable subscribed to ...");
             subscriber.onSubscribe(upstream);
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestFlowable thread");
-                        for (String s : values) {
-                            System.out.println("TestFlowable onNext: " + s);
-                            subscriber.onNext(s);
-                        }
-                        subscriber.onComplete();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestFlowable thread");
+                    for (String s : values) {
+                        System.out.println("TestFlowable onNext: " + s);
+                        subscriber.onNext(s);
                     }
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
-
             });
             System.out.println("starting TestFlowable thread");
             t.start();
@@ -230,12 +204,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void backpressure() {
-        Flowable<Integer> source = Flowable.range(1, 1000).takeWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 100;
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 1000).takeWhile(t1 -> t1 < 100);
         TestSubscriber<Integer> ts = new TestSubscriber<>(5L);
 
         source.subscribe(ts);
@@ -251,12 +220,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void noUnsubscribeDownstream() {
-        Flowable<Integer> source = Flowable.range(1, 1000).takeWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 1000).takeWhile(t1 -> t1 < 2);
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         source.subscribe(ts);
@@ -270,11 +234,8 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     @Test
     public void errorCauseIncludesLastValue() {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-        Flowable.just("abc").takeWhile(new Predicate<String>() {
-            @Override
-            public boolean test(String t1) {
-                throw new TestException();
-            }
+        Flowable.just("abc").takeWhile(_ -> {
+            throw new TestException();
         }).subscribe(ts);
 
         ts.assertTerminated();
@@ -291,12 +252,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.takeWhile(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.takeWhile(Functions.alwaysTrue()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -47,16 +47,13 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
 
     @Test
     public void throttlingWithDropCallbackCrashes() throws Throwable {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // publish as it's first
-                publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
-                publishNext(subscriber, 900, "three");   // publish
-                publishNext(subscriber, 905, "four");   // skip
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // publish as it's first
+            publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
+            publishNext(subscriber, 900, "three");   // publish
+            publishNext(subscriber, 905, "four");   // skip
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Action whenDisposed = mock(Action.class);
@@ -85,16 +82,13 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
 
     @Test
     public void throttlingWithDropCallback() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // publish as it's first
-                publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
-                publishNext(subscriber, 900, "three");   // publish
-                publishNext(subscriber, 905, "four");   // skip
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // publish as it's first
+            publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
+            publishNext(subscriber, 900, "three");   // publish
+            publishNext(subscriber, 905, "four");   // skip
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Observer<Object> dropCallbackObserver = TestHelper.mockObserver();
@@ -118,16 +112,13 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
 
     @Test
     public void throttlingWithCompleted() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                publishNext(subscriber, 100, "one");    // publish as it's first
-                publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
-                publishNext(subscriber, 900, "three");   // publish
-                publishNext(subscriber, 905, "four");   // skip
-                publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            publishNext(subscriber, 100, "one");    // publish as it's first
+            publishNext(subscriber, 300, "two");    // skip as it's last within the first 400
+            publishNext(subscriber, 900, "three");   // publish
+            publishNext(subscriber, 905, "four");   // skip
+            publishCompleted(subscriber, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Flowable<String> sampled = source.throttleFirst(400, TimeUnit.MILLISECONDS, scheduler);
@@ -146,15 +137,12 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
 
     @Test
     public void throttlingWithError() {
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                Exception error = new TestException();
-                publishNext(subscriber, 100, "one");    // Should be published since it is first
-                publishNext(subscriber, 200, "two");    // Should be skipped since onError will arrive before the timeout expires
-                publishError(subscriber, 300, error);   // Should be published as soon as the timeout expires.
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            Exception error = new TestException();
+            publishNext(subscriber, 100, "one");    // Should be published since it is first
+            publishNext(subscriber, 200, "two");    // Should be skipped since onError will arrive before the timeout expires
+            publishError(subscriber, 300, error);   // Should be published as soon as the timeout expires.
         });
 
         Flowable<String> sampled = source.throttleFirst(400, TimeUnit.MILLISECONDS, scheduler);
@@ -169,30 +157,15 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
     }
 
     private <T> void publishCompleted(final Subscriber<T> subscriber, long delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Subscriber<T> subscriber, long delay, final Exception error) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onError(error);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onError(error), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Subscriber<T> subscriber, long delay, final T value) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeIntervalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeIntervalTest.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.*;
@@ -74,22 +73,12 @@ public class FlowableTimeIntervalTest extends RxJavaTest {
     public void timeIntervalDefault() {
         final TestScheduler scheduler = new TestScheduler();
 
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler v) throws Exception {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
             Flowable.range(1, 5)
             .timeInterval()
-            .map(new Function<Timed<Integer>, Long>() {
-                @Override
-                public Long apply(Timed<Integer> v) throws Exception {
-                    return v.time();
-                }
-            })
+            .map(v -> v.time())
             .test()
             .assertResult(0L, 0L, 0L, 0L, 0L);
         } finally {
@@ -101,22 +90,12 @@ public class FlowableTimeIntervalTest extends RxJavaTest {
     public void timeIntervalDefaultSchedulerCustomUnit() {
         final TestScheduler scheduler = new TestScheduler();
 
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler v) throws Exception {
-                return scheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> scheduler);
 
         try {
             Flowable.range(1, 5)
             .timeInterval(TimeUnit.SECONDS)
-            .map(new Function<Timed<Integer>, Long>() {
-                @Override
-                public Long apply(Timed<Integer> v) throws Exception {
-                    return v.time();
-                }
-            })
+            .map(v -> v.time())
             .test()
             .assertResult(0L, 0L, 0L, 0L, 0L);
         } finally {
@@ -139,12 +118,6 @@ public class FlowableTimeIntervalTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Timed<Object>>>() {
-            @Override
-            public Publisher<Timed<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.timeInterval();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.timeInterval());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.*;
 
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import static java.util.concurrent.Flow.*;
 
@@ -46,14 +45,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return timeout;
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> timeout;
 
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -79,14 +73,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.<Integer>never();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return timeout;
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> timeout;
 
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -106,21 +95,13 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.<Integer>never();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return timeout;
-            }
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> timeout;
+
+        Supplier<Flowable<Integer>> firstTimeoutFunc = () -> {
+            throw new TestException();
         };
 
-        Supplier<Flowable<Integer>> firstTimeoutFunc = new Supplier<Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> get() {
-                throw new TestException();
-            }
-        };
-
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -137,14 +118,11 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> {
+            throw new TestException();
         };
 
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -164,14 +142,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return timeout;
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> timeout;
 
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
@@ -188,14 +161,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return Flowable.<Integer> error(new TestException());
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> Flowable.<Integer> error(new TestException());
 
-        Flowable<Integer> other = Flowable.fromIterable(Arrays.asList(100));
+        Flowable<Integer> other = Flowable.fromIterable(List.of(100));
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         InOrder inOrder = inOrder(subscriber);
@@ -215,12 +183,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return PublishProcessor.create();
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> PublishProcessor.create();
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         source.timeout(timeout, timeoutFunc).subscribe(subscriber);
@@ -237,12 +200,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         final PublishProcessor<Integer> timeout = PublishProcessor.create();
 
-        Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                return timeout;
-            }
-        };
+        Function<Integer, Flowable<Integer>> timeoutFunc = _ -> timeout;
 
         Subscriber<Object> subscriber = TestHelper.mockSubscriber();
         source.timeout(PublishProcessor.create(), timeoutFunc).subscribe(subscriber);
@@ -276,87 +234,66 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         final CountDownLatch enteredTimeoutOne = new CountDownLatch(1);
         final AtomicBoolean latchTimeout = new AtomicBoolean(false);
 
-        final Function<Integer, Flowable<Integer>> timeoutFunc = new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t1) {
-                if (t1 == 1) {
-                    // Force "unsubscribe" run on another thread
-                    return Flowable.unsafeCreate(new Publisher<Integer>() {
-                        @Override
-                        public void subscribe(Subscriber<? super Integer> subscriber) {
-                            subscriber.onSubscribe(new BooleanSubscription());
-                            enteredTimeoutOne.countDown();
-                            // force the timeout message be sent after observer.onNext(2)
-                            while (true) {
-                                try {
-                                    if (!observerReceivedTwo.await(30, TimeUnit.SECONDS)) {
-                                        // CountDownLatch timeout
-                                        // There should be something wrong
-                                        latchTimeout.set(true);
-                                    }
-                                    break;
-                                } catch (InterruptedException e) {
-                                    // Since we just want to emulate a busy method,
-                                    // we ignore the interrupt signal from Scheduler.
-                                }
+        final Function<Integer, Flowable<Integer>> timeoutFunc = t1 -> {
+            if (t1 == 1) {
+                // Force "unsubscribe" run on another thread
+                return Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
+                    subscriber.onSubscribe(new BooleanSubscription());
+                    enteredTimeoutOne.countDown();
+                    // force the timeout message be sent after observer.onNext(2)
+                    while (true) {
+                        try {
+                            if (!observerReceivedTwo.await(30, TimeUnit.SECONDS)) {
+                                // CountDownLatch timeout
+                                // There should be something wrong
+                                latchTimeout.set(true);
                             }
-                            subscriber.onNext(1);
-                            timeoutEmittedOne.countDown();
+                            break;
+                        } catch (InterruptedException e) {
+                            // Since we just want to emulate a busy method,
+                            // we ignore the interrupt signal from Scheduler.
                         }
-                    }).subscribeOn(Schedulers.newThread());
-                } else {
-                    return PublishProcessor.create();
-                }
+                    }
+                    subscriber.onNext(1);
+                    timeoutEmittedOne.countDown();
+                }).subscribeOn(Schedulers.newThread());
+            } else {
+                return PublishProcessor.create();
             }
         };
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                observerReceivedTwo.countDown();
-                return null;
-            }
-
+        doAnswer((Answer<Void>) _ -> {
+            observerReceivedTwo.countDown();
+            return null;
         }).when(subscriber).onNext(2);
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                observerCompleted.countDown();
-                return null;
-            }
-
+        doAnswer((Answer<Void>) _ -> {
+            observerCompleted.countDown();
+            return null;
         }).when(subscriber).onComplete();
 
         final TestSubscriber<Integer> ts = new TestSubscriber<>(subscriber);
 
-        new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                PublishProcessor<Integer> source = PublishProcessor.create();
-                source.timeout(timeoutFunc, Flowable.just(3)).subscribe(ts);
-                source.onNext(1); // start timeout
-                try {
-                    if (!enteredTimeoutOne.await(30, TimeUnit.SECONDS)) {
-                        latchTimeout.set(true);
-                    }
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+        new Thread(() -> {
+            PublishProcessor<Integer> source = PublishProcessor.create();
+            source.timeout(timeoutFunc, Flowable.just(3)).subscribe(ts);
+            source.onNext(1); // start timeout
+            try {
+                if (!enteredTimeoutOne.await(30, TimeUnit.SECONDS)) {
+                    latchTimeout.set(true);
                 }
-                source.onNext(2); // disable timeout
-                try {
-                    if (!timeoutEmittedOne.await(30, TimeUnit.SECONDS)) {
-                        latchTimeout.set(true);
-                    }
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-                source.onComplete();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
-
+            source.onNext(2); // disable timeout
+            try {
+                if (!timeoutEmittedOne.await(30, TimeUnit.SECONDS)) {
+                    latchTimeout.set(true);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            source.onComplete();
         }).start();
 
         if (!observerCompleted.await(30, TimeUnit.SECONDS)) {
@@ -383,19 +320,11 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.timeout(Functions.justFunction(Flowable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
+                f.timeout(Functions.justFunction(Flowable.never())));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.timeout(Functions.justFunction(Flowable.never()), Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
+                f.timeout(Functions.justFunction(Flowable.never()), Flowable.never()));
     }
 
     @Test
@@ -582,21 +511,11 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 pp.onNext(0);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onNext(1);
-                    }
-                };
+                Runnable r1 = () -> pp.onNext(1);
 
                 final Throwable ex = new TestException();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sub[0].onError(ex);
-                    }
-                };
+                Runnable r2 = () -> sub[0].onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -637,21 +556,11 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 pp.onNext(0);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onNext(1);
-                    }
-                };
+                Runnable r1 = () -> pp.onNext(1);
 
                 final Throwable ex = new TestException();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sub[0].onError(ex);
-                    }
-                };
+                Runnable r2 = () -> sub[0].onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -694,19 +603,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Throwable ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sub[0].onComplete();
-                    }
-                };
+                Runnable r2 = () -> sub[0].onComplete();
 
                 TestHelper.race(r1, r2);
 
@@ -747,19 +646,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 pp.onNext(0);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onComplete();
-                    }
-                };
+                Runnable r1 = () -> pp.onComplete();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sub[0].onComplete();
-                    }
-                };
+                Runnable r2 = () -> sub[0].onComplete();
 
                 TestHelper.race(r1, r2);
 
@@ -800,19 +689,9 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 pp.onNext(0);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onComplete();
-                    }
-                };
+                Runnable r1 = () -> pp.onComplete();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sub[0].onComplete();
-                    }
-                };
+                Runnable r2 = () -> sub[0].onComplete();
 
                 TestHelper.race(r1, r2);
 
@@ -832,12 +711,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Object> timeoutAndFallback = Flowable.never().doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                counter.incrementAndGet();
-            }
-        });
+        Flowable<Object> timeoutAndFallback = Flowable.never().doOnSubscribe(_ -> counter.incrementAndGet());
 
         pp
         .timeout(timeoutAndFallback, Functions.justFunction(timeoutAndFallback))
@@ -852,12 +726,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         PublishProcessor<Object> pp = PublishProcessor.create();
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable<Object> timeoutAndFallback = Flowable.never().doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                counter.incrementAndGet();
-            }
-        });
+        Flowable<Object> timeoutAndFallback = Flowable.never().doOnSubscribe(_ -> counter.incrementAndGet());
 
         pp
         .timeout(timeoutAndFallback, Functions.justFunction(timeoutAndFallback), timeoutAndFallback)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
@@ -216,11 +216,8 @@ public class FlowableToListTest extends RxJavaTest {
     @Test
     public void collectionSupplierThrows() {
         Flowable.just(1)
-        .toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .toList((Supplier<Collection<Integer>>) () -> {
+            throw new TestException();
         })
         .toFlowable()
         .test()
@@ -230,12 +227,7 @@ public class FlowableToListTest extends RxJavaTest {
     @Test
     public void collectionSupplierReturnsNull() {
         Flowable.just(1)
-        .toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return null;
-            }
-        })
+        .toList((Supplier<Collection<Integer>>) () -> null)
         .toFlowable()
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
@@ -245,11 +237,8 @@ public class FlowableToListTest extends RxJavaTest {
     @Test
     public void singleCollectionSupplierThrows() {
         Flowable.just(1)
-        .toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .toList((Supplier<Collection<Integer>>) () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -258,12 +247,7 @@ public class FlowableToListTest extends RxJavaTest {
     @Test
     public void singleCollectionSupplierReturnsNull() {
         Flowable.just(1)
-        .toList(new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return null;
-            }
-        })
+        .toList((Supplier<Collection<Integer>>) () -> null)
         .to(TestHelper.<Collection<Integer>>testConsumer())
         .assertFailure(NullPointerException.class)
         .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));
@@ -275,18 +259,8 @@ public class FlowableToListTest extends RxJavaTest {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestObserver<List<Integer>> to = pp.toList().test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
         }
@@ -298,18 +272,8 @@ public class FlowableToListTest extends RxJavaTest {
             final PublishProcessor<Integer> pp = PublishProcessor.create();
             final TestSubscriber<List<Integer>> ts = pp.toList().toFlowable().test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -324,23 +288,13 @@ public class FlowableToListTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
             if (ts.values().size() != 0) {
-                ts.assertValue(Arrays.asList(1))
+                ts.assertValue(List.of(1))
                 .assertNoErrors();
             }
         }
@@ -348,19 +302,9 @@ public class FlowableToListTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<List<Object>>>() {
-            @Override
-            public Flowable<List<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.toList().toFlowable();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeFlowableToSingle(new Function<Flowable<Object>, Single<List<Object>>>() {
-            @Override
-            public Single<List<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.toList();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<List<Object>>>) f ->
+                f.toList().toFlowable());
+        TestHelper.checkDoubleOnSubscribeFlowableToSingle((Function<Flowable<Object>, Single<List<Object>>>) f ->
+                f.toList());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
@@ -35,18 +35,8 @@ public class FlowableToMapTest extends RxJavaTest {
         singleObserver = TestHelper.mockSingleObserver();
     }
 
-    Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-        @Override
-        public Integer apply(String t1) {
-            return t1.length();
-        }
-    };
-    Function<String, String> duplicate = new Function<String, String>() {
-        @Override
-        public String apply(String t1) {
-            return t1 + t1;
-        }
-    };
+    Function<String, Integer> lengthFunc = t1 -> t1.length();
+    Function<String, String> duplicate = t1 -> t1 + t1;
 
     @Test
     public void toMapFlowable() {
@@ -90,14 +80,11 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithErrorFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                if ("bb".equals(t1)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return t1.length();
+        Function<String, Integer> lengthFuncErr = t1 -> {
+            if ("bb".equals(t1)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return t1.length();
         };
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFuncErr).toFlowable();
 
@@ -119,14 +106,11 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithErrorInValueSelectorFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Function<String, String> duplicateErr = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                if ("bb".equals(t1)) {
-                    throw new RuntimeException("Forced failure");
-                }
-                return t1 + t1;
+        Function<String, String> duplicateErr = t1 -> {
+            if ("bb".equals(t1)) {
+                throw new RuntimeException("Forced failure");
             }
+            return t1 + t1;
         };
 
         Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr).toFlowable();
@@ -149,33 +133,18 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+
+            private static final long serialVersionUID = -3296811238780863394L;
+
             @Override
-            public Map<Integer, String> get() {
-                return new LinkedHashMap<Integer, String>() {
-
-                    private static final long serialVersionUID = -3296811238780863394L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
-                        return size() > 3;
-                    }
-                };
+            protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
+                return size() > 3;
             }
         };
 
-        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                return t1.length();
-            }
-        };
-        Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        }, mapFactory).toFlowable();
+        Function<String, Integer> lengthFunc = t1 -> t1.length();
+        Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory).toFlowable();
 
         Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
@@ -193,25 +162,12 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithErrorThrowingFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
-            @Override
-            public Map<Integer, String> get() {
-                throw new RuntimeException("Forced failure");
-            }
+        Supplier<Map<Integer, String>> mapFactory = () -> {
+            throw new RuntimeException("Forced failure");
         };
 
-        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                return t1.length();
-            }
-        };
-        Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        }, mapFactory).toFlowable();
+        Function<String, Integer> lengthFunc = t1 -> t1.length();
+        Flowable<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory).toFlowable();
 
         Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
@@ -265,14 +221,11 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithError() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                if ("bb".equals(t1)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return t1.length();
+        Function<String, Integer> lengthFuncErr = t1 -> {
+            if ("bb".equals(t1)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return t1.length();
         };
         Single<Map<Integer, String>> mapped = source.toMap(lengthFuncErr);
 
@@ -293,14 +246,11 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithErrorInValueSelector() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Function<String, String> duplicateErr = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                if ("bb".equals(t1)) {
-                    throw new RuntimeException("Forced failure");
-                }
-                return t1 + t1;
+        Function<String, String> duplicateErr = t1 -> {
+            if ("bb".equals(t1)) {
+                throw new RuntimeException("Forced failure");
             }
+            return t1 + t1;
         };
 
         Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, duplicateErr);
@@ -322,33 +272,18 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+
+            private static final long serialVersionUID = -3296811238780863394L;
+
             @Override
-            public Map<Integer, String> get() {
-                return new LinkedHashMap<Integer, String>() {
-
-                    private static final long serialVersionUID = -3296811238780863394L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
-                        return size() > 3;
-                    }
-                };
+            protected boolean removeEldestEntry(Map.Entry<Integer, String> eldest) {
+                return size() > 3;
             }
         };
 
-        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                return t1.length();
-            }
-        };
-        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        }, mapFactory);
+        Function<String, Integer> lengthFunc = t1 -> t1.length();
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory);
 
         Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");
@@ -365,25 +300,12 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithErrorThrowingFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = new Supplier<Map<Integer, String>>() {
-            @Override
-            public Map<Integer, String> get() {
-                throw new RuntimeException("Forced failure");
-            }
+        Supplier<Map<Integer, String>> mapFactory = () -> {
+            throw new RuntimeException("Forced failure");
         };
 
-        Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                return t1.length();
-            }
-        };
-        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        }, mapFactory);
+        Function<String, Integer> lengthFunc = t1 -> t1.length();
+        Single<Map<Integer, String>> mapped = source.toMap(lengthFunc, v -> v, mapFactory);
 
         Map<Integer, String> expected = new LinkedHashMap<>();
         expected.put(2, "bb");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
@@ -36,18 +36,8 @@ public class FlowableToMultimapTest extends RxJavaTest {
         singleObserver = TestHelper.mockSingleObserver();
     }
 
-    Function<String, Integer> lengthFunc = new Function<String, Integer>() {
-        @Override
-        public Integer apply(String t1) {
-            return t1.length();
-        }
-    };
-    Function<String, String> duplicate = new Function<String, String>() {
-        @Override
-        public String apply(String t1) {
-            return t1 + t1;
-        }
-    };
+    Function<String, Integer> lengthFunc = t1 -> t1.length();
+    Function<String, String> duplicate = t1 -> t1 + t1;
 
     @Test
     public void toMultimapFlowable() {
@@ -87,36 +77,21 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+
+            private static final long serialVersionUID = -2084477070717362859L;
+
             @Override
-            public Map<Integer, Collection<String>> get() {
-                return new LinkedHashMap<Integer, Collection<String>>() {
-
-                    private static final long serialVersionUID = -2084477070717362859L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
-                        return size() > 2;
-                    }
-                };
+            protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
+                return size() > 2;
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
+        Function<String, String> identity = v -> v;
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(
                 lengthFunc, identity,
-                mapFactory, new Function<Integer, Collection<String>>() {
-                    @Override
-                    public Collection<String> apply(Integer e) {
-                        return new ArrayList<>();
-                    }
-                }).toFlowable();
+                mapFactory, (Function<Integer, Collection<String>>) _ -> new ArrayList<>()).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
@@ -133,36 +108,23 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithCollectionFactoryFlowable() {
         Flowable<String> source = Flowable.just("cc", "dd", "eee", "eee");
 
-        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
-            @Override
-            public Collection<String> apply(Integer t1) {
-                if (t1 == 2) {
-                    return new ArrayList<>();
-                } else {
-                    return new HashSet<>();
-                }
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                return new ArrayList<>();
+            } else {
+                return new HashSet<>();
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
-        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                return new HashMap<>();
-            }
-        };
+        Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = () -> new HashMap<>();
 
         Flowable<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(List.of("eee")));
 
         mapped.subscribe(objectSubscriber);
 
@@ -175,14 +137,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithErrorFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                if ("b".equals(t1)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return t1.length();
+        Function<String, Integer> lengthFuncErr = t1 -> {
+            if ("b".equals(t1)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return t1.length();
         };
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr).toFlowable();
@@ -202,14 +161,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithErrorInValueSelectorFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Function<String, String> duplicateErr = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                if ("b".equals(t1)) {
-                    throw new RuntimeException("Forced failure");
-                }
-                return t1 + t1;
+        Function<String, String> duplicateErr = t1 -> {
+            if ("b".equals(t1)) {
+                throw new RuntimeException("Forced failure");
             }
+            return t1 + t1;
         };
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr).toFlowable();
@@ -229,20 +185,12 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapThrowingFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                throw new RuntimeException("Forced failure");
-            }
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Flowable<Map<Integer, Collection<String>>> mapped = source
-                .toMultimap(lengthFunc, new Function<String, String>() {
-                    @Override
-                    public String apply(String v) {
-                        return v;
-                    }
-                }, mapFactory).toFlowable();
+                .toMultimap(lengthFunc, v -> v, mapFactory).toFlowable();
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
@@ -259,29 +207,16 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithThrowingCollectionFactoryFlowable() {
         Flowable<String> source = Flowable.just("cc", "cc", "eee", "eee");
 
-        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
-            @Override
-            public Collection<String> apply(Integer t1) {
-                if (t1 == 2) {
-                    throw new RuntimeException("Forced failure");
-                } else {
-                    return new HashSet<>();
-                }
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                throw new RuntimeException("Forced failure");
+            } else {
+                return new HashSet<>();
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
-        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                return new HashMap<>();
-            }
-        };
+        Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = () -> new HashMap<>();
 
         Flowable<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory).toFlowable();
@@ -333,36 +268,21 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+
+            private static final long serialVersionUID = -2084477070717362859L;
+
             @Override
-            public Map<Integer, Collection<String>> get() {
-                return new LinkedHashMap<Integer, Collection<String>>() {
-
-                    private static final long serialVersionUID = -2084477070717362859L;
-
-                    @Override
-                    protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
-                        return size() > 2;
-                    }
-                };
+            protected boolean removeEldestEntry(Map.Entry<Integer, Collection<String>> eldest) {
+                return size() > 2;
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
+        Function<String, String> identity = v -> v;
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(
                 lengthFunc, identity,
-                mapFactory, new Function<Integer, Collection<String>>() {
-                    @Override
-                    public Collection<String> apply(Integer e) {
-                        return new ArrayList<>();
-                    }
-                });
+                mapFactory, (Function<Integer, Collection<String>>) _ -> new ArrayList<>());
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
@@ -378,36 +298,23 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithCollectionFactory() {
         Flowable<String> source = Flowable.just("cc", "dd", "eee", "eee");
 
-        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
-            @Override
-            public Collection<String> apply(Integer t1) {
-                if (t1 == 2) {
-                    return new ArrayList<>();
-                } else {
-                    return new HashSet<>();
-                }
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                return new ArrayList<>();
+            } else {
+                return new HashSet<>();
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
-        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                return new HashMap<>();
-            }
-        };
+        Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = () -> new HashMap<>();
 
         Single<Map<Integer, Collection<String>>> mapped = source
                 .toMultimap(lengthFunc, identity, mapSupplier, collectionFactory);
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(List.of("eee")));
 
         mapped.subscribe(singleObserver);
 
@@ -419,14 +326,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithError() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Function<String, Integer> lengthFuncErr = new Function<String, Integer>() {
-            @Override
-            public Integer apply(String t1) {
-                if ("b".equals(t1)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return t1.length();
+        Function<String, Integer> lengthFuncErr = t1 -> {
+            if ("b".equals(t1)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return t1.length();
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFuncErr);
@@ -445,14 +349,11 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithErrorInValueSelector() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd");
 
-        Function<String, String> duplicateErr = new Function<String, String>() {
-            @Override
-            public String apply(String t1) {
-                if ("b".equals(t1)) {
-                    throw new RuntimeException("Forced failure");
-                }
-                return t1 + t1;
+        Function<String, String> duplicateErr = t1 -> {
+            if ("b".equals(t1)) {
+                throw new RuntimeException("Forced failure");
             }
+            return t1 + t1;
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc, duplicateErr);
@@ -471,20 +372,12 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapThrowingFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                throw new RuntimeException("Forced failure");
-            }
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> {
+            throw new RuntimeException("Forced failure");
         };
 
         Single<Map<Integer, Collection<String>>> mapped = source
-                .toMultimap(lengthFunc, new Function<String, String>() {
-                    @Override
-                    public String apply(String v) {
-                        return v;
-                    }
-                }, mapFactory);
+                .toMultimap(lengthFunc, v -> v, mapFactory);
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
@@ -500,29 +393,16 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithThrowingCollectionFactory() {
         Flowable<String> source = Flowable.just("cc", "cc", "eee", "eee");
 
-        Function<Integer, Collection<String>> collectionFactory = new Function<Integer, Collection<String>>() {
-            @Override
-            public Collection<String> apply(Integer t1) {
-                if (t1 == 2) {
-                    throw new RuntimeException("Forced failure");
-                } else {
-                    return new HashSet<>();
-                }
+        Function<Integer, Collection<String>> collectionFactory = t1 -> {
+            if (t1 == 2) {
+                throw new RuntimeException("Forced failure");
+            } else {
+                return new HashSet<>();
             }
         };
 
-        Function<String, String> identity = new Function<String, String>() {
-            @Override
-            public String apply(String v) {
-                return v;
-            }
-        };
-        Supplier<Map<Integer, Collection<String>>> mapSupplier = new Supplier<Map<Integer, Collection<String>>>() {
-            @Override
-            public Map<Integer, Collection<String>> get() {
-                return new HashMap<>();
-            }
-        };
+        Function<String, String> identity = v -> v;
+        Supplier<Map<Integer, Collection<String>>> mapSupplier = HashMap::new;
 
         Single<Map<Integer, Collection<String>>> mapped = source.toMultimap(lengthFunc,
                 identity, mapSupplier, collectionFactory);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSortedListTest.java
@@ -46,14 +46,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
     @Test
     public void sortedListWithCustomFunctionFlowable() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Flowable<List<Integer>> flowable = w.toSortedList(new Comparator<Integer>() {
-
-            @Override
-            public int compare(Integer t1, Integer t2) {
-                return t2 - t1;
-            }
-
-        }).toFlowable();
+        Flowable<List<Integer>> flowable = w.toSortedList((t1, t2) -> t2 - t1).toFlowable();
 
         Subscriber<List<Integer>> subscriber = TestHelper.mockSubscriber();
         flowable.subscribe(subscriber);
@@ -102,12 +95,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
 
     @Test
     public void sortedComparator() {
-        Flowable.just(5, 1, 2, 4, 3).sorted(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer a, Integer b) {
-                return b - a;
-            }
-        })
+        Flowable.just(5, 1, 2, 4, 3).sorted((a, b) -> b - a)
         .test()
         .assertResult(5, 4, 3, 2, 1);
     }
@@ -121,12 +109,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
 
     @Test
     public void toSortedListComparatorCapacityFlowable() {
-        Flowable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer a, Integer b) {
-                return b - a;
-            }
-        }, 4).toFlowable()
+        Flowable.just(5, 1, 2, 4, 3).toSortedList((a, b) -> b - a, 4).toFlowable()
         .test()
         .assertResult(Arrays.asList(5, 4, 3, 2, 1));
     }
@@ -145,14 +128,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
     @Test
     public void sortedListWithCustomFunction() {
         Flowable<Integer> w = Flowable.just(1, 3, 2, 5, 4);
-        Single<List<Integer>> single = w.toSortedList(new Comparator<Integer>() {
-
-            @Override
-            public int compare(Integer t1, Integer t2) {
-                return t2 - t1;
-            }
-
-        });
+        Single<List<Integer>> single = w.toSortedList((t1, t2) -> t2 - t1);
 
         SingleObserver<List<Integer>> observer = TestHelper.mockSingleObserver();
         single.subscribe(observer);
@@ -185,12 +161,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
 
     @Test
     public void toSortedListComparatorCapacity() {
-        Flowable.just(5, 1, 2, 4, 3).toSortedList(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer a, Integer b) {
-                return b - a;
-            }
-        }, 4)
+        Flowable.just(5, 1, 2, 4, 3).toSortedList((a, b) -> b - a, 4)
         .test()
         .assertResult(Arrays.asList(5, 4, 3, 2, 1));
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -25,7 +25,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -40,19 +39,15 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
-            Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-                @Override
-                public void subscribe(Subscriber<? super Integer> t1) {
-                    subscribeThread.set(Thread.currentThread());
-                    t1.onSubscribe(subscription);
-                    t1.onNext(1);
-                    t1.onNext(2);
-                    // observeOn will prevent canceling the upstream upon its termination now
-                    // this call is racing for that state in this test
-                    // not doing it will make sure the unsubscribeOn always gets through
-                    // t1.onComplete();
-                }
+            Flowable<Integer> w = Flowable.unsafeCreate(t1 -> {
+                subscribeThread.set(Thread.currentThread());
+                t1.onSubscribe(subscription);
+                t1.onNext(1);
+                t1.onNext(2);
+                // observeOn will prevent canceling the upstream upon its termination now
+                // this call is racing for that state in this test
+                // not doing it will make sure the unsubscribeOn always gets through
+                // t1.onComplete();
             });
 
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -89,19 +84,15 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         try {
             final ThreadSubscription subscription = new ThreadSubscription();
             final AtomicReference<Thread> subscribeThread = new AtomicReference<>();
-            Flowable<Integer> w = Flowable.unsafeCreate(new Publisher<Integer>() {
-
-                @Override
-                public void subscribe(Subscriber<? super Integer> t1) {
-                    subscribeThread.set(Thread.currentThread());
-                    t1.onSubscribe(subscription);
-                    t1.onNext(1);
-                    t1.onNext(2);
-                    // observeOn will prevent canceling the upstream upon its termination now
-                    // this call is racing for that state in this test
-                    // not doing it will make sure the unsubscribeOn always gets through
-                    // t1.onComplete();
-                }
+            Flowable<Integer> w = Flowable.unsafeCreate(t1 -> {
+                subscribeThread.set(Thread.currentThread());
+                t1.onSubscribe(subscription);
+                t1.onNext(1);
+                t1.onNext(2);
+                // observeOn will prevent canceling the upstream upon its termination now
+                // this call is racing for that state in this test
+                // not doing it will make sure the unsubscribeOn always gets through
+                // t1.onComplete();
             });
 
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
@@ -169,14 +160,9 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
              * DON'T DO THIS IN PRODUCTION CODE
              */
             final CountDownLatch latch = new CountDownLatch(1);
-            eventLoop.scheduleDirect(new Runnable() {
-
-                @Override
-                public void run() {
-                    t = Thread.currentThread();
-                    latch.countDown();
-                }
-
+            eventLoop.scheduleDirect(() -> {
+                t = Thread.currentThread();
+                latch.countDown();
             });
             try {
                 latch.await();
@@ -220,12 +206,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         final int[] calls = { 0 };
 
         Flowable.just(1)
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        })
+        .doOnCancel(() -> calls[0]++)
         .unsubscribeOn(Schedulers.single())
         .test()
         .assertResult(1);
@@ -238,12 +219,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
         final int[] calls = { 0 };
 
         Flowable.error(new TestException())
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        })
+        .doOnCancel(() -> calls[0]++)
         .unsubscribeOn(Schedulers.single())
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
@@ -50,14 +50,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     }
 
-    private final Consumer<Disposable> disposeSubscription = new Consumer<Disposable>() {
-
-        @Override
-        public void accept(Disposable d) {
-            d.dispose();
-        }
-
-    };
+    private final Consumer<Disposable> disposeSubscription = d -> d.dispose();
 
     @Test
     public void using() {
@@ -73,19 +66,9 @@ public class FlowableUsingTest extends RxJavaTest {
         final Resource resource = mock(Resource.class);
         when(resource.getTextFromWeb()).thenReturn("Hello world!");
 
-        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
-            @Override
-            public Resource get() {
-                return resource;
-            }
-        };
+        Supplier<Resource> resourceFactory = () -> resource;
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource res) {
-                return Flowable.fromArray(res.getTextFromWeb().split(" "));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = res -> Flowable.fromArray(res.getTextFromWeb().split(" "));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -115,37 +98,27 @@ public class FlowableUsingTest extends RxJavaTest {
 
     private void performTestUsingWithSubscribingTwice(boolean disposeEagerly) {
         // When subscribe is called, a new resource should be created.
-        Supplier<Resource> resourceFactory = new Supplier<Resource>() {
+        Supplier<Resource> resourceFactory = () -> new Resource() {
+
+            boolean first = true;
+
             @Override
-            public Resource get() {
-                return new Resource() {
-
-                    boolean first = true;
-
-                    @Override
-                    public String getTextFromWeb() {
-                        if (first) {
-                            first = false;
-                            return "Hello world!";
-                        }
-                        return "Nothing";
-                    }
-
-                    @Override
-                    public void dispose() {
-                        // do nothing
-                    }
-
-                };
+            public String getTextFromWeb() {
+                if (first) {
+                    first = false;
+                    return "Hello world!";
+                }
+                return "Nothing";
             }
+
+            @Override
+            public void dispose() {
+                // do nothing
+            }
+
         };
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource res) {
-                    return Flowable.fromArray(res.getTextFromWeb().split(" "));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = res -> Flowable.fromArray(res.getTextFromWeb().split(" "));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -177,19 +150,11 @@ public class FlowableUsingTest extends RxJavaTest {
     }
 
     private void performTestUsingWithResourceFactoryError(boolean disposeEagerly) {
-        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
-            @Override
-            public Disposable get() {
-                throw new TestException();
-            }
+        Supplier<Disposable> resourceFactory = () -> {
+            throw new TestException();
         };
 
-        Function<Disposable, Flowable<Integer>> observableFactory = new Function<Disposable, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Disposable d) {
-                return Flowable.empty();
-            }
-        };
+        Function<Disposable, Flowable<Integer>> observableFactory = _ -> Flowable.empty();
 
         Flowable.using(resourceFactory, observableFactory, disposeSubscription)
         .blockingLast();
@@ -207,18 +172,10 @@ public class FlowableUsingTest extends RxJavaTest {
 
     private void performTestUsingWithFlowableFactoryError(boolean disposeEagerly) {
         final Runnable unsubscribe = mock(Runnable.class);
-        Supplier<Disposable> resourceFactory = new Supplier<Disposable>() {
-            @Override
-            public Disposable get() {
-                return Disposable.fromRunnable(unsubscribe);
-            }
-        };
+        Supplier<Disposable> resourceFactory = () -> Disposable.fromRunnable(unsubscribe);
 
-        Function<Disposable, Flowable<Integer>> observableFactory = new Function<Disposable, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Disposable subscription) {
-                throw new TestException();
-            }
+        Function<Disposable, Flowable<Integer>> observableFactory = _ -> {
+            throw new TestException();
         };
 
         try {
@@ -238,12 +195,7 @@ public class FlowableUsingTest extends RxJavaTest {
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource resource) {
-                return Flowable.fromArray(resource.getTextFromWeb().split(" "));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = resource -> Flowable.fromArray(resource.getTextFromWeb().split(" "));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -265,12 +217,7 @@ public class FlowableUsingTest extends RxJavaTest {
         final Action completion = createOnCompletedAction(events);
         final Action unsub = createUnsubAction(events);
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource resource) {
-                return Flowable.fromArray(resource.getTextFromWeb().split(" "));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = resource -> Flowable.fromArray(resource.getTextFromWeb().split(" "));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -292,13 +239,8 @@ public class FlowableUsingTest extends RxJavaTest {
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource resource) {
-                return Flowable.fromArray(resource.getTextFromWeb().split(" "))
-                        .concatWith(Flowable.<String>error(new RuntimeException()));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = resource -> Flowable.fromArray(resource.getTextFromWeb().split(" "))
+                .concatWith(Flowable.<String>error(new RuntimeException()));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -320,13 +262,8 @@ public class FlowableUsingTest extends RxJavaTest {
         final Consumer<Throwable> onError = createOnErrorAction(events);
         final Action unsub = createUnsubAction(events);
 
-        Function<Resource, Flowable<String>> observableFactory = new Function<Resource, Flowable<String>>() {
-            @Override
-            public Flowable<String> apply(Resource resource) {
-                return Flowable.fromArray(resource.getTextFromWeb().split(" "))
-                        .concatWith(Flowable.<String>error(new RuntimeException()));
-            }
-        };
+        Function<Resource, Flowable<String>> observableFactory = resource -> Flowable.fromArray(resource.getTextFromWeb().split(" "))
+                .concatWith(Flowable.<String>error(new RuntimeException()));
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
 
@@ -341,50 +278,30 @@ public class FlowableUsingTest extends RxJavaTest {
     }
 
     private static Action createUnsubAction(final List<String> events) {
-        return new Action() {
-            @Override
-            public void run() {
-                events.add("unsub");
-            }
-        };
+        return () -> events.add("unsub");
     }
 
     private static Consumer<Throwable> createOnErrorAction(final List<String> events) {
-        return new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) {
-                events.add("error");
-            }
-        };
+        return _ -> events.add("error");
     }
 
     private static Supplier<Resource> createResourceFactory(final List<String> events) {
-        return new Supplier<Resource>() {
+        return () -> new Resource() {
+
             @Override
-            public Resource get() {
-                return new Resource() {
+            public String getTextFromWeb() {
+                return "hello world";
+            }
 
-                    @Override
-                    public String getTextFromWeb() {
-                        return "hello world";
-                    }
-
-                    @Override
-                    public void dispose() {
-                        events.add("disposed");
-                    }
-                };
+            @Override
+            public void dispose() {
+                events.add("disposed");
             }
         };
     }
 
     private static Action createOnCompletedAction(final List<String> events) {
-        return new Action() {
-            @Override
-            public void run() {
-                events.add("completed");
-            }
-        };
+        return () -> events.add("completed");
     }
 
     @Test
@@ -395,25 +312,12 @@ public class FlowableUsingTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable.<Integer, Integer>using(
-                new Supplier<Integer>() {
-                    @Override
-                    public Integer get() {
-                        return 1;
-                    }
-                },
-                new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) {
-                        throw new TestException("forced failure");
-                    }
-                },
-                new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer c) {
-                        count.incrementAndGet();
-                    }
-                }
-        )
+                        () -> 1,
+                        (Function<Integer, Flowable<Integer>>) _ -> {
+                            throw new TestException("forced failure");
+                        },
+                        _ -> count.incrementAndGet()
+                )
         .subscribe(ts);
 
         ts.assertError(TestException.class);
@@ -429,24 +333,9 @@ public class FlowableUsingTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
 
         Flowable.<Integer, Integer>using(
-                new Supplier<Integer>() {
-                    @Override
-                    public Integer get() {
-                        return 1;
-                    }
-                },
-                new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) {
-                        return Flowable.just(v);
-                    }
-                },
-                new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer c) {
-                        count.incrementAndGet();
-                    }
-                }, false
+                        () -> 1,
+                        (Function<Integer, Flowable<Integer>>) v -> Flowable.just(v),
+                        _ -> count.incrementAndGet(), false
         )
         .subscribe(ts);
 
@@ -460,39 +349,19 @@ public class FlowableUsingTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Flowable.using(
-                new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return 1;
-                    }
-                },
-                new Function<Object, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Object v) throws Exception {
-                        return Flowable.never();
-                    }
-                },
+                (Supplier<Object>) () -> 1,
+                (Function<Object, Flowable<Object>>) _ -> Flowable.never(),
                 Functions.emptyConsumer()
         ));
     }
 
     @Test
     public void supplierDisposerCrash() {
-        TestSubscriberEx<Object> ts = Flowable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Object v) throws Exception {
-                throw new TestException("First");
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object e) throws Exception {
-                throw new TestException("Second");
-            }
+        TestSubscriberEx<Object> ts = Flowable.using((Supplier<Object>) () -> 1,
+                        (Function<Object, Flowable<Object>>) _ -> {
+            throw new TestException("First");
+        }, _ -> {
+            throw new TestException("Second");
         })
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
@@ -505,22 +374,11 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerOnErrorDisposerCrash() {
-        TestSubscriberEx<Object> ts = Flowable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Object v) throws Exception {
-                return Flowable.error(new TestException("First"));
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object e) throws Exception {
-                throw new TestException("Second");
-            }
-        })
+        TestSubscriberEx<Object> ts = Flowable.using((Supplier<Object>) () -> 1,
+                        (Function<Object, Flowable<Object>>) _ -> Flowable.error(new TestException("First")),
+                        _ -> {
+                            throw new TestException("Second");
+                        })
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -532,22 +390,11 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void eagerOnCompleteDisposerCrash() {
-        Flowable.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Object v) throws Exception {
-                return Flowable.empty();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object e) throws Exception {
-                throw new TestException("Second");
-            }
-        })
+        Flowable.using((Supplier<Object>) () -> 1,
+                        (Function<Object, Flowable<Object>>) _ -> Flowable.empty(),
+                        _ -> {
+                            throw new TestException("Second");
+                        })
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "Second");
     }
@@ -556,22 +403,11 @@ public class FlowableUsingTest extends RxJavaTest {
     public void nonEagerDisposerCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, Flowable<Object>>() {
-                @Override
-                public Flowable<Object> apply(Object v) throws Exception {
-                    return Flowable.empty();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException("Second");
-                }
-            }, false)
+            Flowable.using((Supplier<Object>) () -> 1,
+                            (Function<Object, Flowable<Object>>) _ -> Flowable.empty(),
+                            _ -> {
+                                throw new TestException("Second");
+                            }, false)
             .test()
             .assertResult();
 
@@ -593,13 +429,8 @@ public class FlowableUsingTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return Flowable.using(Functions.justSupplier(1), Functions.justFunction(f), Functions.emptyConsumer());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f ->
+                Flowable.using(Functions.justSupplier(1), Functions.justFunction(f), Functions.emptyConsumer()));
     }
 
     @Test
@@ -637,24 +468,8 @@ public class FlowableUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         Flowable.using(Functions.justSupplier(1),
-            new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) throws Throwable {
-                    return Flowable.range(1, 2)
-                            .doOnCancel(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Cancel");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, true)
+                        (Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2)
+                                .doOnCancel(() -> sb.append("Cancel")), _ -> sb.append("Resource"), true)
         .take(1)
         .test()
         .assertResult(1);
@@ -667,23 +482,8 @@ public class FlowableUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         Flowable.using(Functions.justSupplier(1),
-            new Function<Integer, Flowable<Integer>>() {
-                @Override
-                public Flowable<Integer> apply(Integer t) throws Throwable {
-                    return Flowable.range(1, 2)
-                            .doOnCancel(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Cancel");
-                                }
-                            });
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, false)
+                        (Function<Integer, Flowable<Integer>>) _ -> Flowable.range(1, 2)
+                                .doOnCancel(() -> sb.append("Cancel")), _ -> sb.append("Resource"), false)
         .take(1)
         .test()
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -270,17 +270,9 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
     @Test
     public void innerBadSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return Flowable.just(1).window(f).flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                        return v;
-                    }
-                });
-            }
-        }, false, 1, 1, (Object[])null);
+        TestHelper.checkBadSourceFlowable(f -> Flowable.just(1).window(f)
+                .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v),
+                false, 1, 1, (Object[])null);
     }
 
     @Test
@@ -299,12 +291,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         };
 
         ps.window(BehaviorProcessor.createDefault(1))
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         ps.onNext(1);
@@ -316,17 +303,9 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Object>, Object>() {
-            @Override
-            public Object apply(Flowable<Object> f) throws Exception {
-                return f.window(Flowable.never()).flatMap(new Function<Flowable<Object>, Flowable<Object>>() {
-                    @Override
-                    public Flowable<Object> apply(Flowable<Object> v) throws Exception {
-                        return v;
-                    }
-                });
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceFlowable((Function<Flowable<Object>, Object>) f ->
+                f.window(Flowable.never()).flatMap((Function<Flowable<Object>, Flowable<Object>>) v -> v),
+                false, 1, 1, 1);
     }
 
     @Test
@@ -370,13 +349,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
     @Test
     public void boundaryDirectDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Flowable<Object>>>() {
-            @Override
-            public Publisher<Flowable<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.window(Flowable.never()).takeLast(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.window(Flowable.never()).takeLast(1));
     }
 
     @Test
@@ -386,13 +359,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = source.window(boundary)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(
-                    Flowable<Integer> w) throws Exception {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) w -> w.take(1))
         .test();
 
         source.onNext(1);
@@ -417,11 +384,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
                     ref.set(subscriber);
                 }
             })
-            .doOnNext(new Consumer<Flowable<Object>>() {
-                @Override
-                public void accept(Flowable<Object> w) throws Throwable {
-                    w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
-                }
+            .doOnNext(w -> {
+                w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
             })
             .to(TestHelper.<Flowable<Object>>testConsumer());
 
@@ -465,18 +429,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
                 })
                 .to(TestHelper.<Flowable<Object>>testConsumer());
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        refMain.get().onComplete();
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ref.get().onError(ex);
-                    }
-                };
+                Runnable r1 = () -> refMain.get().onComplete();
+                Runnable r2 = () -> ref.get().onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -515,18 +469,8 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             })
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    refMain.get().onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ref.get().onNext(1);
-                }
-            };
+            Runnable r1 = () -> refMain.get().onNext(1);
+            Runnable r2 = () -> ref.get().onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -604,19 +548,11 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             })
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    Subscriber<Object> subscriber = ref.get();
-                    subscriber.onNext(1);
-                    subscriber.onComplete();
-                }
+            Runnable r1 = () -> ts.cancel();
+            Runnable r2 = () -> {
+                Subscriber<Object> subscriber = ref.get();
+                subscriber.onNext(1);
+                subscriber.onComplete();
             };
 
             TestHelper.race(r1, r2);
@@ -662,19 +598,11 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             })
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    Subscriber<Object> subscriber = ref.get();
-                    subscriber.onNext(1);
-                    subscriber.onError(ex);
-                }
+            Runnable r1 = () -> ts.cancel();
+            Runnable r2 = () -> {
+                Subscriber<Object> subscriber = ref.get();
+                subscriber.onNext(1);
+                subscriber.onError(ex);
             };
 
             TestHelper.race(r1, r2);
@@ -687,12 +615,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(Flowable.just(1).concatWith(Flowable.<Integer>never()))
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -712,12 +635,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         final AtomicReference<Flowable<Integer>> inner = new AtomicReference<>();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(Flowable.<Integer>never())
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(inner::set)
         .test();
 
         assertTrue(pp.hasSubscribers());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -38,12 +38,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     private static <T> List<List<T>> toLists(Flowable<Flowable<T>> observables) {
 
-        return observables.flatMapSingle(new Function<Flowable<T>, SingleSource<List<T>>>() {
-            @Override
-            public SingleSource<List<T>> apply(Flowable<T> w) throws Throwable {
-                return w.toList();
-            }
-        }).toList().blockingGet();
+        return observables.flatMapSingle((Function<Flowable<T>, SingleSource<List<T>>>) w -> w.toList()).toList().blockingGet();
     }
 
     @Test
@@ -103,14 +98,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
 
         final AtomicInteger count = new AtomicInteger();
-        Flowable.merge(Flowable.range(1, 10000).doOnNext(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                count.incrementAndGet();
-            }
-
-        }).window(5).take(2))
+        Flowable.merge(Flowable.range(1, 10000).doOnNext(_ -> count.incrementAndGet()).window(5).take(2))
         .subscribe(ts);
 
         ts.awaitDone(500, TimeUnit.MILLISECONDS);
@@ -125,14 +113,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 100000)
-                .doOnNext(new Consumer<Integer>() {
-
-                    @Override
-                    public void accept(Integer t1) {
-                        count.incrementAndGet();
-                    }
-
-                })
+                .doOnNext(_ -> count.incrementAndGet())
                 .observeOn(Schedulers.computation())
                 .window(5)
                 .take(2))
@@ -148,14 +129,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     public void windowUnsubscribeOverlapping() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
-        Flowable.merge(Flowable.range(1, 10000).doOnNext(new Consumer<Integer>() {
-
-            @Override
-            public void accept(Integer t1) {
-                count.incrementAndGet();
-            }
-
-        }).window(5, 4).take(2)).subscribe(ts);
+        Flowable.merge(Flowable.range(1, 10000).doOnNext(_ -> count.incrementAndGet()).window(5, 4).take(2)).subscribe(ts);
         ts.awaitDone(500, TimeUnit.MILLISECONDS);
         ts.assertTerminated();
         //        System.out.println(ts.getOnNextEvents());
@@ -168,14 +142,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         final AtomicInteger count = new AtomicInteger();
         Flowable.merge(Flowable.range(1, 100000)
-                .doOnNext(new Consumer<Integer>() {
-
-                    @Override
-                    public void accept(Integer t1) {
-                        count.incrementAndGet();
-                    }
-
-                })
+                .doOnNext(_ -> count.incrementAndGet())
                 .observeOn(Schedulers.computation())
                 .window(5, 4)
                 .take(2), 128)
@@ -247,26 +214,23 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
     }
 
     public static Flowable<Integer> hotStream() {
-        return Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription bs = new BooleanSubscription();
-                s.onSubscribe(bs);
-                while (!bs.isCancelled()) {
-                    // burst some number of items
-                    for (int i = 0; i < Math.random() * 20; i++) {
-                        s.onNext(i);
-                    }
-                    try {
-                        // sleep for a random amount of time
-                        // NOTE: Only using Thread.sleep here as an artificial demo.
-                        Thread.sleep((long) (Math.random() * 200));
-                    } catch (Exception e) {
-                        // do nothing
-                    }
+        return Flowable.unsafeCreate((Publisher<Integer>) s -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            s.onSubscribe(bs);
+            while (!bs.isCancelled()) {
+                // burst some number of items
+                for (int i = 0; i < Math.random() * 20; i++) {
+                    s.onNext(i);
                 }
-                System.out.println("Hot done.");
+                try {
+                    // sleep for a random amount of time
+                    // NOTE: Only using Thread.sleep here as an artificial demo.
+                    Thread.sleep((long) (Math.random() * 200));
+                } catch (Exception e) {
+                    // do nothing
+                }
             }
+            System.out.println("Hot done.");
         }).subscribeOn(Schedulers.newThread()); // use newThread since we are using sleep to block
     }
 
@@ -279,12 +243,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         hotStream()
         .window(10)
         .take(2)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> w) {
-                return w.startWithItem(indicator);
-            }
-        }).subscribe(ts);
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) w -> w.startWithItem(indicator)).subscribe(ts);
 
         ts.awaitDone(2, TimeUnit.SECONDS);
         ts.assertComplete();
@@ -297,18 +256,8 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .window(2, 1)
-        .map(new Function<Flowable<Integer>, Flowable<List<Integer>>>() {
-            @Override
-            public Flowable<List<Integer>> apply(Flowable<Integer> t) {
-                return t.toList().toFlowable();
-            }
-        })
-        .concatMapEager(new Function<Flowable<List<Integer>>, Publisher<List<Integer>>>() {
-            @Override
-            public Publisher<List<Integer>> apply(Flowable<List<Integer>> v) {
-                return v;
-            }
-        })
+        .map(t -> t.toList().toFlowable())
+        .concatMapEager((Function<Flowable<List<Integer>>, Publisher<List<Integer>>>) v -> v)
         .subscribe(ts);
 
         ts.assertNoErrors();
@@ -326,7 +275,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         System.out.println(ts.values());
 
         ts.assertValues(Arrays.asList(1, 2), Arrays.asList(2, 3),
-                Arrays.asList(3, 4), Arrays.asList(4, 5), Arrays.asList(5));
+                Arrays.asList(3, 4), Arrays.asList(4, 5), List.of(5));
         ts.assertNoErrors();
         ts.assertComplete();
     }
@@ -342,26 +291,11 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
-            @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.window(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Flowable<Object>>>) f -> f.window(1));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
-            @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.window(2, 1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Flowable<Object>>>) f -> f.window(2, 1));
 
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Flowable<Object>>>() {
-            @Override
-            public Flowable<Flowable<Object>> apply(Flowable<Object> f) throws Exception {
-                return f.window(1, 2);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Flowable<Object>>>) f -> f.window(1, 2));
     }
 
     @Test
@@ -395,12 +329,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         final TestSubscriber[] to = { null };
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .window(2)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Exception {
-                to[0] = w.test();
-            }
-        })
+        .doOnNext(w -> to[0] = w.test())
         .test()
         .assertError(TestException.class);
 
@@ -414,12 +343,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         final TestSubscriber[] to = { null };
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .window(2, 3)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Exception {
-                to[0] = w.test();
-            }
-        })
+        .doOnNext(w -> to[0] = w.test())
         .test()
         .assertError(TestException.class);
 
@@ -433,12 +357,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
         final TestSubscriber[] to = { null };
         Flowable.just(1).concatWith(Flowable.<Integer>error(new TestException()))
         .window(3, 2)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Exception {
-                to[0] = w.test();
-            }
-        })
+        .doOnNext(w -> to[0] = w.test())
         .test()
         .assertError(TestException.class);
 
@@ -451,12 +370,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(10)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -477,12 +391,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(v -> inner.set(v))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -505,12 +414,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(5, 10)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -531,12 +435,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(5, 10)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(v -> inner.set(v))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -559,12 +458,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(5, 3)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -585,12 +479,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(5, 3)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(inner::set)
         .test();
 
         assertTrue(pp.hasSubscribers());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -50,42 +50,28 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         final List<String> list = new ArrayList<>();
         final List<List<String>> lists = new ArrayList<>();
 
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 10);
-                push(subscriber, "two", 60);
-                push(subscriber, "three", 110);
-                push(subscriber, "four", 160);
-                push(subscriber, "five", 210);
-                complete(subscriber, 500);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 10);
+            push(subscriber, "two", 60);
+            push(subscriber, "three", 110);
+            push(subscriber, "four", 160);
+            push(subscriber, "five", 210);
+            complete(subscriber, 500);
         });
 
-        Flowable<Object> openings = Flowable.unsafeCreate(new Publisher<Object>() {
-            @Override
-            public void subscribe(Subscriber<? super Object> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, new Object(), 50);
-                push(subscriber, new Object(), 200);
-                complete(subscriber, 250);
-            }
+        Flowable<Object> openings = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, new Object(), 50);
+            push(subscriber, new Object(), 200);
+            complete(subscriber, 250);
         });
 
-        Function<Object, Flowable<Object>> closer = new Function<Object, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Object opening) {
-                return Flowable.unsafeCreate(new Publisher<Object>() {
-                    @Override
-                    public void subscribe(Subscriber<? super Object> subscriber) {
-                        subscriber.onSubscribe(new BooleanSubscription());
-                        push(subscriber, new Object(), 100);
-                        complete(subscriber, 101);
-                    }
-                });
-            }
-        };
+        Function<Object, Flowable<Object>> closer = _ -> Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, new Object(), 100);
+            complete(subscriber, 101);
+        });
 
         Flowable<Flowable<String>> windowed = source.window(openings, closer);
         windowed.subscribe(observeWindow(list, lists));
@@ -105,46 +91,31 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Subscriber<?> subscriber, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     private Consumer<Flowable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
-        return new Consumer<Flowable<String>>() {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<String>() {
             @Override
-            public void accept(Flowable<String> stringFlowable) {
-                stringFlowable.subscribe(new DefaultSubscriber<String>() {
-                    @Override
-                    public void onComplete() {
-                        lists.add(new ArrayList<>(list));
-                        list.clear();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        fail(e.getMessage());
-                    }
-
-                    @Override
-                    public void onNext(String args) {
-                        list.add(args);
-                    }
-                });
+            public void onComplete() {
+                lists.add(new ArrayList<>(list));
+                list.clear();
             }
-        };
+
+            @Override
+            public void onError(Throwable e) {
+                fail(e.getMessage());
+            }
+
+            @Override
+            public void onNext(String args) {
+                list.add(args);
+            }
+        });
     }
 
     @Test
@@ -156,17 +127,9 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<>();
 
-        source.window(open, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return close;
-            }
-        })
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Throwable {
-                w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
-            }
+        source.window(open, (Function<Integer, Flowable<Integer>>) _ -> close)
+        .doOnNext(w -> {
+            w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
         })
         .subscribe(ts);
 
@@ -200,17 +163,9 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = new TestSubscriber<>();
 
-        source.window(open, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer t) {
-                return close;
-            }
-        })
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Throwable {
-                w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
-            }
+        source.window(open, (Function<Integer, Flowable<Integer>>) _ -> close)
+        .doOnNext(w -> {
+            w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
         })
         .subscribe(ts);
 
@@ -248,12 +203,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         };
 
         pp.window(BehaviorProcessor.createDefault(1), Functions.justFunction(Flowable.never()))
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         pp.onNext(1);
@@ -269,12 +219,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return end;
-            }
-        })
+        TestSubscriber<Integer> ts = source.window(start, (Function<Integer, Flowable<Integer>>) _ -> end)
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test();
 
@@ -305,12 +250,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return end;
-            }
-        })
+        TestSubscriber<Integer> ts = source.window(start, (Function<Integer, Flowable<Integer>>) _ -> end)
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test();
 
@@ -330,12 +270,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> start = PublishProcessor.create();
         final PublishProcessor<Integer> end = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = source.window(start, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return end;
-            }
-        })
+        TestSubscriber<Integer> ts = source.window(start, (Function<Integer, Flowable<Integer>>) _ -> end)
         .flatMap(Functions.<Flowable<Integer>>identity())
         .test();
 
@@ -363,26 +298,18 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorProcessor.createDefault(1)
-            .window(BehaviorProcessor.createDefault(1), new Function<Integer, Publisher<Integer>>() {
+            .window(BehaviorProcessor.createDefault(1), _ -> new Flowable<Integer>() {
                 @Override
-                public Publisher<Integer> apply(Integer f) throws Exception {
-                    return new Flowable<Integer>() {
-                        @Override
-                        protected void subscribeActual(
-                                Subscriber<? super Integer> s) {
-                            s.onSubscribe(new BooleanSubscription());
-                            s.onNext(1);
-                            s.onNext(2);
-                            s.onError(new TestException());
-                        }
-                    };
+                protected void subscribeActual(
+                        Subscriber<? super Integer> s) {
+                    s.onSubscribe(new BooleanSubscription());
+                    s.onNext(1);
+                    s.onNext(2);
+                    s.onError(new TestException());
                 }
             })
-            .doOnNext(new Consumer<Flowable<Integer>>() {
-                @Override
-                public void accept(Flowable<Integer> w) throws Throwable {
-                    w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
-                }
+            .doOnNext(w -> {
+                w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
             })
             .test()
             .assertValueCount(1)
@@ -397,12 +324,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     static Flowable<Integer> flowableDisposed(final AtomicBoolean ref) {
         return Flowable.just(1).concatWith(Flowable.<Integer>never())
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        ref.set(true);
-                    }
-                });
+                .doOnCancel(() -> ref.set(true));
     }
 
     @Test
@@ -412,17 +334,9 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         final AtomicBoolean closeDisposed = new AtomicBoolean();
 
         flowableDisposed(mainDisposed)
-        .window(flowableDisposed(openDisposed), new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return flowableDisposed(closeDisposed);
-            }
-        })
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Throwable {
-                w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
-            }
+        .window(flowableDisposed(openDisposed), (Function<Integer, Flowable<Integer>>) _ -> flowableDisposed(closeDisposed))
+        .doOnNext(w -> {
+            w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
         })
         .to(TestHelper.<Flowable<Integer>>testConsumer())
         .assertSubscribed()
@@ -460,12 +374,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(Flowable.just(1).concatWith(Flowable.<Integer>never()), Functions.justFunction(Flowable.never()))
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -486,12 +395,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(Flowable.<Integer>just(1).concatWith(Flowable.<Integer>never()),
                 Functions.justFunction(Flowable.never()))
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(v -> inner.set(v))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -522,11 +426,8 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         PublishProcessor<Integer> source = PublishProcessor.create();
         PublishProcessor<Integer> boundary = PublishProcessor.create();
 
-        TestSubscriber<Flowable<Integer>> ts = source.window(boundary, new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer end) throws Throwable {
-                throw new TestException();
-            }
+        TestSubscriber<Flowable<Integer>> ts = source.window(boundary, _ -> {
+            throw new TestException();
         })
         .test()
         ;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -50,17 +50,14 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final List<String> list = new ArrayList<>();
         final List<List<String>> lists = new ArrayList<>();
 
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 10);
-                push(subscriber, "two", 90);
-                push(subscriber, "three", 110);
-                push(subscriber, "four", 190);
-                push(subscriber, "five", 210);
-                complete(subscriber, 250);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 10);
+            push(subscriber, "two", 90);
+            push(subscriber, "three", 110);
+            push(subscriber, "four", 190);
+            push(subscriber, "five", 210);
+            complete(subscriber, 250);
         });
 
         Flowable<Flowable<String>> windowed = source.window(100, TimeUnit.MILLISECONDS, scheduler, 2);
@@ -86,17 +83,14 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final List<String> list = new ArrayList<>();
         final List<List<String>> lists = new ArrayList<>();
 
-        Flowable<String> source = Flowable.unsafeCreate(new Publisher<String>() {
-            @Override
-            public void subscribe(Subscriber<? super String> subscriber) {
-                subscriber.onSubscribe(new BooleanSubscription());
-                push(subscriber, "one", 98);
-                push(subscriber, "two", 99);
-                push(subscriber, "three", 99); // FIXME happens after the window is open
-                push(subscriber, "four", 101);
-                push(subscriber, "five", 102);
-                complete(subscriber, 150);
-            }
+        Flowable<String> source = Flowable.unsafeCreate(subscriber -> {
+            subscriber.onSubscribe(new BooleanSubscription());
+            push(subscriber, "one", 98);
+            push(subscriber, "two", 99);
+            push(subscriber, "three", 99); // FIXME happens after the window is open
+            push(subscriber, "four", 101);
+            push(subscriber, "five", 102);
+            complete(subscriber, 150);
         });
 
         Flowable<Flowable<String>> windowed = source.window(100, TimeUnit.MILLISECONDS, scheduler);
@@ -120,46 +114,31 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     private <T> void push(final Subscriber<T> subscriber, final T value, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Subscriber<?> subscriber, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                subscriber.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> subscriber.onComplete(), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> Consumer<Flowable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
-        return new Consumer<Flowable<T>>() {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<T>() {
             @Override
-            public void accept(Flowable<T> stringFlowable) {
-                stringFlowable.subscribe(new DefaultSubscriber<T>() {
-                    @Override
-                    public void onComplete() {
-                        lists.add(new ArrayList<>(list));
-                        list.clear();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        Assert.fail(e.getMessage());
-                    }
-
-                    @Override
-                    public void onNext(T args) {
-                        list.add(args);
-                    }
-                });
+            public void onComplete() {
+                lists.add(new ArrayList<>(list));
+                list.clear();
             }
-        };
+
+            @Override
+            public void onError(Throwable e) {
+                Assert.fail(e.getMessage());
+            }
+
+            @Override
+            public void onNext(T args) {
+                list.add(args);
+            }
+        });
     }
 
     @Test
@@ -180,7 +159,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         assertEquals(3, lists.get(2).size());
         assertEquals(Arrays.asList(7, 8, 9), lists.get(2));
         assertEquals(1, lists.get(3).size());
-        assertEquals(Arrays.asList(10), lists.get(3));
+        assertEquals(List.of(10), lists.get(3));
     }
 
     @Test
@@ -194,31 +173,10 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         FlowableWindowWithSizeTest.hotStream()
         .window(300, TimeUnit.MILLISECONDS)
         .take(10)
-        .doOnComplete(new Action() {
-            @Override
-            public void run() {
-                System.out.println("Main done!");
-            }
-        })
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> w) {
-                return w.startWithItem(indicator)
-                        .doOnComplete(new Action() {
-                            @Override
-                            public void run() {
-                                System.out.println("inner done: " + wip.incrementAndGet());
-                            }
-                        })
-                        ;
-            }
-        })
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer pv) {
-                System.out.println(pv);
-            }
-        })
+        .doOnComplete(() -> System.out.println("Main done!"))
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) w -> w.startWithItem(indicator)
+                .doOnComplete(() -> System.out.println("inner done: " + wip.incrementAndGet())))
+        .doOnNext(pv -> System.out.println(pv))
         .subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -515,12 +473,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
             final TestSubscriber<Integer> tsInner = new TestSubscriber<>();
 
             TestSubscriber<Flowable<Integer>> ts = pp.window(2, 1, TimeUnit.SECONDS, scheduler)
-            .doOnNext(new Consumer<Flowable<Integer>>() {
-                @Override
-                public void accept(Flowable<Integer> w) throws Throwable {
-                    w.subscribe(tsInner);
-                }
-            }) // avoid abandonment
+            .doOnNext(w -> w.subscribe(tsInner)) // avoid abandonment
             .test(1L);
 
             scheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -571,12 +524,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     public void restartTimerMany() throws Exception {
         final AtomicBoolean cancel1 = new AtomicBoolean();
         Flowable.intervalRange(1, 1000, 1, 1, TimeUnit.MILLISECONDS)
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                cancel1.set(true);
-            }
-        })
+        .doOnCancel(() -> cancel1.set(true))
         .window(1, TimeUnit.MILLISECONDS, Schedulers.single(), 2, true)
         .flatMap(Functions.<Flowable<Long>>identity())
         .take(500)
@@ -613,12 +561,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         };
 
         ps.window(1, TimeUnit.MILLISECONDS, scheduler)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         ps.onNext(1);
@@ -646,12 +589,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         };
 
         ps.window(1, TimeUnit.MILLISECONDS, scheduler, 10, true)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         ps.onNext(1);
@@ -679,12 +617,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         };
 
         ps.window(1, TimeUnit.MILLISECONDS, scheduler, 2, true)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         ps.onNext(1);
@@ -712,12 +645,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         };
 
         ps.window(1, 2, TimeUnit.MILLISECONDS, scheduler)
-        .flatMap(new Function<Flowable<Integer>, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Flowable<Integer>>) v -> v)
         .subscribe(ts);
 
         ps.onNext(1);
@@ -829,12 +757,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
         TestSubscriber<Flowable<Integer>> ts = ps.window(5, TimeUnit.MILLISECONDS, scheduler, 5, true)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> w) throws Throwable {
-                w.subscribe();
-            }
-        }) // avoid abandonment
+        .doOnNext(w -> w.subscribe()) // avoid abandonment
         .test();
 
         // window #1
@@ -856,13 +779,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Flowable<Object>>>() {
-            @Override
-            public Publisher<Flowable<Object>> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.window(1, TimeUnit.SECONDS, 1).takeLast(0);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.window(1, TimeUnit.SECONDS, 1).takeLast(0));
     }
 
     @Test
@@ -1183,12 +1100,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(10, TimeUnit.MINUTES)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -1209,12 +1121,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, TimeUnit.MINUTES)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(v -> inner.set(v))
         .test();
 
         assertFalse("Processor still has subscribers!", pp.hasSubscribers());
@@ -1233,12 +1140,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(10, TimeUnit.MINUTES, 100)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -1259,12 +1161,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, TimeUnit.MINUTES, 100)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(v -> inner.set(v))
         .test();
 
         assertFalse("Processor still has subscribers!", pp.hasSubscribers());
@@ -1283,12 +1180,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp.window(10, 15, TimeUnit.MINUTES)
         .take(1)
-        .flatMap(new Function<Flowable<Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Flowable<Integer> w) throws Throwable {
-                return w.take(1);
-            }
-        })
+        .flatMap((Function<Flowable<Integer>, Publisher<Integer>>) w -> w.take(1))
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -1309,12 +1201,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(10, 15, TimeUnit.MINUTES)
         .take(1)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
-            @Override
-            public void accept(Flowable<Integer> v) throws Throwable {
-                inner.set(v);
-            }
-        })
+        .doOnNext(inner::set)
         .test();
 
         assertFalse("Processor still has subscribers!", pp.hasSubscribers());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -35,17 +35,9 @@ import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.*;
 
 public class FlowableWithLatestFromTest extends RxJavaTest {
-    static final BiFunction<Integer, Integer, Integer> COMBINER = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return (t1 << 8) + t2;
-        }
-    };
-    static final BiFunction<Integer, Integer, Integer> COMBINER_ERROR = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            throw new TestException("Forced failure");
-        }
+    static final BiFunction<Integer, Integer, Integer> COMBINER = (t1, t2) -> (t1 << 8) + t2;
+    static final BiFunction<Integer, Integer, Integer> COMBINER_ERROR = (_, _) -> {
+        throw new TestException("Forced failure");
     };
     @Test
     public void simple() {
@@ -305,12 +297,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         ts.assertNoErrors();
     }
 
-    static final Function<Object[], String> toArray = new Function<Object[], String>() {
-        @Override
-        public String apply(Object[] args) {
-            return Arrays.toString(args);
-        }
-    };
+    static final Function<Object[], String> toArray = args -> Arrays.toString(args);
 
     @Test
     public void manySources() {
@@ -538,12 +525,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        just.withLatestFrom(just, just, new Function3<Integer, Integer, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer a, Integer b, Integer c) {
-                return Arrays.asList(a, b, c);
-            }
-        })
+        just.withLatestFrom(just, just, (a, b, c) -> Arrays.asList(a, b, c))
         .subscribe(ts);
 
         ts.assertValue(Arrays.asList(1, 1, 1));
@@ -557,12 +539,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        just.withLatestFrom(just, just, just, new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer a, Integer b, Integer c, Integer d) {
-                return Arrays.asList(a, b, c, d);
-            }
-        })
+        just.withLatestFrom(just, just, just, (a, b, c, d) -> Arrays.asList(a, b, c, d))
         .subscribe(ts);
 
         ts.assertValue(Arrays.asList(1, 1, 1, 1));
@@ -576,12 +553,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        just.withLatestFrom(just, just, just, just, new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer a, Integer b, Integer c, Integer d, Integer e) {
-                return Arrays.asList(a, b, c, d, e);
-            }
-        })
+        just.withLatestFrom(just, just, just, just, (a, b, c, d, e) -> Arrays.asList(a, b, c, d, e))
         .subscribe(ts);
 
         ts.assertValue(Arrays.asList(1, 1, 1, 1, 1));
@@ -591,46 +563,23 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.just(1).withLatestFrom(Flowable.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a;
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.just(1).withLatestFrom(Flowable.just(2), (BiFunction<Integer, Integer, Object>) (a, _) -> a));
 
-        TestHelper.checkDisposed(Flowable.just(1).withLatestFrom(Flowable.just(2), Flowable.just(3), new Function3<Integer, Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b, Integer c) throws Exception {
-                return a;
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.just(1).withLatestFrom(Flowable.just(2), Flowable.just(3), (Function3<Integer, Integer, Integer, Object>) (a, _, _) -> a));
     }
 
     @Test
     public void manyIteratorThrows() {
         Flowable.just(1)
-        .withLatestFrom(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(2);
-            }
-        }), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return a;
-            }
-        })
+        .withLatestFrom(new CrashingMappedIterable<>(1, 100, 100, _ -> Flowable.just(2)), (Function<Object[], Object>) a -> a)
         .to(TestHelper.testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
 
     @Test
     public void manyCombinerThrows() {
-        Flowable.just(1).withLatestFrom(Flowable.just(2), Flowable.just(3), new Function3<Integer, Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b, Integer c) throws Exception {
-                throw new TestException();
-            }
+        Flowable.just(1).withLatestFrom(Flowable.just(2), Flowable.just(3), (_, _, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -649,12 +598,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
                     subscriber.onError(new TestException("Second"));
                     subscriber.onComplete();
                 }
-            }.withLatestFrom(Flowable.just(2), Flowable.just(3), new Function3<Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c) throws Exception {
-                    return a;
-                }
-            })
+            }.withLatestFrom(Flowable.just(2), Flowable.just(3), (Function3<Integer, Integer, Integer, Object>) (a, _, _) -> a)
             .to(TestHelper.testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 
@@ -676,12 +620,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
                     s.onError(new TestException("First"));
                     s.onError(new TestException("Second"));
                 }
-            }, new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return a + b;
-                }
-            })
+            }, Integer::sum)
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 
@@ -694,12 +633,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     @Test
     public void combineToNull1() {
         Flowable.just(1)
-        .withLatestFrom(Flowable.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return null;
-            }
-        })
+        .withLatestFrom(Flowable.just(2), (_, _) -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -707,12 +641,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     @Test
     public void combineToNull2() {
         Flowable.just(1)
-        .withLatestFrom(Arrays.asList(Flowable.just(2), Flowable.just(3)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] o) throws Exception {
-                return null;
-            }
-        })
+        .withLatestFrom(Arrays.asList(Flowable.just(2), Flowable.just(3)), _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -754,12 +683,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     @Test
     public void coldSourceConsumedWithoutOther() {
         Flowable.range(1, 10).withLatestFrom(Flowable.never(),
-        new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer a, Object b) throws Exception {
-                return a;
-            }
-        })
+                        (BiFunction<Integer, Object, Object>) (a, _) -> a)
         .test(1)
         .assertResult();
     }
@@ -767,12 +691,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     @Test
     public void coldSourceConsumedWithoutManyOthers() {
         Flowable.range(1, 10).withLatestFrom(Flowable.never(), Flowable.never(), Flowable.never(),
-        new Function4<Integer, Object, Object, Object, Object>() {
-            @Override
-            public Object apply(Integer a, Object b, Object c, Object d) throws Exception {
-                return a;
-            }
-        })
+                        (Function4<Integer, Object, Object, Object, Object>) (a, _, _, _) -> a)
         .test(1)
         .assertResult();
     }
@@ -785,29 +704,13 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
             final PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-            final Flowable<Object> source = pp0.withLatestFrom(pp1, pp2, pp3, new Function4<Object, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Object a, Integer b, Integer c, Integer d)
-                        throws Exception {
-                    return a;
-                }
-            });
+            final Flowable<Object> source = pp0.withLatestFrom(pp1, pp2, pp3, (Function4<Object, Integer, Integer, Integer, Object>) (a, _, _, _) -> a);
 
             final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> source.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -828,29 +731,13 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
             final PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-            final Flowable<Object> source = pp0.withLatestFrom(pp1, pp2, pp3, new Function4<Object, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Object a, Integer b, Integer c, Integer d)
-                        throws Exception {
-                    return a;
-                }
-            });
+            final Flowable<Object> source = pp0.withLatestFrom(pp1, pp2, pp3, (Function4<Object, Integer, Integer, Integer, Object>) (a, _, _, _) -> a);
 
             final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> source.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
+            Runnable r2 = () -> pp1.onComplete();
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
@@ -44,12 +44,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
 
     @Before
     public void setUp() {
-        concat2Strings = new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String t1, String t2) {
-                return t1 + "-" + t2;
-            }
-        };
+        concat2Strings = (t1, t2) -> t1 + "-" + t2;
 
         s1 = PublishProcessor.create();
         s2 = PublishProcessor.create();
@@ -61,22 +56,8 @@ public class FlowableZipIterableTest extends RxJavaTest {
         zipped.subscribe(subscriber);
     }
 
-    BiFunction<Object, Object, String> zipr2 = new BiFunction<Object, Object, String>() {
-
-        @Override
-        public String apply(Object t1, Object t2) {
-            return "" + t1 + t2;
-        }
-
-    };
-    Function3<Object, Object, Object, String> zipr3 = new Function3<Object, Object, Object, String>() {
-
-        @Override
-        public String apply(Object t1, Object t2, Object t3) {
-            return "" + t1 + t2 + t3;
-        }
-
-    };
+    BiFunction<Object, Object, String> zipr2 = (t1, t2) -> "" + t1 + t2;
+    Function3<Object, Object, Object, String> zipr3 = (t1, t2, t3) -> "" + t1 + t2 + t3;
 
     @Test
     public void zipIterableSameSize() {
@@ -130,7 +111,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = Arrays.asList();
+        Iterable<String> r2 = List.of();
 
         r1.zipWith(r2, zipr2).subscribe(subscriber);
 
@@ -222,11 +203,8 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = new Iterable<String>() {
-            @Override
-            public Iterator<String> iterator() {
-                throw new TestException();
-            }
+        Iterable<String> r2 = () -> {
+            throw new TestException();
         };
 
         r1.zipWith(r2, zipr2).subscribe(subscriber);
@@ -249,33 +227,26 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = new Iterable<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() {
+            int count;
 
             @Override
-            public Iterator<String> iterator() {
-                return new Iterator<String>() {
-                    int count;
+            public boolean hasNext() {
+                if (count == 0) {
+                    return true;
+                }
+                throw new TestException();
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (count == 0) {
-                            return true;
-                        }
-                        throw new TestException();
-                    }
+            @Override
+            public String next() {
+                count++;
+                return "1";
+            }
 
-                    @Override
-                    public String next() {
-                        count++;
-                        return "1";
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException("Not supported yet.");
-                    }
-
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
         };
@@ -299,27 +270,20 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = new Iterable<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() {
+            @Override
+            public boolean hasNext() {
+                return true;
+            }
 
             @Override
-            public Iterator<String> iterator() {
-                return new Iterator<String>() {
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
+            public String next() {
+                throw new TestException();
+            }
 
-                    @Override
-                    public String next() {
-                        throw new TestException();
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException("Not supported yet.");
-                    }
-
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("Not supported yet.");
             }
 
         };
@@ -335,12 +299,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
 
     }
 
-    Consumer<String> printer = new Consumer<String>() {
-        @Override
-        public void accept(String pv) {
-            System.out.println(pv);
-        }
-    };
+    Consumer<String> printer = System.out::println;
 
     static final class SquareStr implements Function<Integer, String> {
         final AtomicInteger counter = new AtomicInteger();
@@ -366,37 +325,19 @@ public class FlowableZipIterableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.just(1).zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.just(1).zipWith(List.of(1),
+                (BiFunction<Integer, Integer, Object>) Integer::sum));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Integer>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Integer> f) throws Exception {
-                return f.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Integer>, Flowable<Object>>) f -> f.zipWith(List.of(1),
+                (BiFunction<Integer, Integer, Object>) (a, b) -> a + b));
     }
 
     @Test
     public void iteratorThrows() {
-        Flowable.just(1).zipWith(new CrashingIterable(100, 1, 100), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.just(1).zipWith(new CrashingIterable(100, 1, 100), (BiFunction<Integer, Integer, Object>) (a, b) -> a + b)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
@@ -416,12 +357,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
                     subscriber.onComplete();
                 }
             }
-            .zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b) throws Exception {
-                    return a + b;
-                }
-            })
+            .zipWith(List.of(1), (BiFunction<Integer, Integer, Object>) (a, b) -> a + b)
             .test()
             .assertResult(2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -49,12 +49,7 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Before
     public void setUp() {
-        concat2Strings = new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String t1, String t2) {
-                return t1 + "-" + t2;
-            }
-        };
+        concat2Strings = (t1, t2) -> t1 + "-" + t2;
 
         s1 = PublishProcessor.create();
         s2 = PublishProcessor.create();
@@ -154,22 +149,8 @@ public class FlowableZipTest extends RxJavaTest {
 
     }
 
-    BiFunction<Object, Object, String> zipr2 = new BiFunction<Object, Object, String>() {
-
-        @Override
-        public String apply(Object t1, Object t2) {
-            return "" + t1 + t2;
-        }
-
-    };
-    Function3<Object, Object, Object, String> zipr3 = new Function3<Object, Object, Object, String>() {
-
-        @Override
-        public String apply(Object t1, Object t2, Object t3) {
-            return "" + t1 + t2 + t3;
-        }
-
-    };
+    BiFunction<Object, Object, String> zipr2 = (t1, t2) -> "" + t1 + t2;
+    Function3<Object, Object, Object, String> zipr3 = (t1, t2, t3) -> "" + t1 + t2 + t3;
 
     /**
      * Testing internal private logic due to the complexity so I want to use TDD to test as a I build it rather than
@@ -541,69 +522,37 @@ public class FlowableZipTest extends RxJavaTest {
     }
 
     private BiFunction<String, String, String> getConcat2Strings() {
-        return new BiFunction<String, String, String>() {
-
-            @Override
-            public String apply(String t1, String t2) {
-                return t1 + "-" + t2;
-            }
-        };
+        return (t1, t2) -> t1 + "-" + t2;
     }
 
     private BiFunction<Integer, Integer, Integer> getDivideZipr() {
-        BiFunction<Integer, Integer, Integer> zipr = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer i1, Integer i2) {
-                return i1 / i2;
-            }
-
-        };
+        BiFunction<Integer, Integer, Integer> zipr = (i1, i2) -> i1 / i2;
         return zipr;
     }
 
     private Function3<String, String, String, String> getConcat3StringsZipr() {
-        Function3<String, String, String, String> zipr = new Function3<String, String, String, String>() {
-
-            @Override
-            public String apply(String a1, String a2, String a3) {
-                if (a1 == null) {
-                    a1 = "";
-                }
-                if (a2 == null) {
-                    a2 = "";
-                }
-                if (a3 == null) {
-                    a3 = "";
-                }
-                return a1 + a2 + a3;
+        Function3<String, String, String, String> zipr = (a1, a2, a3) -> {
+            if (a1 == null) {
+                a1 = "";
             }
-
+            if (a2 == null) {
+                a2 = "";
+            }
+            if (a3 == null) {
+                a3 = "";
+            }
+            return a1 + a2 + a3;
         };
         return zipr;
     }
 
     private BiFunction<String, Integer, String> getConcatStringIntegerZipr() {
-        BiFunction<String, Integer, String> zipr = new BiFunction<String, Integer, String>() {
-
-            @Override
-            public String apply(String s, Integer i) {
-                return getStringValue(s) + getStringValue(i);
-            }
-
-        };
+        BiFunction<String, Integer, String> zipr = (s, i) -> getStringValue(s) + getStringValue(i);
         return zipr;
     }
 
     private Function3<String, Integer, int[], String> getConcatStringIntegerIntArrayZipr() {
-        Function3<String, Integer, int[], String> zipr = new Function3<String, Integer, int[], String>() {
-
-            @Override
-            public String apply(String s, Integer i, int[] iArray) {
-                return getStringValue(s) + getStringValue(i) + getStringValue(iArray);
-            }
-
-        };
+        Function3<String, Integer, int[], String> zipr = (s, i, iArray) -> getStringValue(s) + getStringValue(i) + getStringValue(iArray);
         return zipr;
     }
 
@@ -730,12 +679,7 @@ public class FlowableZipTest extends RxJavaTest {
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable.zip(Flowable.just(1),
-                Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) {
-                        return a + b;
-                    }
-                }).subscribe(new DefaultSubscriber<Integer>() {
+                Flowable.just(1), (a, b) -> a + b).subscribe(new DefaultSubscriber<Integer>() {
 
             @Override
             public void onComplete() {
@@ -763,22 +707,12 @@ public class FlowableZipTest extends RxJavaTest {
     @Test
     public void start() {
         Flowable<String> os = OBSERVABLE_OF_5_INTEGERS
-                .zipWith(OBSERVABLE_OF_5_INTEGERS, new BiFunction<Integer, Integer, String>() {
-
-                    @Override
-                    public String apply(Integer a, Integer b) {
-                        return a + "-" + b;
-                    }
-                });
+                .zipWith(OBSERVABLE_OF_5_INTEGERS, (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
-        os.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                System.out.println(s);
-                list.add(s);
-            }
+        os.subscribe(s -> {
+            System.out.println(s);
+            list.add(s);
         });
 
         assertEquals(5, list.size());
@@ -790,13 +724,7 @@ public class FlowableZipTest extends RxJavaTest {
     @Test
     public void startAsync() throws InterruptedException {
         Flowable<String> os = ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(new CountDownLatch(1)).onBackpressureBuffer()
-                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(new CountDownLatch(1)).onBackpressureBuffer(), new BiFunction<Integer, Integer, String>() {
-
-                    @Override
-                    public String apply(Integer a, Integer b) {
-                        return a + "-" + b;
-                    }
-                }).take(5);
+                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(new CountDownLatch(1)).onBackpressureBuffer(), (a, b) -> a + "-" + b).take(5);
 
         TestSubscriber<String> ts = new TestSubscriber<>();
         os.subscribe(ts);
@@ -815,13 +743,7 @@ public class FlowableZipTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final CountDownLatch infiniteFlowable = new CountDownLatch(1);
         Flowable<String> os = OBSERVABLE_OF_5_INTEGERS
-                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteFlowable), new BiFunction<Integer, Integer, String>() {
-
-                    @Override
-                    public String apply(Integer a, Integer b) {
-                        return a + "-" + b;
-                    }
-                });
+                .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteFlowable), (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
         os.subscribe(new DefaultSubscriber<String>() {
@@ -878,23 +800,12 @@ public class FlowableZipTest extends RxJavaTest {
     public void emitMaterializedNotifications() {
         Flowable<Notification<Integer>> oi = Flowable.just(1, 2, 3).materialize();
         Flowable<Notification<String>> os = Flowable.just("a", "b", "c").materialize();
-        Flowable<String> f = Flowable.zip(oi, os, new BiFunction<Notification<Integer>, Notification<String>, String>() {
-
-            @Override
-            public String apply(Notification<Integer> t1, Notification<String> t2) {
-                return kind(t1) + "_" + value(t1) + "-" + kind(t2) + "_" + value(t2);
-            }
-
-        });
+        Flowable<String> f = Flowable.zip(oi, os, (t1, t2) -> kind(t1) + "_" + value(t1) + "-" + kind(t2) + "_" + value(t2));
 
         final ArrayList<String> list = new ArrayList<>();
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                System.out.println(s);
-                list.add(s);
-            }
+        f.subscribe(s -> {
+            System.out.println(s);
+            list.add(s);
         });
 
         assertEquals(4, list.size());
@@ -907,23 +818,12 @@ public class FlowableZipTest extends RxJavaTest {
     @Test
     public void startEmptyFlowables() {
 
-        Flowable<String> f = Flowable.zip(Flowable.<Integer> empty(), Flowable.<String> empty(), new BiFunction<Integer, String, String>() {
-
-            @Override
-            public String apply(Integer t1, String t2) {
-                return t1 + "-" + t2;
-            }
-
-        });
+        Flowable<String> f = Flowable.zip(Flowable.<Integer> empty(), Flowable.<String> empty(), (t1, t2) -> t1 + "-" + t2);
 
         final ArrayList<String> list = new ArrayList<>();
-        f.subscribe(new Consumer<String>() {
-
-            @Override
-            public void accept(String s) {
-                System.out.println(s);
-                list.add(s);
-            }
+        f.subscribe(s -> {
+            System.out.println(s);
+            list.add(s);
         });
 
         assertEquals(0, list.size());
@@ -935,12 +835,9 @@ public class FlowableZipTest extends RxJavaTest {
         final Object invoked = new Object();
         Collection<Flowable<Object>> observables = Collections.emptyList();
 
-        Flowable<Object> f = Flowable.zip(observables, new Function<Object[], Object>() {
-            @Override
-            public Object apply(final Object[] args) {
-                assertEquals("No argument should have been passed", 0, args.length);
-                return invoked;
-            }
+        Flowable<Object> f = Flowable.zip(observables, args -> {
+            Assert.assertEquals("No argument should have been passed", 0, args.length);
+            return invoked;
         });
 
         TestSubscriber<Object> ts = new TestSubscriber<>();
@@ -959,12 +856,9 @@ public class FlowableZipTest extends RxJavaTest {
         final Object invoked = new Object();
         Collection<Flowable<Object>> observables = Collections.emptyList();
 
-        Flowable<Object> f = Flowable.zip(observables, new Function<Object[], Object>() {
-            @Override
-            public Object apply(final Object[] args) {
-                assertEquals("No argument should have been passed", 0, args.length);
-                return invoked;
-            }
+        Flowable<Object> f = Flowable.zip(observables, args -> {
+            Assert.assertEquals("No argument should have been passed", 0, args.length);
+            return invoked;
         });
 
         f.blockingLast();
@@ -978,14 +872,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
-
-            @Override
-            public String apply(Integer t1, Integer t2) {
-                return t1 + "-" + t2;
-            }
-
-        }).take(Flowable.bufferSize() * 2).subscribe(ts);
+        Flowable.zip(f1, f2, (t1, t2) -> t1 + "-" + t2).take(Flowable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1002,14 +889,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
-
-            @Override
-            public String apply(Integer t1, Integer t2) {
-                return t1 + "-" + t2;
-            }
-
-        }).take(Flowable.bufferSize() * 2).subscribe(ts);
+        Flowable.zip(f1, f2, (t1, t2) -> t1 + "-" + t2).take(Flowable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1026,14 +906,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).take(Flowable.bufferSize() * 2);
 
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
-
-            @Override
-            public String apply(Integer t1, Integer t2) {
-                return t1 + "-" + t2;
-            }
-
-        }).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
+        Flowable.zip(f1, f2, (t1, t2) -> t1 + "-" + t2).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1051,14 +924,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB).subscribeOn(Schedulers.computation());
 
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
-
-            @Override
-            public String apply(Integer t1, Integer t2) {
-                return t1 + "-" + t2;
-            }
-
-        }).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
+        Flowable.zip(f1, f2, (t1, t2) -> t1 + "-" + t2).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1076,14 +942,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> f2 = createInfiniteFlowable(generatedB);
 
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Flowable.zip(f1, f2, new BiFunction<Integer, Integer, String>() {
-
-            @Override
-            public String apply(Integer t1, Integer t2) {
-                return t1 + "-" + t2;
-            }
-
-        }).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
+        Flowable.zip(f1, f2, (t1, t2) -> t1 + "-" + t2).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(ts);
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1094,25 +953,20 @@ public class FlowableZipTest extends RxJavaTest {
     }
 
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
-        Flowable<Integer> flowable = Flowable.fromIterable(new Iterable<Integer>() {
+        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() {
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
+            public void remove() {
+            }
 
-                    @Override
-                    public void remove() {
-                    }
+            @Override
+            public Integer next() {
+                return generated.getAndIncrement();
+            }
 
-                    @Override
-                    public Integer next() {
-                        return generated.getAndIncrement();
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        return true;
-                    }
-                };
+            @Override
+            public boolean hasNext() {
+                return true;
             }
         });
         return flowable;
@@ -1121,52 +975,38 @@ public class FlowableZipTest extends RxJavaTest {
     Flowable<Integer> OBSERVABLE_OF_5_INTEGERS = OBSERVABLE_OF_5_INTEGERS(new AtomicInteger());
 
     Flowable<Integer> OBSERVABLE_OF_5_INTEGERS(final AtomicInteger numEmitted) {
-        return Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                BooleanSubscription bs = new BooleanSubscription();
-                subscriber.onSubscribe(bs);
-                for (int i = 1; i <= 5; i++) {
-                    if (bs.isCancelled()) {
-                        break;
-                    }
-                    numEmitted.incrementAndGet();
-                    subscriber.onNext(i);
-                    Thread.yield();
+        return Flowable.unsafeCreate(subscriber -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            subscriber.onSubscribe(bs);
+            for (int i = 1; i <= 5; i++) {
+                if (bs.isCancelled()) {
+                    break;
                 }
-                subscriber.onComplete();
+                numEmitted.incrementAndGet();
+                subscriber.onNext(i);
+                Thread.yield();
             }
-
+            subscriber.onComplete();
         });
     }
 
     Flowable<Integer> ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(final CountDownLatch latch) {
-        return Flowable.unsafeCreate(new Publisher<Integer>() {
-
-            @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                final BooleanSubscription bs = new BooleanSubscription();
-                subscriber.onSubscribe(bs);
-                Thread t = new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        System.out.println("-------> subscribe to infinite sequence");
-                        System.out.println("Starting thread: " + Thread.currentThread());
-                        int i = 1;
-                        while (!bs.isCancelled()) {
-                            subscriber.onNext(i++);
-                            Thread.yield();
-                        }
-                        subscriber.onComplete();
-                        latch.countDown();
-                        System.out.println("Ending thread: " + Thread.currentThread());
-                    }
-                });
-                t.start();
-
-            }
+        return Flowable.unsafeCreate(subscriber -> {
+            final BooleanSubscription bs = new BooleanSubscription();
+            subscriber.onSubscribe(bs);
+            Thread t = new Thread(() -> {
+                System.out.println("-------> subscribe to infinite sequence");
+                System.out.println("Starting thread: " + Thread.currentThread());
+                int i = 1;
+                while (!bs.isCancelled()) {
+                    subscriber.onNext(i++);
+                    Thread.yield();
+                }
+                subscriber.onComplete();
+                latch.countDown();
+                System.out.println("Ending thread: " + Thread.currentThread());
+            });
+            t.start();
 
         });
     }
@@ -1175,21 +1015,9 @@ public class FlowableZipTest extends RxJavaTest {
     public void issue1812() {
         // https://github.com/ReactiveX/RxJava/issues/1812
         Flowable<Integer> zip1 = Flowable.zip(Flowable.range(0, 1026), Flowable.range(0, 1026),
-                new BiFunction<Integer, Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer i1, Integer i2) {
-                        return i1 + i2;
-                    }
-                });
+                (i1, i2) -> i1 + i2);
         Flowable<Integer> zip2 = Flowable.zip(zip1, Flowable.range(0, 1026),
-                new BiFunction<Integer, Integer, Integer>() {
-
-                    @Override
-                    public Integer apply(Integer i1, Integer i2) {
-                        return i1 + i2;
-                    }
-                });
+                (i1, i2) -> i1 + i2);
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 1026; i++) {
             expected.add(i * 3);
@@ -1199,12 +1027,7 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void unboundedDownstreamOverrequesting() {
-        Flowable<Integer> source = Flowable.range(1, 2).zipWith(Flowable.range(1, 2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + 10 * t2;
-            }
-        });
+        Flowable<Integer> source = Flowable.range(1, 2).zipWith(Flowable.range(1, 2), (t1, t2) -> t1 + 10 * t2);
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
             @Override
@@ -1231,12 +1054,7 @@ public class FlowableZipTest extends RxJavaTest {
         // used so that this test will not timeout on slow machines.
         int i = 0;
         while (System.currentTimeMillis() - startTime < 9000 && i++ < 100000) {
-            int value = Flowable.zip(src, src, new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer t1, Integer t2) {
-                    return t1 + t2 * 10;
-                }
-            }).blockingSingle(0);
+            int value = Flowable.zip(src, src, (t1, t2) -> t1 + t2 * 10).blockingSingle(0);
 
             Assert.assertEquals(11, value);
         }
@@ -1250,12 +1068,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> src = Flowable.just(1).subscribeOn(Schedulers.computation());
         TestSubscriber<Integer> ts = new TestSubscriber<>(1L);
 
-        Flowable.zip(src, src, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 + t2 * 10;
-            }
-        }).subscribe(ts);
+        Flowable.zip(src, src, (t1, t2) -> t1 + t2 * 10).subscribe(ts);
 
         ts.awaitDone(1, TimeUnit.SECONDS);
         ts.assertNoErrors();
@@ -1369,12 +1182,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> error2 = Flowable.error(new TestException("Two"));
         Flowable<Integer> source2 = Flowable.range(1, 2).concatWith(error2);
 
-        TestSubscriberEx<Object> ts = Flowable.zip(source1, source2, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return "" + a + b;
-            }
-        }, true)
+        TestSubscriberEx<Object> ts = Flowable.zip(source1, source2, (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, true)
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class, "11", "22");
 
@@ -1392,12 +1200,7 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable<Integer> error2 = Flowable.error(new TestException("Two"));
         Flowable<Integer> source2 = Flowable.range(1, 2).concatWith(error2);
 
-        TestSubscriberEx<Object> ts = Flowable.zip(source1, source2, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return "" + a + b;
-            }
-        }, true, 1)
+        TestSubscriberEx<Object> ts = Flowable.zip(source1, source2, (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, true, 1)
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class, "11", "22");
 
@@ -1411,12 +1214,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void zip2Prefetch() {
         Flowable.zip(Flowable.range(1, 9),
                 Flowable.range(21, 9),
-            new BiFunction<Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b) throws Exception {
-                    return "" + a + b;
-                }
-            }, false, 2
+                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, false, 2
         )
         .takeLast(1)
         .test()
@@ -1432,13 +1230,8 @@ public class FlowableZipTest extends RxJavaTest {
     public void zip2() {
         Flowable.zip(Flowable.just(1),
                 Flowable.just(2),
-            new BiFunction<Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b) throws Exception {
-                    return "" + a + b;
-                }
-            }
-        )
+                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b
+                )
         .test()
         .assertResult("12");
     }
@@ -1447,13 +1240,8 @@ public class FlowableZipTest extends RxJavaTest {
     public void zip3() {
         Flowable.zip(Flowable.just(1),
                 Flowable.just(2), Flowable.just(3),
-            new Function3<Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c) throws Exception {
-                    return "" + a + b + c;
-                }
-            }
-        )
+                        (Function3<Integer, Integer, Integer, Object>) (a, b, c) -> "" + a + b + c
+                )
         .test()
         .assertResult("123");
     }
@@ -1463,13 +1251,8 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable.zip(Flowable.just(1),
                 Flowable.just(2), Flowable.just(3),
                 Flowable.just(4),
-            new Function4<Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d) throws Exception {
-                    return "" + a + b + c + d;
-                }
-            }
-        )
+                        (Function4<Integer, Integer, Integer, Integer, Object>) (a, b, c, d) -> "" + a + b + c + d
+                )
         .test()
         .assertResult("1234");
     }
@@ -1479,13 +1262,8 @@ public class FlowableZipTest extends RxJavaTest {
         Flowable.zip(Flowable.just(1),
                 Flowable.just(2), Flowable.just(3),
                 Flowable.just(4), Flowable.just(5),
-            new Function5<Integer, Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e) throws Exception {
-                    return "" + a + b + c + d + e;
-                }
-            }
-        )
+                        (Function5<Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e) -> "" + a + b + c + d + e
+                )
         .test()
         .assertResult("12345");
     }
@@ -1496,13 +1274,8 @@ public class FlowableZipTest extends RxJavaTest {
                 Flowable.just(2), Flowable.just(3),
                 Flowable.just(4), Flowable.just(5),
                 Flowable.just(6),
-            new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f) throws Exception {
-                    return "" + a + b + c + d + e + f;
-                }
-            }
-        )
+                        (Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e, f) -> "" + a + b + c + d + e + f
+                )
         .test()
         .assertResult("123456");
     }
@@ -1513,14 +1286,8 @@ public class FlowableZipTest extends RxJavaTest {
                 Flowable.just(2), Flowable.just(3),
                 Flowable.just(4), Flowable.just(5),
                 Flowable.just(6), Flowable.just(7),
-            new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g)
-                        throws Exception {
-                    return "" + a + b + c + d + e + f + g;
-                }
-            }
-        )
+                        (Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e, f, g) -> "" + a + b + c + d + e + f + g
+                )
         .test()
         .assertResult("1234567");
     }
@@ -1532,14 +1299,9 @@ public class FlowableZipTest extends RxJavaTest {
                 Flowable.just(4), Flowable.just(5),
                 Flowable.just(6), Flowable.just(7),
                 Flowable.just(8),
-            new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
-                        Integer h) throws Exception {
-                    return "" + a + b + c + d + e + f + g + h;
-                }
-            }
-        )
+                        (Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>)
+                        (a, b, c, d, e, f, g, h) -> "" + a + b + c + d + e + f + g + h
+                )
         .test()
         .assertResult("12345678");
     }
@@ -1551,14 +1313,9 @@ public class FlowableZipTest extends RxJavaTest {
                 Flowable.just(4), Flowable.just(5),
                 Flowable.just(6), Flowable.just(7),
                 Flowable.just(8), Flowable.just(9),
-            new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                @Override
-                public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
-                        Integer h, Integer i) throws Exception {
-                    return "" + a + b + c + d + e + f + g + h + i;
-                }
-            }
-        )
+                        (Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>)
+                        (a, b, c, d, e, f, g, h, i) -> "" + a + b + c + d + e + f + g + h + i
+                )
         .test()
         .assertResult("123456789");
     }
@@ -1570,34 +1327,19 @@ public class FlowableZipTest extends RxJavaTest {
 
         Arrays.fill(arr, Flowable.just(1));
 
-        Flowable.zip(Arrays.asList(arr), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        Flowable.zip(Arrays.asList(arr), (Function<Object[], Object>) a -> Arrays.toString(a))
         .test()
         .assertResult("[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]");
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Flowable.zip(Flowable.just(1), Flowable.just(1), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }));
+        TestHelper.checkDisposed(Flowable.zip(Flowable.just(1), Flowable.just(1), (BiFunction<Integer, Integer, Object>) (a, b) -> a + b));
     }
 
     @Test
     public void badRequest() {
-        TestHelper.assertBadRequestReported(Flowable.zip(Flowable.just(1), Flowable.just(1), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }));
+        TestHelper.assertBadRequestReported(Flowable.zip(Flowable.just(1), Flowable.just(1), (BiFunction<Integer, Integer, Object>) (a, b) -> a + b));
     }
 
     @Test
@@ -1613,12 +1355,7 @@ public class FlowableZipTest extends RxJavaTest {
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     sub[0] = s;
                 }
-            }, new BiFunction<Object, Object, Object>() {
-                @Override
-                public Object apply(Object a, Object b) throws Exception {
-                    return a;
-                }
-            })
+            }, (a, _) -> a)
             .to(TestHelper.<Object>testConsumer());
 
             pp.onError(new TestException("First"));
@@ -1639,12 +1376,7 @@ public class FlowableZipTest extends RxJavaTest {
         PublishProcessor<Object> pp1 = PublishProcessor.create();
         PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        TestSubscriberEx<Object> ts = Flowable.zip(pp1, pp2, new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        }, true)
+        TestSubscriberEx<Object> ts = Flowable.zip(pp1, pp2, (a, _) -> a, true)
         .to(TestHelper.<Object>testConsumer());
 
         pp1.onError(new TestException("First"));
@@ -1659,12 +1391,7 @@ public class FlowableZipTest extends RxJavaTest {
         PublishProcessor<Object> pp1 = PublishProcessor.create();
         PublishProcessor<Object> pp2 = PublishProcessor.create();
 
-        TestSubscriberEx<Object> ts = Flowable.zip(pp1, pp2, new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        TestSubscriberEx<Object> ts = Flowable.zip(pp1, pp2, (a, _) -> a)
         .to(TestHelper.<Object>testSubscriber(0L));
 
         pp1.onError(new TestException("First"));
@@ -1676,68 +1403,36 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void fusedInputThrows() {
-        Flowable.zip(Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }), Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.zip(Flowable.just(1).map(_ -> {
+            throw new TestException();
+        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) (a, b) -> a + b)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void fusedInputThrowsDelayError() {
-        Flowable.zip(Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }), Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        Flowable.zip(Flowable.just(1).map(_ -> {
+            throw new TestException();
+        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) (a, b) -> a + b, true)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void fusedInputThrowsBackpressured() {
-        Flowable.zip(Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }), Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.zip(Flowable.just(1).map(_ -> {
+            throw new TestException();
+        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) (a, b) -> a + b)
         .test(0L)
         .assertFailure(TestException.class);
     }
 
     @Test
     public void fusedInputThrowsDelayErrorBackpressured() {
-        Flowable.zip(Flowable.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }), Flowable.just(2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        Flowable.zip(Flowable.just(1).map(_ -> {
+            throw new TestException();
+        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) (a, b) -> a + b, true)
         .test(0L)
         .assertFailure(TestException.class);
     }
@@ -1746,25 +1441,10 @@ public class FlowableZipTest extends RxJavaTest {
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
             TestSubscriber<List<Object>> ts = Flowable.zip(
-                    Flowable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    }),
-                    Flowable.just(1).observeOn(Schedulers.computation()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    }),
-                    new BiFunction<Object, Object, List<Object>>() {
-                        @Override
-                        public List<Object> apply(Object t1, Object t2) throws Exception {
-                            return Arrays.asList(t1, t2);
-                        }
-                    }
-            )
+                    Flowable.just(1).observeOn(Schedulers.single()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4)),
+                    Flowable.just(1).observeOn(Schedulers.computation()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4)),
+                            (t1, t2) -> Arrays.asList(t1, t2)
+                    )
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(1);
@@ -1823,24 +1503,14 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void fusedInputThrows2() {
-        Flowable.zip(new ThrowingQueueSubscription(), Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.zip(new ThrowingQueueSubscription(), Flowable.just(1), (a, b) -> a + b)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void fusedInputThrows2Backpressured() {
-        Flowable.zip(new ThrowingQueueSubscription(), Flowable.just(1), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.zip(new ThrowingQueueSubscription(), Flowable.just(1), (a, b) -> a + b)
         .test(0)
         .assertFailure(TestException.class);
     }
@@ -1856,12 +1526,7 @@ public class FlowableZipTest extends RxJavaTest {
             }
         };
 
-        Flowable.zip(Flowable.range(1, 2), Flowable.range(3, 2), new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Flowable.zip(Flowable.range(1, 2), Flowable.range(3, 2), (a, b) -> a + b)
         .subscribe(ts);
 
         ts.assertResult(4);
@@ -1872,24 +1537,11 @@ public class FlowableZipTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         List<Flowable<Object>> flowableList = new ArrayList<>();
-        flowableList.add(Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> e)
-                    throws Exception { throw new TestException(); }
-        }, BackpressureStrategy.MISSING));
-        flowableList.add(Flowable.create(new FlowableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(FlowableEmitter<Object> e)
-                    throws Exception { counter.getAndIncrement(); }
-        }, BackpressureStrategy.MISSING));
+        flowableList.add(Flowable.create(_ -> { throw new TestException(); }, BackpressureStrategy.MISSING));
+        flowableList.add(Flowable.create(_ -> counter.getAndIncrement(), BackpressureStrategy.MISSING));
 
         Flowable.zip(flowableList,
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return a;
-                    }
-                })
+                        (Function<Object[], Object>) a -> a)
         .test()
         .assertFailure(TestException.class)
         ;
@@ -1899,19 +1551,9 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void publishersInIterable() {
-        Publisher<Integer> source = new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> subscriber) {
-                Flowable.just(1).subscribe(subscriber);
-            }
-        };
+        Publisher<Integer> source = subscriber -> Flowable.just(1).subscribe(subscriber);
 
-        Flowable.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Flowable.zip(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -63,7 +63,7 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final TestSubscriber<Integer> ts = Maybe.concat(Arrays.asList(pp.singleElement()))
+            final TestSubscriber<Integer> ts = Maybe.concat(Collections.singletonList(pp.singleElement()))
             .test();
 
             pp.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -580,17 +580,17 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void badRequest() {
-        TestHelper.assertBadRequestReported(MaybeSubject.create().flattenAsFlowable(v -> Arrays.asList(v)));
+        TestHelper.assertBadRequestReported(MaybeSubject.create().flattenAsFlowable(v -> Collections.singletonList(v)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(m -> m.flattenAsFlowable(v -> Arrays.asList(v)));
+        TestHelper.checkDoubleOnSubscribeMaybeToFlowable(m -> m.flattenAsFlowable(v -> Collections.singletonList(v)));
     }
 
     @Test
     public void onSuccessRequestRace() {
-        List<Object> list = Arrays.asList(1);
+        List<Object> list = List.of(1);
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             MaybeSubject<Integer> ms = MaybeSubject.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
@@ -219,7 +219,7 @@ public class MaybeZipArrayTest extends RxJavaTest {
     public void oneSourceOnly() {
         Maybe.zipArray(v -> Arrays.asList(v), Maybe.just(1))
         .test()
-        .assertResult(Arrays.asList(1));
+        .assertResult(List.of(1));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -38,13 +38,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void simple() {
         Flowable.range(1, 5)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -52,13 +46,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void simpleEmpty() {
         Flowable.range(1, 5)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.empty();
-            }
-        })
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }
@@ -66,15 +54,11 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void simpleMixed() {
         Flowable.range(1, 10)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v);
-                }
-                return Maybe.empty();
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v);
             }
+            return Maybe.empty();
         })
         .test()
         .assertResult(2, 4, 6, 8, 10);
@@ -83,15 +67,11 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void backpressured() {
         TestSubscriber<Integer> ts = Flowable.range(1, 1024)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v);
-                }
-                return Maybe.empty();
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v);
             }
+            return Maybe.empty();
         })
         .test(0L);
 
@@ -119,27 +99,15 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f
-                        .switchMapMaybe(Functions.justFunction(Maybe.never()));
-            }
-        }
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f
+                .switchMapMaybe(Functions.justFunction(Maybe.never()))
         );
     }
 
     @Test
     public void limit() {
         Flowable.range(1, 5)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v))
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -152,16 +120,12 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
         final MaybeSubject<Integer> ms1 = MaybeSubject.create();
         final MaybeSubject<Integer> ms2 = MaybeSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        if (v == 1) {
-                            return ms1;
-                        }
-                        return ms2;
+        TestSubscriber<Integer> ts = pp.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms1;
                     }
-        }).test();
+                    return ms2;
+                }).test();
 
         ts.assertEmpty();
 
@@ -190,16 +154,12 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
         final MaybeSubject<Integer> ms1 = MaybeSubject.create();
         final MaybeSubject<Integer> ms2 = MaybeSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        if (v == 1) {
-                            return ms1;
-                        }
-                        return ms2;
+        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms1;
                     }
-        }).test();
+                    return ms2;
+                }).test();
 
         ts.assertEmpty();
 
@@ -231,13 +191,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -264,13 +218,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -294,13 +242,9 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void mapperCrash() {
         Flowable.just(1)
-        .switchMapMaybe(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .switchMapMaybe(_ -> {
+                    throw new TestException();
+                })
         .test()
         .assertFailure(TestException.class);
     }
@@ -310,14 +254,10 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        ts.cancel();
-                        return Maybe.just(1);
-                    }
-        }).subscribe(ts);
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> {
+                    ts.cancel();
+                    return Maybe.just(1);
+                }).subscribe(ts);
 
         ts.assertEmpty();
     }
@@ -327,15 +267,11 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2)
-        .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v == 2) {
-                    ts.cancel();
-                }
-                return Maybe.just(1);
+        .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v == 2) {
+                ts.cancel();
             }
+            return Maybe.just(1);
         }).subscribe(ts);
 
         ts.assertValue(1)
@@ -349,13 +285,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -384,13 +314,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Integer v)
-                        throws Exception {
-                    return Maybe.error(new TestException("inner"));
-                }
-            })
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException("inner")))
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "inner");
 
@@ -414,18 +338,12 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
                 @Override
-                public MaybeSource<Integer> apply(Integer v)
-                        throws Exception {
-                    return new Maybe<Integer>() {
-                        @Override
-                        protected void subscribeActual(
-                                MaybeObserver<? super Integer> observer) {
-                            observer.onSubscribe(Disposable.empty());
-                            moRef.set(observer);
-                        }
-                    };
+                protected void subscribeActual(
+                        MaybeObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    moRef.set(observer);
                 }
             })
             .to(TestHelper.<Integer>testConsumer());
@@ -449,27 +367,11 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Integer v)
-                        throws Exception {
-                            return ms;
-                        }
-            }).test();
+            final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -490,32 +392,18 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestSubscriberEx<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v)
-                            throws Exception {
-                        if (v == 1) {
-                            return ms;
-                        }
-                        return Maybe.never();
+                final TestSubscriberEx<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms;
                     }
+                    return Maybe.never();
                 }).to(TestHelper.<Integer>testConsumer());
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onNext(2);
-                    }
-                };
+                Runnable r1 = () -> pp.onNext(2);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ms.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ms.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -544,41 +432,22 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v)
-                            throws Exception {
-                        if (v == 1) {
-                            return ms;
-                        }
-                        return Maybe.never();
+                final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms;
                     }
+                    return Maybe.never();
                 }).test();
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ms.onError(ex2);
-                    }
-                };
+                Runnable r2 = () -> ms.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
-                ts.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                });
+                ts.assertError(e -> e instanceof TestException || e instanceof CompositeException);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -597,32 +466,18 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError(new Function<Integer, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Integer v)
-                        throws Exception {
-                    if (v == 1) {
-                            return ms;
-                    }
-                    return Maybe.empty();
+            final TestSubscriber<Integer> ts = pp.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                if (v == 1) {
+                        return ms;
                 }
+                return Maybe.empty();
             }).test();
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(2);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ms.onSuccess(3);
-                }
-            };
+            Runnable r2 = () -> ms.onSuccess(3);
 
             TestHelper.race(r1, r2);
 
@@ -649,31 +504,13 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.switchMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.switchMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.switchMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.switchMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -151,9 +151,9 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     public void mainErrorInnerCompleteDelayError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final SingleSubject<Integer> ms = SingleSubject.create();
+        final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
 
         ts.assertEmpty();
 
@@ -161,15 +161,15 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
         ts.assertEmpty();
 
-        assertTrue(ms.hasObservers());
+        assertTrue(ss.hasObservers());
 
         pp.onError(new TestException());
 
-        assertTrue(ms.hasObservers());
+        assertTrue(ss.hasObservers());
 
         ts.assertEmpty();
 
-        ms.onSuccess(1);
+        ss.onSuccess(1);
 
         ts.assertFailure(TestException.class, 1);
     }
@@ -178,9 +178,9 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     public void mainErrorInnerSuccessDelayError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final SingleSubject<Integer> ms = SingleSubject.create();
+        final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
 
         ts.assertEmpty();
 
@@ -188,15 +188,15 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
         ts.assertEmpty();
 
-        assertTrue(ms.hasObservers());
+        assertTrue(ss.hasObservers());
 
         pp.onError(new TestException());
 
-        assertTrue(ms.hasObservers());
+        assertTrue(ss.hasObservers());
 
         ts.assertEmpty();
 
-        ms.onSuccess(1);
+        ss.onSuccess(1);
 
         ts.assertFailure(TestException.class, 1);
     }
@@ -245,9 +245,9 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     public void cancel() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final SingleSubject<Integer> ms = SingleSubject.create();
+        final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
 
         ts.assertEmpty();
 
@@ -256,12 +256,12 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         ts.assertEmpty();
 
         assertTrue(pp.hasSubscribers());
-        assertTrue(ms.hasObservers());
+        assertTrue(ss.hasObservers());
 
         ts.cancel();
 
         assertFalse(pp.hasSubscribers());
-        assertFalse(ms.hasObservers());
+        assertFalse(ss.hasObservers());
     }
 
     @Test
@@ -326,9 +326,9 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
             final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            final SingleSubject<Integer> ms = SingleSubject.create();
+            final SingleSubject<Integer> ss = SingleSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
+            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
 
             Runnable r1 = () -> pp.onNext(1);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -38,13 +38,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     @Test
     public void simple() {
         Flowable.range(1, 5)
-        .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -67,27 +61,15 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f
-                        .switchMapSingle(Functions.justFunction(Single.never()));
-            }
-        }
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f
+                .switchMapSingle(Functions.justFunction(Single.never()))
         );
     }
 
     @Test
     public void limit() {
         Flowable.range(1, 5)
-        .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .switchMapSingle(Single::just)
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -100,16 +82,12 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         final SingleSubject<Integer> ms1 = SingleSubject.create();
         final SingleSubject<Integer> ms2 = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        if (v == 1) {
-                            return ms1;
-                        }
-                        return ms2;
+        TestSubscriber<Integer> ts = pp.switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms1;
                     }
-        }).test();
+                    return ms2;
+                }).test();
 
         ts.assertEmpty();
 
@@ -138,16 +116,12 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         final SingleSubject<Integer> ms1 = SingleSubject.create();
         final SingleSubject<Integer> ms2 = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        if (v == 1) {
-                            return ms1;
-                        }
-                        return ms2;
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms1;
                     }
-        }).test();
+                    return ms2;
+                }).test();
 
         ts.assertEmpty();
 
@@ -179,13 +153,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -212,13 +180,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -242,13 +204,9 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     @Test
     public void mapperCrash() {
         Flowable.just(1)
-        .switchMapSingle(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .switchMapSingle(_ -> {
+                    throw new TestException();
+                })
         .test()
         .assertFailure(TestException.class);
     }
@@ -258,14 +216,10 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1)
-        .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        ts.cancel();
-                        return Single.just(1);
-                    }
-        }).subscribe(ts);
+        .switchMapSingle(_ -> {
+                    ts.cancel();
+                    return Single.just(1);
+                }).subscribe(ts);
 
         ts.assertEmpty();
     }
@@ -275,15 +229,11 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.just(1, 2)
-        .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v == 2) {
-                    ts.cancel();
-                }
-                return Single.just(1);
+        .switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
+            if (v == 2) {
+                ts.cancel();
             }
+            return Single.just(1);
         }).subscribe(ts);
 
         ts.assertValue(1)
@@ -297,13 +247,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ms = SingleSubject.create();
 
-        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                        return ms;
-                    }
-        }).test();
+        TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
 
         ts.assertEmpty();
 
@@ -332,13 +276,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Integer v)
-                        throws Exception {
-                    return Single.error(new TestException("inner"));
-                }
-            })
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException("inner")))
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "inner");
 
@@ -362,18 +300,12 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle(new Function<Integer, SingleSource<Integer>>() {
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
                 @Override
-                public SingleSource<Integer> apply(Integer v)
-                        throws Exception {
-                    return new Single<Integer>() {
-                        @Override
-                        protected void subscribeActual(
-                                SingleObserver<? super Integer> observer) {
-                            observer.onSubscribe(Disposable.empty());
-                            moRef.set(observer);
-                        }
-                    };
+                protected void subscribeActual(
+                        SingleObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    moRef.set(observer);
                 }
             })
             .to(TestHelper.<Integer>testConsumer());
@@ -396,27 +328,11 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
             final SingleSubject<Integer> ms = SingleSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Integer v)
-                        throws Exception {
-                            return ms;
-                        }
-            }).test();
+            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ms).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
 
@@ -437,32 +353,18 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
                 final SingleSubject<Integer> ms = SingleSubject.create();
 
-                final TestSubscriberEx<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(Integer v)
-                            throws Exception {
-                        if (v == 1) {
-                            return ms;
-                        }
-                        return Single.never();
+                final TestSubscriberEx<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms;
                     }
+                    return Single.never();
                 }).to(TestHelper.<Integer>testConsumer());
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onNext(2);
-                    }
-                };
+                Runnable r1 = () -> pp.onNext(2);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ms.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ms.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -491,41 +393,22 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
                 final SingleSubject<Integer> ms = SingleSubject.create();
 
-                final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(Integer v)
-                            throws Exception {
-                        if (v == 1) {
-                            return ms;
-                        }
-                        return Single.never();
+                final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                    if (v == 1) {
+                        return ms;
                     }
+                    return Single.never();
                 }).test();
 
                 pp.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ms.onError(ex2);
-                    }
-                };
+                Runnable r2 = () -> ms.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
-                ts.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                });
+                ts.assertError(e -> e instanceof TestException || e instanceof CompositeException);
 
                 if (!errors.isEmpty()) {
                     TestHelper.assertUndeliverable(errors, 0, TestException.class);
@@ -544,32 +427,18 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
             final SingleSubject<Integer> ms = SingleSubject.create();
 
-            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError(new Function<Integer, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Integer v)
-                        throws Exception {
-                    if (v == 1) {
-                            return ms;
-                    }
-                    return Single.never();
+            final TestSubscriber<Integer> ts = pp.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                if (v == 1) {
+                        return ms;
                 }
+                return Single.never();
             }).test();
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(2);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ms.onSuccess(3);
-                }
-            };
+            Runnable r2 = () -> ms.onSuccess(3);
 
             TestHelper.race(r1, r2);
 
@@ -606,31 +475,13 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.switchMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.switchMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new FlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Flowable<Integer> upstream) {
-                return upstream.switchMapSingleDelayError(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
+            upstream.switchMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -318,7 +318,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         scheduler.advanceTimeBy(1001, TimeUnit.MILLISECONDS);
 
-        inOrder.verify(o, times(5)).onNext(Arrays.<Integer> asList());
+        inOrder.verify(o, times(5)).onNext(List.<Integer>of());
 
         to.dispose();
 
@@ -355,7 +355,7 @@ public class ObservableBufferTest extends RxJavaTest {
         source.onNext(6);
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList(6));
+        inOrder.verify(o, times(1)).onNext(List.of(6));
 
         inOrder.verify(o).onComplete();
 
@@ -374,7 +374,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(o, times(1)).onNext(List.of());
 
         inOrder.verify(o).onComplete();
 
@@ -393,7 +393,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         source.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(o, times(1)).onNext(List.of());
 
         inOrder.verify(o).onComplete();
 
@@ -413,7 +413,7 @@ public class ObservableBufferTest extends RxJavaTest {
         source.onComplete();
         boundary.onComplete();
 
-        inOrder.verify(o, times(1)).onNext(Arrays.asList());
+        inOrder.verify(o, times(1)).onNext(List.of());
 
         inOrder.verify(o).onComplete();
 
@@ -533,8 +533,8 @@ public class ObservableBufferTest extends RxJavaTest {
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
-        inOrder.verify(o).onNext(Arrays.asList(0L));
-        inOrder.verify(o).onNext(Arrays.asList(1L));
+        inOrder.verify(o).onNext(List.of(0L));
+        inOrder.verify(o).onNext(List.of(1L));
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
 
@@ -594,7 +594,7 @@ public class ObservableBufferTest extends RxJavaTest {
         inOrder.verify(o).onNext(Arrays.asList(1, 2));
         inOrder.verify(o).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(Arrays.asList(3));
+        verify(o, never()).onNext(List.of(3));
         verify(o, never()).onComplete();
 
     }
@@ -620,7 +620,7 @@ public class ObservableBufferTest extends RxJavaTest {
         inOrder.verify(o).onNext(Arrays.asList(1, 2));
         inOrder.verify(o).onError(any(TestException.class));
         inOrder.verifyNoMoreInteractions();
-        verify(o, never()).onNext(Arrays.asList(3));
+        verify(o, never()).onNext(List.of(3));
         verify(o, never()).onComplete();
 
     }
@@ -639,7 +639,7 @@ public class ObservableBufferTest extends RxJavaTest {
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
 
         inOrder.verify(o).onNext(Arrays.asList(0L, 1L));
-        inOrder.verify(o).onNext(Arrays.asList(2L));
+        inOrder.verify(o).onNext(List.of(2L));
         inOrder.verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
     }
@@ -757,7 +757,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         cdl.await();
 
-        verify(o).onNext(Arrays.asList(1));
+        verify(o).onNext(List.of(1));
         verify(o).onComplete();
         verify(o, never()).onError(any(Throwable.class));
 
@@ -988,7 +988,7 @@ public class ObservableBufferTest extends RxJavaTest {
         Observable.range(1, 5)
         .buffer(1, TimeUnit.DAYS, Schedulers.single(), 2, Functions.<Integer>createArrayList(16), true)
         .test()
-        .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), Arrays.asList(5));
+        .assertResult(Arrays.asList(1, 2), Arrays.asList(3, 4), List.of(5));
     }
 
     @Test
@@ -1005,7 +1005,7 @@ public class ObservableBufferTest extends RxJavaTest {
             }
         })
         .test()
-        .assertFailure(TestException.class, Arrays.asList(1));
+        .assertFailure(TestException.class, List.of(1));
     }
 
     @Test
@@ -1043,7 +1043,7 @@ public class ObservableBufferTest extends RxJavaTest {
             Arrays.asList(2, 3, 4, 5),
             Arrays.asList(3, 4, 5),
             Arrays.asList(4, 5),
-            Arrays.asList(5)
+                List.of(5)
         );
     }
 
@@ -1121,7 +1121,7 @@ public class ObservableBufferTest extends RxJavaTest {
         ps.onNext(2);
 
         to
-        .assertFailure(TestException.class, Arrays.asList(1));
+        .assertFailure(TestException.class, List.of(1));
     }
 
     @Test
@@ -1817,7 +1817,7 @@ public class ObservableBufferTest extends RxJavaTest {
                     () -> ps.onComplete()
             );
 
-            to.assertResult(Arrays.asList(1));
+            to.assertResult(List.of(1));
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -357,6 +357,6 @@ public final class ObservableCollectTest extends RxJavaTest {
                     }
                 }).toObservable();
             }
-        }, false, 1, 2, Arrays.asList(1));
+        }, false, 1, 2, List.of(1));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -378,7 +378,7 @@ public class ObservableConcatMapSchedulerTest {
             .concatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer t) {
-                    return Observable.fromIterable(Arrays.asList(t));
+                    return Observable.fromIterable(Collections.singletonList(t));
                 }
             }, 2, ImmediateThinScheduler.INSTANCE)
             .observeOn(Schedulers.computation()).subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
@@ -755,7 +755,7 @@ public class ObservableConcatTest extends RxJavaTest {
             .concatMap(new Function<Integer, Observable<Integer>>() {
                 @Override
                 public Observable<Integer> apply(Integer t) {
-                    return Observable.fromIterable(Arrays.asList(t));
+                    return Observable.fromIterable(Collections.singletonList(t));
                 }
             })
             .observeOn(Schedulers.computation())

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -178,8 +178,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsNormal() {
         Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -200,8 +200,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsException() {
         Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.concat(
                 Observable.fromIterable(Arrays.asList(10, 20, 30)),
@@ -242,8 +242,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapTransformsOnNextFuncThrows() {
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -259,8 +259,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsOnErrorFuncThrows() {
         Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.error(new TestException());
 
@@ -276,10 +276,10 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsOnCompletedFuncThrows() {
         Observable<Integer> onNext = Observable.fromIterable(Arrays.asList(1, 2, 3));
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
-        Observable<Integer> source = Observable.fromIterable(Arrays.<Integer> asList());
+        Observable<Integer> source = Observable.fromIterable(List.<Integer>of());
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -293,8 +293,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapTransformsMergeException() {
         Observable<Integer> onNext = Observable.error(new TestException());
-        Observable<Integer> onComplete = Observable.fromIterable(Arrays.asList(4));
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onComplete = Observable.fromIterable(List.of(4));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 
@@ -409,10 +409,10 @@ public class ObservableFlatMapTest extends RxJavaTest {
                 .subscribeOn(Schedulers.computation())
                 ;
 
-        Observable<Integer> onComplete = composer(Observable.fromIterable(Arrays.asList(4)), subscriptionCount, m)
+        Observable<Integer> onComplete = composer(Observable.fromIterable(List.of(4)), subscriptionCount, m)
                 .subscribeOn(Schedulers.computation());
 
-        Observable<Integer> onError = Observable.fromIterable(Arrays.asList(5));
+        Observable<Integer> onError = Observable.fromIterable(List.of(5));
 
         Observable<Integer> source = Observable.fromIterable(Arrays.asList(10, 20, 30));
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
@@ -56,7 +56,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList("one", "two", "six").toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList("four", "five").toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList("three").toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of("three").toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -69,7 +69,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList(3, 3, 3).toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList(4, 4).toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList(5).toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of(5).toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         assertEquals(3, map.size());
         assertArrayEquals(Arrays.asList(3, 3, 3).toArray(), map.get(3).toArray());
         assertArrayEquals(Arrays.asList(4, 4).toArray(), map.get(4).toArray());
-        assertArrayEquals(Arrays.asList(5).toArray(), map.get(5).toArray());
+        assertArrayEquals(List.of(5).toArray(), map.get(5).toArray());
     }
 
     @Test
@@ -1443,9 +1443,9 @@ public class ObservableGroupByTest extends RxJavaTest {
                 return i % 2;
             }
         }).subscribe(outer);
-        assertEquals(Arrays.asList(e), outer.errors());
-        assertEquals(Arrays.asList(e), inner1.errors());
-        assertEquals(Arrays.asList(e), inner2.errors());
+        assertEquals(List.of(e), outer.errors());
+        assertEquals(List.of(e), inner1.errors());
+        assertEquals(List.of(e), inner2.errors());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -761,7 +761,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -774,7 +774,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -804,7 +804,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -817,7 +817,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -761,7 +761,7 @@ public class ObservableReplayTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -774,7 +774,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
 
         test.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -804,7 +804,7 @@ public class ObservableReplayTest extends RxJavaTest {
         buf.next(2);
         test.advanceTimeBy(1, TimeUnit.SECONDS);
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(2), values);
+        Assert.assertEquals(List.of(2), values);
 
         buf.next(3);
         buf.next(4);
@@ -817,7 +817,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
         values.clear();
         buf.collect(values);
-        Assert.assertEquals(Arrays.asList(5), values);
+        Assert.assertEquals(List.of(5), values);
         Assert.assertFalse(buf.hasCompleted());
         Assert.assertFalse(buf.hasError());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
@@ -15,7 +15,7 @@ package io.reactivex.rxjava4.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class ObservableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void switchWhenEmpty() throws Exception {
         final Observable<Integer> o = Observable.<Integer>empty()
-                .switchIfEmpty(Observable.fromIterable(Arrays.asList(42)));
+                .switchIfEmpty(Observable.fromIterable(List.of(42)));
 
         assertEquals(42, o.blockingSingle().intValue());
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -1231,7 +1231,7 @@ public class ObservableSwitchTest extends RxJavaTest {
             @Override
             public Observable<Integer> apply(Integer v)
                     throws Throwable {
-                return Observable.fromIterable(Arrays.asList(v * 10));
+                return Observable.fromIterable(List.of(v * 10));
             }
         })
         .test()
@@ -1245,7 +1245,7 @@ public class ObservableSwitchTest extends RxJavaTest {
             @Override
             public Observable<Integer> apply(Integer v)
                     throws Throwable {
-                return Observable.fromIterable(Arrays.asList(v * 10)).hide();
+                return Observable.fromIterable(List.of(v * 10)).hide();
             }
         })
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -53,7 +53,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -86,7 +86,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -120,7 +120,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -144,7 +144,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -171,7 +171,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -195,7 +195,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             }
         };
 
-        Observable<Integer> other = Observable.fromIterable(Arrays.asList(100));
+        Observable<Integer> other = Observable.fromIterable(List.of(100));
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
@@ -162,7 +162,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(List.of("eee")));
 
         mapped.subscribe(objectObserver);
 
@@ -407,7 +407,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Map<Integer, Collection<String>> expected = new HashMap<>();
         expected.put(2, Arrays.asList("cc", "dd"));
-        expected.put(3, new HashSet<>(Arrays.asList("eee")));
+        expected.put(3, new HashSet<>(List.of("eee")));
 
         mapped.subscribe(singleObserver);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -179,7 +179,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         assertEquals(3, lists.get(2).size());
         assertEquals(Arrays.asList(7, 8, 9), lists.get(2));
         assertEquals(1, lists.get(3).size());
-        assertEquals(Arrays.asList(10), lists.get(3));
+        assertEquals(List.of(10), lists.get(3));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
@@ -131,7 +131,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
-        Iterable<String> r2 = Arrays.asList();
+        Iterable<String> r2 = List.of();
 
         r1.zipWith(r2, zipr2).subscribe(o);
 
@@ -367,7 +367,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.just(1).zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
+        TestHelper.checkDisposed(Observable.just(1).zipWith(List.of(1), new BiFunction<Integer, Integer, Object>() {
             @Override
             public Object apply(Integer a, Integer b) throws Exception {
                 return a + b;
@@ -380,7 +380,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Integer>, ObservableSource<Object>>() {
             @Override
             public ObservableSource<Object> apply(Observable<Integer> o) throws Exception {
-                return o.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
+                return o.zipWith(List.of(1), new BiFunction<Integer, Integer, Object>() {
                     @Override
                     public Object apply(Integer a, Integer b) throws Exception {
                         return a + b;
@@ -417,7 +417,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
+            .zipWith(List.of(1), new BiFunction<Integer, Integer, Object>() {
                 @Override
                 public Object apply(Integer a, Integer b) throws Exception {
                     return a + b;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -618,7 +618,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void onSuccessRequestRace() {
-        List<Object> list = Arrays.asList(1);
+        List<Object> list = List.of(1);
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
             SingleSubject<Integer> ss = SingleSubject.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
@@ -231,7 +231,7 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void singleSourceZipperReturnsNull() {
-        Single.zip(Arrays.asList(Single.just(1)), Functions.justFunction(null))
+        Single.zip(Collections.singletonList(Single.just(1)), Functions.justFunction(null))
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The zipper returned a null value");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
@@ -86,11 +86,11 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         assertEquals(0, composite.size());
     }
@@ -108,11 +108,11 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         assertEquals(0, composite.size());
     }
@@ -132,7 +132,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onError(new IOException());
 
@@ -155,7 +155,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onComplete();
 
@@ -177,7 +177,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
         assertTrue(composite.size() > 0);
 
-        assertEquals(Arrays.<Object>asList(1), events);
+        assertEquals(List.<Object>of(1), events);
 
         processor.onError(new IOException());
 
@@ -277,7 +277,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
             processor.onNext(1);
             processor.onComplete();
 
-            assertEquals(Arrays.asList(1), events);
+            assertEquals(List.of(1), events);
 
             TestHelper.assertUndeliverable(errors, 0, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -2215,7 +2215,7 @@ public class MaybeTest extends RxJavaTest {
 
         source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), onComplete);
 
-        assertEquals(Arrays.asList(100), values);
+        assertEquals(List.of(100), values);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableNullTests.java
@@ -83,7 +83,7 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestIterableFunctionReturnsNull() {
-        Observable.combineLatest(Arrays.asList(just1), new Function<Object[], Object>() {
+        Observable.combineLatest(Collections.singletonList(just1), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return null;
@@ -118,7 +118,7 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void combineLatestDelayErrorIterableFunctionReturnsNull() {
-        Observable.combineLatestDelayError(Arrays.asList(just1), new Function<Object[], Object>() {
+        Observable.combineLatestDelayError(Collections.singletonList(just1), new Function<Object[], Object>() {
             @Override
             public Object apply(Object[] v) {
                 return null;
@@ -671,7 +671,7 @@ public class ObservableNullTests extends RxJavaTest {
         just1.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
             @Override
             public Iterable<Integer> apply(Integer v) {
-                return Arrays.asList(1);
+                return List.of(1);
             }
         }, new BiFunction<Integer, Integer, Object>() {
             @Override
@@ -1062,7 +1062,7 @@ public class ObservableNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipWithIterableCombinerReturnsNull() {
-        just1.zipWith(Arrays.asList(1), new BiFunction<Integer, Integer, Object>() {
+        just1.zipWith(List.of(1), new BiFunction<Integer, Integer, Object>() {
             @Override
             public Object apply(Integer a, Integer b) {
                 return null;

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
@@ -142,7 +142,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
             }
         });
 
-        assertEquals(Arrays.asList(1), list);
+        assertEquals(List.of(1), list);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
             }
         });
 
-        assertEquals(Arrays.asList(100), list);
+        assertEquals(List.of(100), list);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFlatMapIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFlatMapIterableTest.java
@@ -14,6 +14,7 @@
 package io.reactivex.rxjava4.parallel;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -47,7 +48,7 @@ public class ParallelFlatMapIterableTest extends RxJavaTest {
         for (int i = 1; i < 32; i++) {
             Flowable.range(1, 1000)
             .parallel(i)
-            .flatMapIterable(_ -> Arrays.asList())
+            .flatMapIterable(_ -> List.of())
             .sequential()
             .test()
             .withTag("Parallelism: " + i)
@@ -60,7 +61,7 @@ public class ParallelFlatMapIterableTest extends RxJavaTest {
         for (int i = 1; i < 32; i++) {
             Flowable.range(1, 1000)
             .parallel(i)
-            .flatMapIterable(v -> v % 2 == 0 ? Arrays.asList(v) : Arrays.asList())
+            .flatMapIterable(v -> v % 2 == 0 ? List.of(v) : List.of())
             .sequential()
             .test()
             .withTag("Parallelism: " + i)

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
@@ -227,8 +227,8 @@ public class ParallelSortedJoinTest extends RxJavaTest {
             })
             .test();
 
-            pp1.onNext(Arrays.asList(1));
-            pp2.onNext(Arrays.asList(2));
+            pp1.onNext(List.of(1));
+            pp2.onNext(List.of(2));
 
             pp1.onComplete();
             pp2.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -290,7 +290,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
      */
     @Test
     public void raceForTerminalState() {
-        final List<Integer> expected = Arrays.asList(1);
+        final List<Integer> expected = List.of(1);
         for (int i = 0; i < 100000; i++) {
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -290,7 +290,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
      */
     @Test
     public void raceForTerminalState() {
-        final List<Integer> expected = Arrays.asList(1);
+        final List<Integer> expected = List.of(1);
         for (int i = 0; i < 100000; i++) {
             TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
             Flowable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -37,7 +37,7 @@ public class SingleTest extends RxJavaTest {
     public void helloWorld() {
         TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("Hello World!").toFlowable().subscribe(ts);
-        ts.assertValueSequence(Arrays.asList("Hello World!"));
+        ts.assertValueSequence(List.of("Hello World!"));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class SingleTest extends RxJavaTest {
                     }
                 })
                 .toFlowable().subscribe(ts);
-        ts.assertValueSequence(Arrays.asList("AB"));
+        ts.assertValueSequence(List.of("AB"));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class SingleTest extends RxJavaTest {
             }
         })
         .toFlowable().subscribe(ts);
-        ts.assertValueSequence(Arrays.asList("AB"));
+        ts.assertValueSequence(List.of("AB"));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class SingleTest extends RxJavaTest {
             }
         })
         .toFlowable().subscribe(ts);
-        ts.assertValueSequence(Arrays.asList("AB"));
+        ts.assertValueSequence(List.of("AB"));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class SingleTest extends RxJavaTest {
             }
         }).toFlowable().subscribe(ts);
 
-        ts.assertValueSequence(Arrays.asList("Hello"));
+        ts.assertValueSequence(List.of("Hello"));
     }
 
     @Test
@@ -178,7 +178,7 @@ public class SingleTest extends RxJavaTest {
                 })
                 .toFlowable().subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
-        ts.assertValueSequence(Arrays.asList("Hello"));
+        ts.assertValueSequence(List.of("Hello"));
     }
 
     @Test
@@ -195,7 +195,7 @@ public class SingleTest extends RxJavaTest {
             ts.cancel();
             Assert.fail("TestSubscriber timed out.");
         }
-        ts.assertValueSequence(Arrays.asList("Hello World!"));
+        ts.assertValueSequence(List.of("Hello World!"));
     }
 
     @Test
@@ -511,7 +511,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void toFlowableIterableRemove() {
-        Iterable<? extends Flowable<Integer>> f = SingleInternalHelper.iterableToFlowable(Arrays.asList(Single.just(1)));
+        Iterable<? extends Flowable<Integer>> f = SingleInternalHelper.iterableToFlowable(Collections.singletonList(Single.just(1)));
 
         Iterator<? extends Flowable<Integer>> iterator = f.iterator();
         iterator.next();

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -294,7 +294,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
      */
     @Test
     public void raceForTerminalState() {
-        final List<Integer> expected = Arrays.asList(1);
+        final List<Integer> expected = List.of(1);
         for (int i = 0; i < 100000; i++) {
             TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -294,7 +294,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
      */
     @Test
     public void raceForTerminalState() {
-        final List<Integer> expected = Arrays.asList(1);
+        final List<Integer> expected = List.of(1);
         for (int i = 0; i < 100000; i++) {
             TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.just(1).subscribeOn(Schedulers.computation()).cache().subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/validators/NonNullMethodTypeArgumentCheck.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/NonNullMethodTypeArgumentCheck.java
@@ -106,7 +106,7 @@ public class NonNullMethodTypeArgumentCheck {
 
     @Test
     public void parseTypeArguments() {
-        assertEquals(new ArrayList<>(Arrays.asList("T")), parseTypeArguments("<T>"));
+        assertEquals(new ArrayList<>(List.of("T")), parseTypeArguments("<T>"));
         assertEquals(new ArrayList<>(Arrays.asList("T", "U")), parseTypeArguments("<T, U>"));
         assertEquals(new ArrayList<>(Arrays.asList("T", "Flowable<U>")), parseTypeArguments("<T, Flowable<U>>"));
         assertEquals(new ArrayList<>(Arrays.asList("T", "Flowable<U, V>")), parseTypeArguments("<T, Flowable<U, V>>"));


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080