### PR TITLE
Fix IllegalStateException in SchedulerToExecutorService.invokeAny

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
@@ -189,7 +189,7 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
 
         while (!isTerminated()) {
             for (var f : result) {
-                if (f.isDone() && !f.isCancelled() && f.exceptionNow() == null) {
+                if (f.state() == Future.State.SUCCESS) {
 
                     var v = f.resultNow();
 
@@ -224,7 +224,7 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
             totalTime--;
 
             for (var f : result) {
-                if (f.isDone() && !f.isCancelled() && f.exceptionNow() == null) {
+                if (f.state() == Future.State.SUCCESS) {
 
                     var v = f.resultNow();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.schedulers;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava4.core.Scheduler;
+import io.reactivex.rxjava4.disposables.Disposable;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+public class SchedulerToExecutorServiceTest {
+
+    @Test
+    public void invokeAnyShouldReturnResultOfCompletedTask() throws Exception {
+        Scheduler scheduler = Schedulers.trampoline();
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<String> task1 = () -> "result1";
+        Callable<String> task2 = () -> "result2";
+
+        String result = executor.invokeAny(Arrays.asList(task1, task2));
+
+        assertNotNull("invokeAny should return a result", result);
+        assertTrue("result should be one of the task results",
+                result.equals("result1") || result.equals("result2"));
+    }
+
+    @Test
+    public void invokeAnyWithSingleTask() throws Exception {
+        Scheduler scheduler = Schedulers.trampoline();
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<Integer> task = () -> 42;
+
+        Integer result = executor.invokeAny(Arrays.asList(task));
+
+        assertEquals("invokeAny should return the single task result", Integer.valueOf(42), result);
+    }
+
+    @Test
+    public void invokeAnyWithEmptyTasksShouldThrow() throws Exception {
+        Scheduler scheduler = Schedulers.trampoline();
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        try {
+            executor.invokeAny(Arrays.asList());
+            fail("invokeAny with empty tasks should throw IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`SchedulerToExecutorService.invokeAny()` checks each future with:

```java
if (f.isDone() && !f.isCancelled() && f.exceptionNow() == null) {
```

But `Future.exceptionNow()` is specified to throw `IllegalStateException` when the task **completed normally** (there is no exception to return). So as soon as a task finishes successfully, this guard calls `exceptionNow()` on a successfully-completed future and throws `IllegalStateException` instead of returning the result. Both `invokeAny` overloads contain the same probe.

## Fix

Use the intended state query, which never throws:

```java
if (f.state() == Future.State.SUCCESS) {
```

## Test

Adds `SchedulerToExecutorServiceTest` covering the success paths. The new `invokeAnyShouldReturnResultOfCompletedTask` and `invokeAnyWithSingleTask` tests fail on `master` with `IllegalStateException` and pass with this fix.

Note: the timed `invokeAny(tasks, timeout, unit)` overload has a separate pre-existing issue in its time accounting (the `FIXME`-marked spin loop) that this PR intentionally does not touch; it only addresses the `exceptionNow()` misuse.