### PR TITLE
4x unit test lambdas18

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
@@ -232,10 +232,12 @@ implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver
     }
 
     record TestObserverDisposable(TestObserver<?> to) implements Disposable {
+
         @Override
         public void dispose() {
             to.dispose();
         }
+
         @Override
         public boolean isDisposed() {
             return to.isDisposed();

--- a/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
@@ -29,14 +29,16 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
  * <p>You can override the {@link #onSubscribe(Disposable)}, {@link #onNext(Object)}, {@link #onError(Throwable)},
  * {@link #onComplete()} and {@link #onSuccess(Object)} methods but not the others (this is by design).
  *
- * <p>The {@code TestObserver} implements {@link Disposable} for convenience where dispose calls cancel.
+ * <p>Since 4.0.0, the {@code TestObserver} does implements {@link Disposable}
+ * anymore. Use {@link #asDisposable()} to create a wrapper that calls the {@link #dispose()}.
+ * @implNote Avoids all the resource warnings because {@code Disposable} implements {@link AutoCloseable} now.
  *
  * @param <T> the value type
  * @see io.reactivex.rxjava4.subscribers.TestSubscriber
  */
 public class TestObserver<T>
 extends BaseTestConsumer<T, TestObserver<T>>
-implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
+implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
     /** The actual observer to forward events to. */
     private final Observer<? super T> downstream;
 
@@ -170,6 +172,14 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
         return DisposableHelper.isDisposed(upstream.get());
     }
 
+    /**
+     * Expose this {@code TestObserver} as a {@link Disposable} object.
+     * @return the {@code Disposable} view of this {@code TestObserver}
+     */
+    public final Disposable asDisposable() {
+        return new TestObserverDisposable(this);
+    }
+
     // state retrieval methods
     /**
      * Returns true if this {@code TestObserver} received a subscription.
@@ -218,6 +228,17 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
 
         @Override
         public void onComplete() {
+        }
+    }
+
+    record TestObserverDisposable(TestObserver<?> to) implements Disposable {
+        @Override
+        public void dispose() {
+            to.dispose();
+        }
+        @Override
+        public boolean isDisposed() {
+            return to.isDisposed();
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
@@ -316,10 +316,12 @@ implements FlowableSubscriber<T>, Subscription {
     }
 
     record TestSubscriberDisposable(TestSubscriber<?> to) implements Disposable {
+
         @Override
         public void dispose() {
             to.dispose();
         }
+
         @Override
         public boolean isDisposed() {
             return to.isDisposed();

--- a/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
@@ -19,6 +19,7 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.FlowableSubscriber;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava4.observers.BaseTestConsumer;
 
@@ -284,6 +285,14 @@ implements FlowableSubscriber<T>, Subscription {
     }
 
     /**
+     * Expose this {@code TestSubscriber} as a {@link Disposable} object.
+     * @return the {@code Disposable} view of this {@code TestSubscriber}
+     */
+    public final Disposable asDisposable() {
+        return new TestSubscriberDisposable(this);
+    }
+
+    /**
      * A subscriber that ignores all events and does not report errors.
      */
     enum EmptySubscriber implements FlowableSubscriber<Object> {
@@ -303,6 +312,17 @@ implements FlowableSubscriber<T>, Subscription {
 
         @Override
         public void onComplete() {
+        }
+    }
+
+    record TestSubscriberDisposable(TestSubscriber<?> to) implements Disposable {
+        @Override
+        public void dispose() {
+            to.dispose();
+        }
+        @Override
+        public boolean isDisposed() {
+            return to.isDisposed();
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
@@ -321,7 +321,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void disposedAfterOnNext() {
-        @SuppressWarnings("resource")
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
@@ -392,7 +391,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusion() {
-        @SuppressWarnings("resource")
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
@@ -444,7 +442,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusionClear() {
-        @SuppressWarnings("resource")
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")
@@ -494,7 +491,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     @Test
     public void customFusionDontConsume() {
-        @SuppressWarnings("resource")
         final TestObserver<Integer> to = new TestObserver<>();
 
         @SuppressWarnings("resource")

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCacheTest.java
@@ -217,7 +217,6 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void doubleDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        @SuppressWarnings("resource")
         final TestObserver<Void> to = new TestObserver<>();
 
         ps.ignoreElements().cache()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -1405,7 +1405,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void fusedInputThrows() {
         Flowable.zip(Flowable.just(1).map(_ -> {
             throw new TestException();
-        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) Integer::sum)
+        }), Flowable.just(2), Integer::sum)
         .test()
         .assertFailure(TestException.class);
     }
@@ -1414,7 +1414,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void fusedInputThrowsDelayError() {
         Flowable.zip(Flowable.just(1).map(_ -> {
             throw new TestException();
-        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) Integer::sum, true)
+        }), Flowable.just(2), Integer::sum, true)
         .test()
         .assertFailure(TestException.class);
     }
@@ -1423,7 +1423,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void fusedInputThrowsBackpressured() {
         Flowable.zip(Flowable.just(1).map(_ -> {
             throw new TestException();
-        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) Integer::sum)
+        }), Flowable.just(2), Integer::sum)
         .test(0L)
         .assertFailure(TestException.class);
     }
@@ -1432,7 +1432,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void fusedInputThrowsDelayErrorBackpressured() {
         Flowable.zip(Flowable.just(1).map(_ -> {
             throw new TestException();
-        }), Flowable.just(2), (BiFunction<Integer, Integer, Integer>) Integer::sum, true)
+        }), Flowable.just(2), Integer::sum, true)
         .test(0L)
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
@@ -87,19 +87,9 @@ public class MaybeAmbTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp0.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp0.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp1.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -145,12 +135,9 @@ public class MaybeAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Maybe.never()
             )
-            .subscribe(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe((Consumer<Object>) _ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -171,12 +158,9 @@ public class MaybeAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Maybe.never()
             )
-            .subscribe(Functions.emptyConsumer(), new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), _ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -196,12 +180,9 @@ public class MaybeAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Maybe.never()
             )
-            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
-                @Override
-                public void run() throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), () -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -222,19 +203,9 @@ public class MaybeAmbTest extends RxJavaTest {
                 final Maybe<Integer> source = Maybe.ambArray(ps.singleElement(),
                         Maybe.<Integer>never(), Maybe.<Integer>never(), null);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        source.test();
-                    }
-                };
+                Runnable r1 = source::test;
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onComplete();
-                    }
-                };
+                Runnable r2 = ps::onComplete;
 
                 TestHelper.race(r1, r2);
 
@@ -249,12 +220,7 @@ public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void maybeSourcesInIterable() {
-        MaybeSource<Integer> source = new MaybeSource<Integer>() {
-            @Override
-            public void subscribe(MaybeObserver<? super Integer> observer) {
-                Maybe.just(1).subscribe(observer);
-            }
-        };
+        MaybeSource<Integer> source = observer -> Maybe.just(1).subscribe(observer);
 
         Maybe.amb(Arrays.asList(source, source))
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
@@ -160,12 +160,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
         Maybe<Integer> source = pp.singleElement().cache();
 
-        source.subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                ts.cancel();
-            }
-        });
+        source.subscribe(_ -> ts.cancel());
 
         source.toFlowable().subscribe(ts);
 
@@ -184,12 +179,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
         Maybe<Integer> source = pp.singleElement().cache();
 
-        source.subscribe(Functions.emptyConsumer(), new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                ts.cancel();
-            }
-        });
+        source.subscribe(Functions.emptyConsumer(), (Consumer<Object>) _ -> ts.cancel());
 
         source.toFlowable().subscribe(ts);
 
@@ -207,12 +197,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
         Maybe<Integer> source = pp.singleElement().cache();
 
-        source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
-            @Override
-            public void run() throws Exception {
-                ts.cancel();
-            }
-        });
+        source.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), ts::cancel);
 
         source.toFlowable().subscribe(ts);
 
@@ -228,12 +213,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
             final Maybe<Integer> source = pp.singleElement().cache();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    source.test();
-                }
-            };
+            Runnable r = source::test;
 
             TestHelper.race(r, r);
         }
@@ -249,19 +229,9 @@ public class MaybeCacheTest extends RxJavaTest {
             final TestObserver<Integer> to1 = source.test();
             final TestObserver<Integer> to2 = source.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to1.dispose();
-                }
-            };
+            Runnable r1 = to1::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to2.dispose();
-                }
-            };
+            Runnable r2 = to2::dispose;
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -53,11 +53,8 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
         try {
             @SuppressWarnings("resource")
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
-                    new Consumer<Object>() {
-                        @Override
-                        public void accept(Object v) throws Exception {
-                            throw new TestException();
-                        }
+                    _ -> {
+                        throw new TestException();
                     },
                     Functions.emptyConsumer(),
                     Functions.EMPTY_ACTION);
@@ -79,11 +76,8 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
             @SuppressWarnings("resource")
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
-                    new Consumer<Object>() {
-                        @Override
-                        public void accept(Object v) throws Exception {
-                            throw new TestException("Inner");
-                        }
+                    (Consumer<Object>) _ -> {
+                        throw new TestException("Inner");
                     },
                     Functions.EMPTY_ACTION);
 
@@ -110,11 +104,8 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
                     Functions.emptyConsumer(),
-                    new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            throw new TestException();
-                        }
+                    () -> {
+                        throw new TestException();
                     });
 
             mo.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -84,19 +84,9 @@ public class MaybeConcatArrayTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = Maybe.concatArray(Maybe.just(1), Maybe.just(2))
                     .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
         }
@@ -108,19 +98,9 @@ public class MaybeConcatArrayTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
                     .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
         }
@@ -156,12 +136,9 @@ public class MaybeConcatArrayTest extends RxJavaTest {
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
 
-        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Maybe<Integer> source = Maybe.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Maybe.concatArray(source, source).firstElement()
@@ -175,12 +152,9 @@ public class MaybeConcatArrayTest extends RxJavaTest {
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
 
-        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Maybe<Integer> source = Maybe.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Maybe.concatArrayDelayError(source, source).firstElement()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -40,11 +40,8 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Maybe.concat(new Iterable<MaybeSource<Object>>() {
-            @Override
-            public Iterator<MaybeSource<Object>> iterator() {
-                throw new TestException("iterator()");
-            }
+        Maybe.concat((Iterable<MaybeSource<Object>>) () -> {
+            throw new TestException("iterator()");
         })
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
@@ -68,19 +65,9 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r2 = pp::onComplete;
 
             TestHelper.race(r1, r2);
         }
@@ -88,36 +75,21 @@ public class MaybeConcatIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrows() {
-        Maybe.concat(new CrashingMappedIterable<>(100, 1, 100, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1);
-            }
-        }))
+        Maybe.concat(new CrashingMappedIterable<>(100, 1, 100, _ -> Maybe.just(1)))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
 
     @Test
     public void nextThrows() {
-        Maybe.concat(new CrashingMappedIterable<>(100, 100, 1, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1);
-            }
-        }))
+        Maybe.concat(new CrashingMappedIterable<>(100, 100, 1, _ -> Maybe.just(1)))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
 
     @Test
     public void nextReturnsNull() {
-        Maybe.concat(new CrashingMappedIterable<>(100, 100, 100, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        }))
+        Maybe.concat(new CrashingMappedIterable<>(100, 100, 100, (Function<Integer, Maybe<Integer>>) _ -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -126,12 +98,9 @@ public class MaybeConcatIterableTest extends RxJavaTest {
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
 
-        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Maybe<Integer> source = Maybe.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Maybe.concat(Arrays.asList(source, source)).firstElement()
@@ -145,12 +114,9 @@ public class MaybeConcatIterableTest extends RxJavaTest {
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
 
-        Maybe<Integer> source = Maybe.create(new MaybeOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(MaybeEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Maybe<Integer> source = Maybe.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Maybe.concatDelayError(Arrays.asList(source, source)).firstElement()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapCompletableTest.java
@@ -24,22 +24,14 @@ public class MaybeConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete()));
     }
 
     @Test
     public void mapperThrows() {
         Maybe.just(1)
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMapCompletable((Function<Integer, Completable>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -48,12 +40,7 @@ public class MaybeConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Maybe.just(1)
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .concatMapCompletable((Function<Integer, Completable>) _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapSingleTest.java
@@ -23,14 +23,12 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class MaybeConcatMapSingleTest extends RxJavaTest {
     @Test
     public void flatMapSingleElementValue() {
-        Maybe.just(1).concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just(2);
-                }
-
-                return Single.just(1);
+        Maybe.just(1).concatMapSingle((Function<Integer, SingleSource<Integer>>) integer -> {
+            if (integer == 1) {
+                return Single.just(2);
             }
+
+            return Single.just(1);
         })
             .test()
             .assertResult(2);
@@ -38,14 +36,12 @@ public class MaybeConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleElementValueDifferentType() {
-        Maybe.just(1).concatMapSingle(new Function<Integer, SingleSource<String>>() {
-            @Override public SingleSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just("2");
-                }
-
-                return Single.just("1");
+        Maybe.just(1).concatMapSingle((Function<Integer, SingleSource<String>>) integer -> {
+            if (integer == 1) {
+                return Single.just("2");
             }
+
+            return Single.just("1");
         })
             .test()
             .assertResult("2");
@@ -53,11 +49,7 @@ public class MaybeConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleElementValueNull() {
-        Maybe.just(1).concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Maybe.just(1).concatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> null)
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
@@ -66,10 +58,8 @@ public class MaybeConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleElementValueErrorThrown() {
-        Maybe.just(1).concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Maybe.just(1).concatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
@@ -81,22 +71,14 @@ public class MaybeConcatMapSingleTest extends RxJavaTest {
     public void flatMapSingleElementError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Maybe.error(exception).concatMapSingle(new Function<Object, SingleSource<Object>>() {
-            @Override public SingleSource<Object> apply(final Object integer) throws Exception {
-                return Single.just(new Object());
-            }
-        })
+        Maybe.error(exception).concatMapSingle((Function<Object, SingleSource<Object>>) _ -> Single.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void flatMapSingleElementEmpty() {
-        Maybe.<Integer>empty().concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        })
+        Maybe.<Integer>empty().concatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2))
             .test()
             .assertNoValues()
             .assertResult();
@@ -104,38 +86,20 @@ public class MaybeConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).concatMapSingle((Function<Integer, SingleSource<Integer>>) _ ->
+                Single.just(2)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m.concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.just(2);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, Maybe<Integer>>) m ->
+                m.concatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2)));
     }
 
     @Test
     public void singleErrors() {
         Maybe.just(1)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.error(new TestException());
-                    }
-                })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatMapTest.java
@@ -24,38 +24,20 @@ public class MaybeConcatMapTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).concatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).concatMap((Function<Integer, MaybeSource<Integer>>) _ ->
+                Maybe.just(2)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> v) throws Exception {
-                return v.concatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) v ->
+                v.concatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2)));
     }
 
     @Test
     public void mainError() {
         Maybe.<Integer>error(new TestException())
-        .concatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                })
+        .concatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -63,12 +45,7 @@ public class MaybeConcatMapTest extends RxJavaTest {
     @Test
     public void mainEmpty() {
         Maybe.<Integer>empty()
-        .concatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                })
+        .concatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2))
         .test()
         .assertResult();
     }
@@ -76,12 +53,9 @@ public class MaybeConcatMapTest extends RxJavaTest {
     @Test
     public void mapperThrows() {
         Maybe.just(1)
-        .concatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        throw new TestException();
-                    }
-                })
+        .concatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new TestException();
+        })
         .test()
         .assertFailure(TestException.class);
     }
@@ -89,12 +63,7 @@ public class MaybeConcatMapTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Maybe.just(1)
-        .concatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return null;
-                    }
-                })
+        .concatMap((Function<Integer, MaybeSource<Integer>>) _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
@@ -30,11 +30,8 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void callbackThrows() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                throw new TestException();
-            }
+        Maybe.create(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -42,56 +39,38 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onSuccessNull() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                e.onSuccess(null);
-            }
-        })
+        Maybe.create(e -> e.onSuccess(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void onErrorNull() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                e.onError(null);
-            }
-        })
+        Maybe.create(e -> e.onError(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                e.onSuccess(1);
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.create(e -> e.onSuccess(1)));
     }
 
     @Test
     public void onSuccessThrows() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                Disposable d = Disposable.empty();
-                e.setDisposable(d);
+        Maybe.create(e -> {
+            Disposable d = Disposable.empty();
+            e.setDisposable(d);
 
-                try {
-                    e.onSuccess(1);
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(d.isDisposed());
-                assertTrue(e.isDisposed());
+            try {
+                e.onSuccess(1);
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(d.isDisposed());
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -118,22 +97,19 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onErrorThrows() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                Disposable d = Disposable.empty();
-                e.setDisposable(d);
+        Maybe.create(e -> {
+            Disposable d = Disposable.empty();
+            e.setDisposable(d);
 
-                try {
-                    e.onError(new IOException());
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(d.isDisposed());
-                assertTrue(e.isDisposed());
+            try {
+                e.onError(new IOException());
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(d.isDisposed());
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -160,22 +136,19 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onCompleteThrows() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                Disposable d = Disposable.empty();
-                e.setDisposable(d);
+        Maybe.create(e -> {
+            Disposable d = Disposable.empty();
+            e.setDisposable(d);
 
-                try {
-                    e.onComplete();
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(d.isDisposed());
-                assertTrue(e.isDisposed());
+            try {
+                e.onComplete();
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(d.isDisposed());
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -202,18 +175,15 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onSuccessThrows2() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                try {
-                    e.onSuccess(1);
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(e.isDisposed());
+        Maybe.create(e -> {
+            try {
+                e.onSuccess(1);
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -240,18 +210,15 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onErrorThrows2() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                try {
-                    e.onError(new IOException());
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(e.isDisposed());
+        Maybe.create(e -> {
+            try {
+                e.onError(new IOException());
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -278,18 +245,15 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void onCompleteThrows2() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                try {
-                    e.onComplete();
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(e.isDisposed());
+        Maybe.create(e -> {
+            try {
+                e.onComplete();
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(e.isDisposed());
         }).subscribe(new MaybeObserver<Object>() {
 
             @Override
@@ -319,12 +283,9 @@ public class MaybeCreateTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final Boolean[] response = { null };
-            Maybe.create(new MaybeOnSubscribe<Object>() {
-                @Override
-                public void subscribe(MaybeEmitter<Object> e) throws Exception {
-                    e.onSuccess(1);
-                    response[0] = e.tryOnError(new TestException());
-                }
+            Maybe.create(e -> {
+                e.onSuccess(1);
+                response[0] = e.tryOnError(new TestException());
             })
             .test()
             .assertResult(1);
@@ -339,11 +300,6 @@ public class MaybeCreateTest extends RxJavaTest {
 
     @Test
     public void emitterHasToString() {
-        Maybe.create(new MaybeOnSubscribe<Object>() {
-            @Override
-            public void subscribe(MaybeEmitter<Object> emitter) throws Exception {
-                assertTrue(emitter.toString().contains(MaybeCreate.Emitter.class.getSimpleName()));
-            }
-        }).test().assertEmpty();
+        Maybe.create(emitter -> assertTrue(emitter.toString().contains(MaybeCreate.Emitter.class.getSimpleName()))).test().assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDematerializeTest.java
@@ -72,13 +72,7 @@ public class MaybeDematerializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.dematerialize((Function)Functions.identity());
-            }
-        });
+        TestHelper.<Integer, Integer>checkDoubleOnSubscribeMaybe(v -> v.dematerialize(Notification::createOnNext));
     }
 
     @Test
@@ -89,11 +83,8 @@ public class MaybeDematerializeTest extends RxJavaTest {
     @Test
     public void selectorCrash() {
         Maybe.just(Notification.createOnNext(1))
-        .dematerialize(new Function<Notification<Integer>, Notification<Integer>>() {
-            @Override
-            public Notification<Integer> apply(Notification<Integer> v) throws Exception {
-                throw new TestException();
-            }
+        .dematerialize((Function<Notification<Integer>, Notification<Integer>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -110,12 +101,7 @@ public class MaybeDematerializeTest extends RxJavaTest {
     @Test
     public void selectorDifferentType() {
         Maybe.just(Notification.createOnNext(1))
-        .dematerialize(new Function<Notification<Integer>, Notification<String>>() {
-            @Override
-            public Notification<String> apply(Notification<Integer> v) throws Exception {
-                return Notification.createOnNext("Value-" + 1);
-            }
-        })
+        .dematerialize(_ -> Notification.createOnNext("Value-" + 1))
         .test()
         .assertResult("Value-1");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -32,12 +32,7 @@ public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<>();
 
-    final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
-        @Override
-        public void accept(Integer e) throws Exception {
-            values.add(-e);
-        }
-    };
+    final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
     final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
@@ -115,11 +110,8 @@ public class MaybeDoAfterSuccessTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Maybe.just(1)
-            .doAfterSuccess(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer e) throws Exception {
-                    throw new TestException();
-                }
+            .doAfterSuccess(_ -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1);
@@ -137,11 +129,6 @@ public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m.doAfterSuccess(afterSuccess);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) m -> m.doAfterSuccess(afterSuccess));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoFinallyTest.java
@@ -68,18 +68,10 @@ public class MaybeDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
-                return f.doFinally(MaybeDoFinallyTest.this);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Maybe<Object> f) throws Exception {
-                return f.doFinally(MaybeDoFinallyTest.this).filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Object>>) f ->
+                f.doFinally(MaybeDoFinallyTest.this));
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Object>>) f ->
+                f.doFinally(MaybeDoFinallyTest.this).filter(Functions.alwaysTrue()));
     }
 
     @Test
@@ -120,11 +112,8 @@ public class MaybeDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Maybe.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1)
@@ -141,11 +130,8 @@ public class MaybeDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Maybe.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnEventTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnEventTest.java
@@ -31,27 +31,16 @@ public class MaybeDoOnEventTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishSubject.<Integer>create().singleElement().doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                // irrelevant
-            }
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().singleElement().doOnEvent((_, _) -> {
+            // irrelevant
         }));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m.doOnEvent(new BiConsumer<Integer, Throwable>() {
-                    @Override
-                    public void accept(Integer v, Throwable e) throws Exception {
-                        // irrelevant
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) m -> m.doOnEvent((_, _) -> {
+            // irrelevant
+        }));
     }
 
     @Test
@@ -69,11 +58,8 @@ public class MaybeDoOnEventTest extends RxJavaTest {
                     observer.onSuccess(1);
                 }
             }
-            .doOnSubscribe(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                    throw new TestException("First");
-                }
+            .doOnSubscribe(_ -> {
+                throw new TestException("First");
             })
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnTerminateTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.testsupport.*;
 
 public class MaybeDoOnTerminateTest extends RxJavaTest {
@@ -30,12 +29,7 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateSuccess() {
         final AtomicBoolean atomicBoolean = new AtomicBoolean();
-        Maybe.just(1).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                atomicBoolean.set(true);
-            }
-        })
+        Maybe.just(1).doOnTerminate(() -> atomicBoolean.set(true))
         .test()
         .assertResult(1);
 
@@ -45,12 +39,7 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateError() {
         final AtomicBoolean atomicBoolean = new AtomicBoolean();
-        Maybe.error(new TestException()).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                atomicBoolean.set(true);
-            }
-        })
+        Maybe.error(new TestException()).doOnTerminate(() -> atomicBoolean.set(true))
         .test()
         .assertFailure(TestException.class);
 
@@ -60,12 +49,7 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateComplete() {
         final AtomicBoolean atomicBoolean = new AtomicBoolean();
-        Maybe.empty().doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                atomicBoolean.set(true);
-            }
-        })
+        Maybe.empty().doOnTerminate(() -> atomicBoolean.set(true))
         .test()
         .assertResult();
 
@@ -74,11 +58,8 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
 
     @Test
     public void doOnTerminateSuccessCrash() {
-        Maybe.just(1).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                throw new TestException();
-            }
+        Maybe.just(1).doOnTerminate(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -87,11 +68,8 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateErrorCrash() {
         TestObserverEx<Object> to = Maybe.error(new TestException("Outer"))
-        .doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                throw new TestException("Inner");
-            }
+        .doOnTerminate(() -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
@@ -104,11 +82,8 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateCompleteCrash() {
         Maybe.empty()
-        .doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                throw new TestException();
-            }
+        .doOnTerminate(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapBiSelectorTest.java
@@ -27,23 +27,13 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
 
     BiFunction<Integer, Integer, String> stringCombine() {
-        return new BiFunction<Integer, Integer, String>() {
-            @Override
-            public String apply(Integer a, Integer b) throws Exception {
-                return a + ":" + b;
-            }
-        };
+        return (a, b) -> a + ":" + b;
     }
 
     @Test
     public void normal() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(2);
-            }
-        }, stringCombine())
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2), stringCombine())
         .test()
         .assertResult("1:2");
     }
@@ -51,12 +41,7 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void normalWithEmpty() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        }, stringCombine())
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty(), stringCombine())
         .test()
         .assertResult();
     }
@@ -66,12 +51,9 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.<Integer>empty()
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                call[0]++;
-                return Maybe.just(1);
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            call[0]++;
+            return Maybe.just(1);
         }, stringCombine())
         .test()
         .assertResult();
@@ -84,12 +66,9 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.<Integer>error(new TestException())
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                call[0]++;
-                return Maybe.just(1);
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            call[0]++;
+            return Maybe.just(1);
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -102,12 +81,9 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                call[0]++;
-                return Maybe.<Integer>error(new TestException());
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            call[0]++;
+            return Maybe.<Integer>error(new TestException());
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -118,47 +94,22 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(PublishProcessor.create().singleElement()
-                .flatMap(new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.just(1);
-            }
-        }, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) throws Exception {
-                return b;
-            }
-        }));
+                .flatMap((Function<Object, MaybeSource<Integer>>) _ -> Maybe.just(1),
+                        (BiFunction<Object, Integer, Object>) (_, b) -> b));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.flatMap(new Function<Object, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Object v) throws Exception {
-                        return Maybe.just(1);
-                    }
-                }, new BiFunction<Object, Integer, Object>() {
-                    @Override
-                    public Object apply(Object a, Integer b) throws Exception {
-                        return b;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(v ->
+                v.flatMap((Function<Object, MaybeSource<Integer>>) _ ->
+                        Maybe.just(1), (BiFunction<Object, Integer, Object>) (_, b) -> b));
     }
 
     @Test
     public void mapperThrows() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new TestException();
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -167,12 +118,7 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, stringCombine())
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> null, stringCombine())
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -180,16 +126,8 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void resultSelectorThrows() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2), (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -198,17 +136,7 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void resultSelectorReturnsNull() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return null;
-            }
-        })
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(2), (_, _) -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -218,17 +146,11 @@ public class MaybeFlatMapBiSelectorTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                to.dispose();
-                return Maybe.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                throw new IllegalStateException();
-            }
+        .flatMap((Function<Integer, MaybeSource<Integer>>) _ -> {
+            to.dispose();
+            return Maybe.just(2);
+        }, (BiFunction<Integer, Integer, Integer>) (_, _) -> {
+            throw new IllegalStateException();
         })
         .subscribeWith(to)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapCompletableTest.java
@@ -24,22 +24,14 @@ public class MaybeFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete()));
     }
 
     @Test
     public void mapperThrows() {
         Maybe.just(1)
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable((Function<Integer, Completable>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -48,12 +40,7 @@ public class MaybeFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Maybe.just(1)
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapCompletable((Function<Integer, Completable>) _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.util.CrashingIterable;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.operators.QueueSubscription;
@@ -37,12 +36,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult(1, 2);
     }
@@ -50,12 +44,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void emptyIterable() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(_ -> Collections.<Integer>emptyList())
         .test()
         .assertResult();
     }
@@ -63,12 +52,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void error() {
 
-        Maybe.<Integer>error(new TestException()).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.<Integer>error(new TestException()).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertFailure(TestException.class);
     }
@@ -76,12 +60,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void empty() {
 
-        Maybe.<Integer>empty().flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.<Integer>empty().flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult();
     }
@@ -89,12 +68,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void backpressure() {
 
-        TestSubscriber<Integer> ts = Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        TestSubscriber<Integer> ts = Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .test(0);
 
         ts.assertEmpty();
@@ -110,12 +84,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void take() {
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .take(1)
         .test()
         .assertResult(1);
@@ -123,12 +92,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void take2() {
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .doOnSubscribe(s -> s.request(Long.MAX_VALUE))
         .take(1)
         .test()
@@ -139,12 +103,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     public void fused() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -157,12 +116,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     public void fusedNoSync() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.SYNC);
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(v -> Arrays.asList(v, v + 1))
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -174,12 +128,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void iteratorCrash() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(1, 100, 100);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(_ -> new CrashingIterable(1, 100, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
@@ -187,12 +136,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextCrash() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 1, 100);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(_ -> new CrashingIterable(100, 1, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
@@ -200,12 +144,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextCrash() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 100, 1);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(_ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -213,12 +152,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextCrash2() {
 
-        Maybe.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 2, 100);
-            }
-        })
+        Maybe.just(1).flattenAsFlowable(_ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -226,14 +160,11 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async1() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .hide()
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -247,14 +178,11 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async2() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -267,14 +195,11 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async3() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .take(500 * 1000)
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -288,14 +213,11 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async4() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .take(500 * 1000)
         .to(TestHelper.<Integer>testConsumer())
@@ -309,12 +231,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(1, 2, 3);
-                    }
-        }).subscribe(new FlowableSubscriber<Integer>() {
+        .flattenAsFlowable(_ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() {
             QueueSubscription<Integer> qs;
             @SuppressWarnings("unchecked")
             @Override
@@ -348,12 +265,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextThrowsUnbounded() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 2, 100);
-                    }
-                })
+        .flattenAsFlowable(_ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -361,12 +273,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextThrowsUnbounded() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 100, 1);
-                    }
-                })
+        .flattenAsFlowable(_ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -374,12 +281,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextThrows() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 2, 100);
-                    }
-                })
+        .flattenAsFlowable(_ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testSubscriber(2L))
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -387,12 +289,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextThrows() {
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 100, 1);
-                    }
-                })
+        .flattenAsFlowable(_ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testSubscriber(2L))
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -403,12 +300,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(1, 2, 3);
-                }
-            })
+                            _ -> Arrays.asList(1, 2, 3))
             .test(5L)
             .assertEmpty();
         }
@@ -425,30 +317,19 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
             ps.onNext(1);
 
             final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(a);
-                }
-            })
+                _ -> Arrays.asList(a))
             .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                    for (int i = 0; i < 500; i++) {
-                        ts.request(1);
-                    }
+            Runnable r1 = () -> {
+                ps.onComplete();
+                for (int i1 = 0; i1 < 500; i1++) {
+                    ts.request(1);
                 }
             };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int i = 0; i < 500; i++) {
-                        ts.request(1);
-                    }
+            Runnable r2 = () -> {
+                for (int i2 = 0; i2 < 500; i2++) {
+                    ts.request(1);
                 }
             };
 
@@ -464,27 +345,12 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
             ps.onNext(1);
 
             final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(1, 2, 3);
-                }
-            })
+                            _ -> Arrays.asList(1, 2, 3))
             .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r1 = ps::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -498,34 +364,24 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+            int count;
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            int count;
-                            @Override
-                            public boolean hasNext() {
-                                if (count++ == 2) {
-                                    ts.cancel();
-                                }
-                                return true;
-                            }
+            public boolean hasNext() {
+                if (count++ == 2) {
+                    ts.cancel();
+                }
+                return true;
+            }
 
-                            @Override
-                            public Integer next() {
-                                return 1;
-                            }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -542,34 +398,24 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+            int count;
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            int count;
-                            @Override
-                            public boolean hasNext() {
-                                if (count++ == 2) {
-                                    ts.cancel();
-                                }
-                                return true;
-                            }
+            public boolean hasNext() {
+                if (count++ == 2) {
+                    ts.cancel();
+                }
+                return true;
+            }
 
-                            @Override
-                            public Integer next() {
-                                return 1;
-                            }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -24,7 +24,6 @@ import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.util.CrashingIterable;
 import io.reactivex.rxjava4.operators.QueueDisposable;
 import io.reactivex.rxjava4.operators.QueueFuseable;
@@ -36,12 +35,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult(1, 2);
     }
@@ -49,12 +43,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void emptyIterable() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
-            }
-        })
+        Maybe.just(1).flattenAsObservable(_ -> Collections.<Integer>emptyList())
         .test()
         .assertResult();
     }
@@ -62,12 +51,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void error() {
 
-        Maybe.<Integer>error(new TestException()).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.<Integer>error(new TestException()).flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertFailure(TestException.class);
     }
@@ -75,24 +59,14 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void empty() {
 
-        Maybe.<Integer>empty().flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.<Integer>empty().flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult();
     }
 
     @Test
     public void take() {
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .take(1)
         .test()
         .assertResult(1);
@@ -102,12 +76,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     public void fused() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .subscribe(to);
 
         to.assertFuseable()
@@ -120,12 +89,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     public void fusedNoSync() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(v -> Arrays.asList(v, v + 1))
         .subscribe(to);
 
         to.assertFuseable()
@@ -137,12 +101,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void iteratorCrash() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(1, 100, 100);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(_ -> new CrashingIterable(1, 100, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
@@ -150,12 +109,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void hasNextCrash() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 1, 100);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(_ -> new CrashingIterable(100, 1, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
@@ -163,12 +117,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void nextCrash() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 100, 1);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(_ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -176,52 +125,30 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void hasNextCrash2() {
 
-        Maybe.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 2, 100);
-            }
-        })
+        Maybe.just(1).flattenAsObservable(_ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToObservable(new Function<Maybe<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Maybe<Object> o) throws Exception {
-                return o.flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Collections.singleton(1);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToObservable(o ->
+                o.flattenAsObservable(_ -> Collections.singleton(1)));
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Collections.singleton(1);
-                    }
-                }));
+        TestHelper.checkDisposed(Maybe.just(1).flattenAsObservable(_ -> Collections.singleton(1)));
     }
 
     @Test
     public void async1() {
         Maybe.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .hide()
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -235,14 +162,11 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async2() {
         Maybe.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -255,14 +179,11 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async3() {
         Maybe.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .take(500 * 1000)
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -276,14 +197,11 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async4() {
         Maybe.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable(_ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .take(500 * 1000)
         .to(TestHelper.<Integer>testConsumer())
@@ -297,12 +215,7 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(1, 2, 3);
-                    }
-        }).subscribe(new Observer<Integer>() {
+        .flattenAsObservable(_ -> Arrays.asList(1, 2, 3)).subscribe(new Observer<Integer>() {
             QueueDisposable<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingleElementTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingleElementTest.java
@@ -23,14 +23,12 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class MaybeFlatMapSingleElementTest extends RxJavaTest {
     @Test
     public void flatMapSingleValue() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just(2);
-                }
-
-                return Single.just(1);
+        Maybe.just(1).flatMapSingle(integer -> {
+            if (integer == 1) {
+                return Single.just(2);
             }
+
+            return Single.just(1);
         })
             .test()
             .assertResult(2);
@@ -38,14 +36,12 @@ public class MaybeFlatMapSingleElementTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueDifferentType() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<String>>() {
-            @Override public SingleSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just("2");
-                }
-
-                return Single.just("1");
+        Maybe.just(1).flatMapSingle((Function<Integer, SingleSource<String>>) integer -> {
+            if (integer == 1) {
+                return Single.just("2");
             }
+
+            return Single.just("1");
         })
             .test()
             .assertResult("2");
@@ -53,12 +49,8 @@ public class MaybeFlatMapSingleElementTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueNull() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
-            .to(TestHelper.<Integer>testConsumer())
+        Maybe.just(1).flatMapSingle(_ -> null)
+            .to(TestHelper.testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
             .assertErrorMessage("The mapper returned a null SingleSource");
@@ -66,12 +58,10 @@ public class MaybeFlatMapSingleElementTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueErrorThrown() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Maybe.just(1).flatMapSingle(_ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
-            .to(TestHelper.<Integer>testConsumer())
+            .to(TestHelper.testConsumer())
             .assertNoValues()
             .assertError(RuntimeException.class)
             .assertErrorMessage("something went terribly wrong!");
@@ -81,22 +71,14 @@ public class MaybeFlatMapSingleElementTest extends RxJavaTest {
     public void flatMapSingleError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Maybe.error(exception).flatMapSingle(new Function<Object, SingleSource<Object>>() {
-            @Override public SingleSource<Object> apply(final Object integer) throws Exception {
-                return Single.just(new Object());
-            }
-        })
+        Maybe.error(exception).flatMapSingle((Function<Object, SingleSource<Object>>) _ -> Single.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void flatMapSingleEmpty() {
-        Maybe.<Integer>empty().flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        })
+        Maybe.<Integer>empty().flatMapSingle(_ -> Single.just(2))
             .test()
             .assertNoValues()
             .assertResult();
@@ -104,38 +86,18 @@ public class MaybeFlatMapSingleElementTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).flatMapSingle(_ -> Single.just(2)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.just(2);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, Maybe<Integer>>) m -> m.flatMapSingle(_ -> Single.just(2)));
     }
 
     @Test
     public void singleErrors() {
         Maybe.just(1)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.error(new TestException());
-                    }
-                })
+        .flatMapSingle(_ -> Single.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingleTest.java
@@ -25,14 +25,12 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class MaybeFlatMapSingleTest extends RxJavaTest {
     @Test
     public void flatMapSingleValue() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just(2);
-                }
-
-                return Single.just(1);
+        Maybe.just(1).flatMapSingle(integer -> {
+            if (integer == 1) {
+                return Single.just(2);
             }
+
+            return Single.just(1);
         })
             .toSingle()
             .test()
@@ -41,14 +39,12 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueDifferentType() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<String>>() {
-            @Override public SingleSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just("2");
-                }
-
-                return Single.just("1");
+        Maybe.just(1).flatMapSingle((Function<Integer, SingleSource<String>>) integer -> {
+            if (integer == 1) {
+                return Single.just("2");
             }
+
+            return Single.just("1");
         })
             .toSingle()
             .test()
@@ -57,13 +53,9 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueNull() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Maybe.just(1).flatMapSingle(_ -> null)
         .toSingle()
-        .to(TestHelper.<Integer>testConsumer())
+        .to(TestHelper.testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
             .assertErrorMessage("The mapper returned a null SingleSource");
@@ -71,13 +63,11 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleValueErrorThrown() {
-        Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Maybe.just(1).flatMapSingle(_ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
         .toSingle()
-        .to(TestHelper.<Integer>testConsumer())
+        .to(TestHelper.testConsumer())
             .assertNoValues()
             .assertError(RuntimeException.class)
             .assertErrorMessage("something went terribly wrong!");
@@ -87,11 +77,7 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
     public void flatMapSingleError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Maybe.error(exception).flatMapSingle(new Function<Object, SingleSource<Object>>() {
-            @Override public SingleSource<Object> apply(final Object integer) throws Exception {
-                return Single.just(new Object());
-            }
-        })
+        Maybe.error(exception).flatMapSingle((Function<Object, SingleSource<Object>>) _ -> Single.just(new Object()))
             .toSingle()
             .test()
             .assertError(exception);
@@ -99,11 +85,7 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void flatMapSingleEmpty() {
-        Maybe.<Integer>empty().flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        })
+        Maybe.<Integer>empty().flatMapSingle(_ -> Single.just(2))
             .toSingle()
             .test()
             .assertNoValues()
@@ -112,38 +94,18 @@ public class MaybeFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return Single.just(2);
-            }
-        }).toSingle());
+        TestHelper.checkDisposed(Maybe.just(1).flatMapSingle(_ -> Single.just(2)).toSingle());
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Integer>, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Maybe<Integer> m) throws Exception {
-                return m.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.just(2);
-                    }
-                }).toSingle();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle((Function<Maybe<Integer>, SingleSource<Integer>>) m -> m.flatMapSingle(_ -> Single.just(2)).toSingle());
     }
 
     @Test
     public void singleErrors() {
         Maybe.just(1)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                        return Single.error(new TestException());
-                    }
-                })
+        .flatMapSingle(_ -> Single.error(new TestException()))
         .toSingle()
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlattenTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlattenTest.java
@@ -24,38 +24,19 @@ public class MaybeFlattenTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Maybe.just(1).flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Maybe.just(1).flatMap(_ -> Maybe.just(2)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> v) throws Exception {
-                return v.flatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Integer>, MaybeSource<Integer>>) v ->
+                v.flatMap(_ -> Maybe.just(2)));
     }
 
     @Test
     public void mainError() {
         Maybe.<Integer>error(new TestException())
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                })
+        .flatMap(_ -> Maybe.just(2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -63,12 +44,7 @@ public class MaybeFlattenTest extends RxJavaTest {
     @Test
     public void mainEmpty() {
         Maybe.<Integer>empty()
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(2);
-                    }
-                })
+        .flatMap(_ -> Maybe.just(2))
         .test()
         .assertResult();
     }
@@ -76,12 +52,9 @@ public class MaybeFlattenTest extends RxJavaTest {
     @Test
     public void mapperThrows() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        throw new TestException();
-                    }
-                })
+        .flatMap(_ -> {
+            throw new TestException();
+        })
         .test()
         .assertFailure(TestException.class);
     }
@@ -89,12 +62,7 @@ public class MaybeFlattenTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return null;
-                    }
-                })
+        .flatMap(_ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromActionTest.java
@@ -34,12 +34,7 @@ public class MaybeFromActionTest extends RxJavaTest {
     public void fromAction() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Maybe.fromAction(atomicInteger::incrementAndGet)
             .test()
             .assertResult();
 
@@ -50,12 +45,7 @@ public class MaybeFromActionTest extends RxJavaTest {
     public void fromActionTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = atomicInteger::incrementAndGet;
 
         Maybe.fromAction(run)
             .test()
@@ -74,12 +64,7 @@ public class MaybeFromActionTest extends RxJavaTest {
     public void fromActionInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe<Object> maybe = Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Maybe<Object> maybe = Maybe.fromAction(atomicInteger::incrementAndGet);
 
         assertEquals(0, atomicInteger.get());
 
@@ -92,11 +77,8 @@ public class MaybeFromActionTest extends RxJavaTest {
 
     @Test
     public void fromActionThrows() {
-        Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Maybe.fromAction(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -107,12 +89,7 @@ public class MaybeFromActionTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Maybe<Void> m = Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter[0]++;
-            }
-        });
+        Maybe<Void> m = Maybe.fromAction(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -128,12 +105,9 @@ public class MaybeFromActionTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Object> to = Maybe.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                }
+            TestObserver<Object> to = Maybe.fromAction(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -167,12 +141,7 @@ public class MaybeFromActionTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.dispose();
-            }
-        })
+        Maybe.fromAction(to::dispose)
         .subscribeWith(to)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromCallableTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -38,12 +37,9 @@ public class MaybeFromCallableTest extends RxJavaTest {
     public void fromCallable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Maybe.fromCallable(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         })
             .test()
             .assertResult();
@@ -55,12 +51,9 @@ public class MaybeFromCallableTest extends RxJavaTest {
     public void fromCallableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Callable<Object> callable = new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Callable<Object> callable = () -> {
+            atomicInteger.incrementAndGet();
+            return null;
         };
 
         Maybe.fromCallable(callable)
@@ -80,12 +73,9 @@ public class MaybeFromCallableTest extends RxJavaTest {
     public void fromCallableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe<Object> completable = Maybe.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Maybe<Object> completable = Maybe.fromCallable(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         });
 
         assertEquals(0, atomicInteger.get());
@@ -99,11 +89,8 @@ public class MaybeFromCallableTest extends RxJavaTest {
 
     @Test
     public void fromCallableThrows() {
-        Maybe.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Maybe.fromCallable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -114,12 +101,9 @@ public class MaybeFromCallableTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Maybe<Integer> m = Maybe.fromCallable(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                counter[0]++;
-                return 0;
-            }
+        Maybe<Integer> m = Maybe.fromCallable(() -> {
+            counter[0]++;
+            return 0;
         });
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
@@ -136,13 +120,10 @@ public class MaybeFromCallableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Integer> to = Maybe.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                    return 1;
-                }
+            TestObserver<Integer> to = Maybe.fromCallable(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
+                return 1;
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -169,22 +150,19 @@ public class MaybeFromCallableTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.call()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.call()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Maybe<String> fromCallableObservable = Maybe.fromCallable(func);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromFutureTest.java
@@ -68,12 +68,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
-                to.dispose();
-            }
-        }, null);
+        FutureTask<Object> ft = new FutureTask<>(to::dispose, null);
 
         Schedulers.single().scheduleDirect(ft, 100, TimeUnit.MILLISECONDS);
 
@@ -88,12 +83,9 @@ public class MaybeFromFutureTest extends RxJavaTest {
     public void cancelAndCrashWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
-                to.dispose();
-                throw new TestException();
-            }
+        FutureTask<Object> ft = new FutureTask<>(() -> {
+            to.dispose();
+            throw new TestException();
         }, null);
 
         Schedulers.single().scheduleDirect(ft, 100, TimeUnit.MILLISECONDS);
@@ -107,10 +99,7 @@ public class MaybeFromFutureTest extends RxJavaTest {
 
     @Test
     public void futureNull() {
-        FutureTask<Object> ft = new FutureTask<>(new Runnable() {
-            @Override
-            public void run() {
-            }
+        FutureTask<Object> ft = new FutureTask<>(() -> {
         }, null);
 
         Schedulers.single().scheduleDirect(ft, 100, TimeUnit.MILLISECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -34,12 +34,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
     public void fromRunnable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Maybe.fromRunnable(atomicInteger::incrementAndGet)
             .test()
             .assertResult();
 
@@ -50,12 +45,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
     public void fromRunnableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Runnable run = new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Runnable run = atomicInteger::incrementAndGet;
 
         Maybe.fromRunnable(run)
             .test()
@@ -74,11 +64,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
     public void fromRunnableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        final Maybe<Object> maybe = Maybe.fromRunnable(new Runnable() {
-            @Override public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        final Maybe<Object> maybe = Maybe.fromRunnable(atomicInteger::incrementAndGet);
 
         assertEquals(0, atomicInteger.get());
 
@@ -91,11 +77,8 @@ public class MaybeFromRunnableTest extends RxJavaTest {
 
     @Test
     public void fromRunnableThrows() {
-        Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new UnsupportedOperationException();
-            }
+        Maybe.fromRunnable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -106,12 +89,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Maybe<Void> m = Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                counter[0]++;
-            }
-        });
+        Maybe<Void> m = Maybe.fromRunnable(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -127,15 +105,12 @@ public class MaybeFromRunnableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Object> to = Maybe.fromRunnable(new Runnable() {
-                @Override
-                public void run() {
-                    cdl1.countDown();
-                    try {
-                        cdl2.await(5, TimeUnit.SECONDS);
-                    } catch (InterruptedException ex) {
-                        throw new RuntimeException(ex);
-                    }
+            TestObserver<Object> to = Maybe.fromRunnable(() -> {
+                cdl1.countDown();
+                try {
+                    cdl2.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException ex) {
+                    throw new RuntimeException(ex);
                 }
             }).subscribeOn(Schedulers.single()).test();
 
@@ -172,12 +147,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                to.dispose();
-            }
-        })
+        Maybe.fromRunnable(to::dispose)
         .subscribeWith(to)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromSupplierTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -39,12 +38,9 @@ public class MaybeFromSupplierTest extends RxJavaTest {
     public void fromSupplier() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Maybe.fromSupplier(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         })
             .test()
             .assertResult();
@@ -56,12 +52,9 @@ public class MaybeFromSupplierTest extends RxJavaTest {
     public void fromSupplierTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Supplier<Object> supplier = new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Supplier<Object> supplier = () -> {
+            atomicInteger.incrementAndGet();
+            return null;
         };
 
         Maybe.fromSupplier(supplier)
@@ -81,12 +74,9 @@ public class MaybeFromSupplierTest extends RxJavaTest {
     public void fromSupplierInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Maybe<Object> completable = Maybe.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                atomicInteger.incrementAndGet();
-                return null;
-            }
+        Maybe<Object> completable = Maybe.fromSupplier(() -> {
+            atomicInteger.incrementAndGet();
+            return null;
         });
 
         assertEquals(0, atomicInteger.get());
@@ -100,11 +90,8 @@ public class MaybeFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fromSupplierThrows() {
-        Maybe.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Maybe.fromSupplier(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -115,12 +102,9 @@ public class MaybeFromSupplierTest extends RxJavaTest {
     public void supplier() throws Throwable {
         final int[] counter = { 0 };
 
-        Maybe<Integer> m = Maybe.fromSupplier(new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                counter[0]++;
-                return 0;
-            }
+        Maybe<Integer> m = Maybe.fromSupplier(() -> {
+            counter[0]++;
+            return 0;
         });
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
@@ -137,13 +121,10 @@ public class MaybeFromSupplierTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Integer> to = Maybe.fromSupplier(new Supplier<Integer>() {
-                @Override
-                public Integer get() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                    return 1;
-                }
+            TestObserver<Integer> to = Maybe.fromSupplier(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
+                return 1;
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -170,22 +151,19 @@ public class MaybeFromSupplierTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.get()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.get()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Maybe<String> fromSupplierObservable = Maybe.fromSupplier(func);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeIsEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeIsEmptyTest.java
@@ -85,12 +85,7 @@ public class MaybeIsEmptyTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposedMaybeToSingle(new Function<Maybe<Object>, SingleSource<Boolean>>() {
-            @Override
-            public SingleSource<Boolean> apply(Maybe<Object> m) throws Exception {
-                return m.isEmpty();
-            }
-        });
+        TestHelper.checkDisposedMaybeToSingle(Maybe::isEmpty);
     }
 
     @Test
@@ -102,22 +97,12 @@ public class MaybeIsEmptyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybeToSingle(new Function<Maybe<Object>, Single<Boolean>>() {
-            @Override
-            public Single<Boolean> apply(Maybe<Object> f) throws Exception {
-                return f.isEmpty();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybeToSingle((Function<Maybe<Object>, Single<Boolean>>) Maybe::isEmpty);
     }
 
     @Test
     public void disposeToMaybe() {
-        TestHelper.checkDisposedMaybe(new Function<Maybe<Object>, Maybe<Boolean>>() {
-            @Override
-            public Maybe<Boolean> apply(Maybe<Object> m) throws Exception {
-                return m.isEmpty().toMaybe();
-            }
-        });
+        TestHelper.checkDisposedMaybe((Function<Maybe<Object>, Maybe<Boolean>>) m -> m.isEmpty().toMaybe());
     }
 
     @Test
@@ -129,11 +114,6 @@ public class MaybeIsEmptyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribeToMaybe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, Maybe<Boolean>>() {
-            @Override
-            public Maybe<Boolean> apply(Maybe<Object> f) throws Exception {
-                return f.isEmpty().toMaybe();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe((Function<Maybe<Object>, Maybe<Boolean>>) f -> f.isEmpty().toMaybe());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorXTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -69,11 +68,8 @@ public class MaybeOnErrorXTest extends RxJavaTest {
     @Test
     public void onErrorReturnFunctionThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
-        .onErrorReturn(new Function<Throwable, Object>() {
-            @Override
-            public Object apply(Throwable v) throws Exception {
-                throw new IOException();
-            }
+        .onErrorReturn(_ -> {
+            throw new IOException();
         })
         .to(TestHelper.testConsumer()), TestException.class, IOException.class);
     }
@@ -81,11 +77,8 @@ public class MaybeOnErrorXTest extends RxJavaTest {
     @Test
     public void onErrorCompletePredicateThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
-        .onErrorComplete(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable v) throws Exception {
-                throw new IOException();
-            }
+        .onErrorComplete(_ -> {
+            throw new IOException();
         })
         .to(TestHelper.testConsumer()), TestException.class, IOException.class);
     }
@@ -101,11 +94,8 @@ public class MaybeOnErrorXTest extends RxJavaTest {
     @Test
     public void onErrorResumeNextFunctionThrows() {
         TestHelper.assertCompositeExceptions(Maybe.error(new TestException())
-        .onErrorResumeNext(new Function<Throwable, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Throwable v) throws Exception {
-                throw new IOException();
-            }
+        .onErrorResumeNext(_ -> {
+            throw new IOException();
         })
         .to(TestHelper.testConsumer()), TestException.class, IOException.class);
     }
@@ -133,12 +123,7 @@ public class MaybeOnErrorXTest extends RxJavaTest {
 
     @Test
     public void onErrorReturnDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.onErrorReturnItem(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(v -> v.onErrorReturnItem(1));
     }
 
     @Test
@@ -164,12 +149,7 @@ public class MaybeOnErrorXTest extends RxJavaTest {
 
     @Test
     public void onErrorCompleteDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.onErrorComplete();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(Maybe::onErrorComplete);
     }
 
     @Test
@@ -179,12 +159,7 @@ public class MaybeOnErrorXTest extends RxJavaTest {
 
     @Test
     public void onErrorNextDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> v) throws Exception {
-                return v.onErrorResumeWith(Maybe.just(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(v -> v.onErrorResumeWith(Maybe.just(1)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
@@ -38,12 +38,7 @@ public class MaybePeekTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.doOnSuccess(Functions.emptyConsumer());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.doOnSuccess(Functions.emptyConsumer()));
     }
 
     @Test
@@ -61,12 +56,7 @@ public class MaybePeekTest extends RxJavaTest {
                     observer.onError(new TestException("Second"));
                 }
             }
-            .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    err[0] = e;
-                }
-            })
+            .doOnError(e -> err[0] = e)
             .to(TestHelper.<Integer>testConsumer());
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Second");
@@ -92,12 +82,7 @@ public class MaybePeekTest extends RxJavaTest {
                 observer.onComplete();
             }
         }
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                compl[0]++;
-            }
-        })
+        .doOnComplete(() -> compl[0]++)
         .test();
 
         assertEquals(1, compl[0]);
@@ -108,11 +93,8 @@ public class MaybePeekTest extends RxJavaTest {
     @Test
     public void doOnErrorThrows() {
         TestObserverEx<Object> to = Maybe.error(new TestException("Main"))
-        .doOnError(new Consumer<Object>() {
-            @Override
-            public void accept(Object t) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnError((Consumer<Object>) _ -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Object>testConsumer());
 
@@ -131,11 +113,8 @@ public class MaybePeekTest extends RxJavaTest {
         try {
 
             Maybe.just(1)
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doAfterTerminate(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilPublisherTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -36,12 +35,7 @@ public class MaybeTakeUntilPublisherTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.takeUntil(Flowable.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.takeUntil(Flowable.never()));
     }
 
     @Test
@@ -130,18 +124,8 @@ public class MaybeTakeUntilPublisherTest extends RxJavaTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -166,18 +150,8 @@ public class MaybeTakeUntilPublisherTest extends RxJavaTest {
 
             TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onComplete();
-                }
-            };
+            Runnable r1 = pp1::onComplete;
+            Runnable r2 = pp2::onComplete;
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -65,12 +64,7 @@ public class MaybeTakeUntilTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.takeUntil(Maybe.never());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.takeUntil(Maybe.never()));
     }
 
     @Test
@@ -159,18 +153,8 @@ public class MaybeTakeUntilTest extends RxJavaTest {
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex1);
+                Runnable r2 = () -> pp2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -195,18 +179,8 @@ public class MaybeTakeUntilTest extends RxJavaTest {
 
             TestObserver<Integer> to = pp1.singleElement().takeUntil(pp2.singleElement()).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onComplete();
-                }
-            };
+            Runnable r1 = pp1::onComplete;
+            Runnable r2 = pp2::onComplete;
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -169,18 +168,8 @@ public class MaybeTimeoutPublisherTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex);
+                Runnable r2 = () -> pp2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -199,18 +188,8 @@ public class MaybeTimeoutPublisherTest extends RxJavaTest {
 
             TestObserverEx<Integer> to = pp1.singleElement().timeout(pp2).to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onComplete();
-                }
-            };
+            Runnable r1 = pp1::onComplete;
+            Runnable r2 = pp2::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -226,12 +205,7 @@ public class MaybeTimeoutPublisherTest extends RxJavaTest {
 
     @Test
     public void badSourceOther() {
-        TestHelper.checkBadSourceFlowable(new Function<Flowable<Integer>, Object>() {
-            @Override
-            public Object apply(Flowable<Integer> f) throws Exception {
-                return Maybe.never().timeout(f, Maybe.just(1));
-            }
-        }, false, null, 1, 1);
+        TestHelper.checkBadSourceFlowable(f -> Maybe.never().timeout(f, Maybe.just(1)), false, null, 1, 1);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
@@ -290,18 +290,8 @@ public class MaybeTimeoutTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex);
+                Runnable r2 = () -> pp2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -320,18 +310,8 @@ public class MaybeTimeoutTest extends RxJavaTest {
 
             TestObserverEx<Integer> to = pp1.singleElement().timeout(pp2.singleElement()).to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onComplete();
-                }
-            };
+            Runnable r1 = pp1::onComplete;
+            Runnable r2 = pp2::onComplete;
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsingTest.java
@@ -34,21 +34,10 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void resourceSupplierThrows() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw new TestException();
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.just(1);
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> {
+            throw new TestException();
+        }, _ -> Maybe.just(1), _ -> {
 
-            }
         })
         .test()
         .assertFailure(TestException.class);
@@ -57,21 +46,8 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void errorEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> Maybe.error(new TestException()), _ -> {
 
-            }
         }, true)
         .test()
         .assertFailure(TestException.class);
@@ -80,21 +56,8 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void emptyEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.empty();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> Maybe.empty(), _ -> {
 
-            }
         }, true)
         .test()
         .assertResult();
@@ -103,21 +66,8 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void errorNonEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> Maybe.error(new TestException()), _ -> {
 
-            }
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -126,21 +76,8 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void emptyNonEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.empty();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> Maybe.empty(), _ -> {
 
-            }
         }, false)
         .test()
         .assertResult();
@@ -149,21 +86,10 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void supplierCrashEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> {
+            throw new TestException();
+        }, _ -> {
 
-            }
         }, true)
         .test()
         .assertFailure(TestException.class);
@@ -172,21 +98,10 @@ public class MaybeUsingTest extends RxJavaTest {
     @Test
     public void supplierCrashNonEager() {
 
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
+        Maybe.using(() -> 1, _ -> {
+            throw new TestException();
+        }, _ -> {
 
-            }
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -194,23 +109,12 @@ public class MaybeUsingTest extends RxJavaTest {
 
     @Test
     public void supplierAndDisposerCrashEager() {
-        TestObserverEx<Integer> to = Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                throw new TestException("Main");
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
+        var to = Maybe.using(() -> 1, _ -> {
+            throw new TestException("Main");
+        }, _ -> {
+            throw new TestException("Disposer");
         }, true)
-        .to(TestHelper.<Integer>testConsumer())
+        .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
         List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
@@ -223,23 +127,12 @@ public class MaybeUsingTest extends RxJavaTest {
     public void supplierAndDisposerCrashNonEager() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    throw new TestException("Main");
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                    throw new TestException("Disposer");
-                }
+            Maybe.using(() -> 1, _ -> {
+                throw new TestException("Main");
+            }, _ -> {
+                throw new TestException("Disposer");
             }, false)
-            .to(TestHelper.<Integer>testConsumer())
+            .to(TestHelper.testConsumer())
             .assertFailureAndMessage(TestException.class, "Main");
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
@@ -252,22 +145,7 @@ public class MaybeUsingTest extends RxJavaTest {
     public void dispose() {
         final int[] call = {0 };
 
-        TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.never();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                call[0]++;
-            }
-        }, false)
+        var to = Maybe.using(() -> 1, _ -> Maybe.never(), _ -> call[0]++, false)
         .test();
 
         to.dispose();
@@ -279,21 +157,8 @@ public class MaybeUsingTest extends RxJavaTest {
     public void disposeCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return Maybe.never();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                    throw new TestException();
-                }
+            var to = Maybe.using(() -> 1, _ -> Maybe.never(), _ -> {
+                throw new TestException();
             }, false)
             .test();
 
@@ -307,41 +172,15 @@ public class MaybeUsingTest extends RxJavaTest {
 
     @Test
     public void isDisposed() {
-        TestHelper.checkDisposed(Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return Maybe.never();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
+        TestHelper.checkDisposed(Maybe.using(() -> 1, _ -> Maybe.never(), _ -> {
 
-                }
-            }, false));
+        }, false));
     }
 
     @Test
     public void justDisposerCrashes() {
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.just(1);
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
+        Maybe.using(() -> 1, _ -> Maybe.just(1), _ -> {
+            throw new TestException("Disposer");
         }, true)
         .test()
         .assertFailure(TestException.class);
@@ -349,21 +188,8 @@ public class MaybeUsingTest extends RxJavaTest {
 
     @Test
     public void emptyDisposerCrashes() {
-        Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.empty();
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
+        Maybe.using(() -> 1, _ -> Maybe.empty(), _ -> {
+            throw new TestException("Disposer");
         }, true)
         .test()
         .assertFailure(TestException.class);
@@ -371,23 +197,10 @@ public class MaybeUsingTest extends RxJavaTest {
 
     @Test
     public void errorDisposerCrash() {
-        TestObserverEx<Integer> to = Maybe.using(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        }, new Function<Object, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Object v) throws Exception {
-                return Maybe.error(new TestException("Main"));
-            }
-        }, new Consumer<Object>() {
-            @Override
-            public void accept(Object d) throws Exception {
-                throw new TestException("Disposer");
-            }
+        var to = Maybe.using(() -> 1, _ -> Maybe.error(new TestException("Main")), _ -> {
+            throw new TestException("Disposer");
         }, true)
-        .to(TestHelper.<Integer>testConsumer())
+        .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
         List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
@@ -400,36 +213,20 @@ public class MaybeUsingTest extends RxJavaTest {
     public void doubleOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return Maybe.wrap(new MaybeSource<Integer>() {
-                        @Override
-                        public void subscribe(MaybeObserver<? super Integer> observer) {
-                            Disposable d1 = Disposable.empty();
+            Maybe.using(() -> 1, _ -> Maybe.wrap((MaybeSource<Integer>) observer -> {
+                Disposable d1 = Disposable.empty();
 
-                            observer.onSubscribe(d1);
+                observer.onSubscribe(d1);
 
-                            Disposable d2 = Disposable.empty();
+                Disposable d2 = Disposable.empty();
 
-                            observer.onSubscribe(d2);
+                observer.onSubscribe(d2);
 
-                            assertFalse(d1.isDisposed());
+                assertFalse(d1.isDisposed());
 
-                            assertTrue(d2.isDisposed());
-                        }
-                    });
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
+                assertTrue(d2.isDisposed());
+            }), _ -> {
 
-                }
             }, false).test();
             TestHelper.assertError(errors, 0, IllegalStateException.class, "Disposable already set!");
         } finally {
@@ -443,38 +240,15 @@ public class MaybeUsingTest extends RxJavaTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return ps.lastElement();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                }
+            final TestObserver<Integer> to = Maybe.using(() -> 1, _ -> ps.lastElement(), _ -> {
             }, true)
             .test();
 
             ps.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = to::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r2 = ps::onComplete;
 
             TestHelper.race(r1, r2);
         }
@@ -487,38 +261,15 @@ public class MaybeUsingTest extends RxJavaTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return ps.firstElement();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
-                }
+            final TestObserver<Integer> to = Maybe.using(() -> 1, _ -> ps.firstElement(), _ -> {
             }, true)
             .test();
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = to::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onError(ex);
-                }
-            };
+            Runnable r2 = () -> ps.onError(ex);
 
             TestHelper.race(r1, r2);
         }
@@ -530,37 +281,14 @@ public class MaybeUsingTest extends RxJavaTest {
 
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestObserver<Integer> to = Maybe.using(new Supplier<Object>() {
-                @Override
-                public Object get() throws Exception {
-                    return 1;
-                }
-            }, new Function<Object, MaybeSource<Integer>>() {
-                @Override
-                public MaybeSource<Integer> apply(Object v) throws Exception {
-                    return ps.firstElement();
-                }
-            }, new Consumer<Object>() {
-                @Override
-                public void accept(Object d) throws Exception {
+            final TestObserver<Integer> to = Maybe.using(() -> 1, _ -> ps.firstElement(), _ -> {
 
-                }
             }, true)
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = to::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r2 = ps::onComplete;
 
             TestHelper.race(r1, r2);
         }
@@ -571,24 +299,8 @@ public class MaybeUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Integer> to = Maybe.using(Functions.justSupplier(1),
-            new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer t) throws Throwable {
-                    return Maybe.<Integer>never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, true)
+                        (Function<Integer, Maybe<Integer>>) _ -> Maybe.<Integer>never()
+                                .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), true)
         .test()
         ;
         to.assertEmpty();
@@ -603,24 +315,8 @@ public class MaybeUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Integer> to = Maybe.using(Functions.justSupplier(1),
-            new Function<Integer, Maybe<Integer>>() {
-                @Override
-                public Maybe<Integer> apply(Integer t) throws Throwable {
-                    return Maybe.<Integer>never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, false)
+                        (Function<Integer, Maybe<Integer>>) _ -> Maybe.<Integer>never()
+                                .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), false)
         .test()
         ;
         to.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
@@ -34,19 +34,9 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class MaybeZipArrayTest extends RxJavaTest {
 
-    final BiFunction<Object, Object, Object> addString = new BiFunction<Object, Object, Object>() {
-        @Override
-        public Object apply(Object a, Object b) throws Exception {
-            return "" + a + b;
-        }
-    };
+    final BiFunction<Object, Object, Object> addString = (a, b) -> "" + a + b;
 
-    final Function3<Object, Object, Object, Object> addString3 = new Function3<Object, Object, Object, Object>() {
-        @Override
-        public Object apply(Object a, Object b, Object c) throws Exception {
-            return "" + a + b + c;
-        }
-    };
+    final Function3<Object, Object, Object, Object> addString3 = (a, b, c) -> "" + a + b + c;
 
     @Test
     public void firstError() {
@@ -78,11 +68,8 @@ public class MaybeZipArrayTest extends RxJavaTest {
 
     @Test
     public void zipperThrows() {
-        Maybe.zip(Maybe.just(1), Maybe.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        Maybe.zip(Maybe.just(1), Maybe.just(2), (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -90,12 +77,7 @@ public class MaybeZipArrayTest extends RxJavaTest {
 
     @Test
     public void zipperReturnsNull() {
-        Maybe.zip(Maybe.just(1), Maybe.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return null;
-            }
-        })
+        Maybe.zip(Maybe.just(1), Maybe.just(2), (_, _) -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -128,19 +110,9 @@ public class MaybeZipArrayTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp0.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp0.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp1.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -157,12 +129,7 @@ public class MaybeZipArrayTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
-        Maybe.zipArray(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, Maybe.just(1), null)
+        Maybe.zipArray((Function<Object[], Object>) _ -> 1, Maybe.just(1), null)
         .blockingGet();
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipIterableTest.java
@@ -31,12 +31,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class MaybeZipIterableTest extends RxJavaTest {
 
-    final Function<Object[], Object> addString = new Function<Object[], Object>() {
-        @Override
-        public Object apply(Object[] a) throws Exception {
-            return Arrays.toString(a);
-        }
-    };
+    final Function<Object[], Object> addString = Arrays::toString;
 
     @Test
     public void firstError() {
@@ -68,11 +63,8 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void zipperThrows() {
-        Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] b) throws Exception {
-                throw new TestException();
-            }
+        Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -80,12 +72,7 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void zipperReturnsNull() {
-        Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return null;
-            }
-        })
+        Maybe.zip(Arrays.asList(Maybe.just(1), Maybe.just(2)), _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -120,19 +107,9 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp0.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp0.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp1.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -149,59 +126,34 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Maybe.zip(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }), addString)
+        Maybe.zip(new CrashingMappedIterable<>(1, 100, 100, Maybe::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
 
     @Test
     public void hasNextThrows() {
-        Maybe.zip(new CrashingMappedIterable<>(100, 20, 100, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }), addString)
+        Maybe.zip(new CrashingMappedIterable<>(100, 20, 100, Maybe::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
 
     @Test
     public void nextThrows() {
-        Maybe.zip(new CrashingMappedIterable<>(100, 100, 5, new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }), addString)
+        Maybe.zip(new CrashingMappedIterable<>(100, 100, 5, Maybe::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
-        Maybe.zip(Arrays.asList(null, Maybe.just(1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        })
+        Maybe.zip(Arrays.asList(null, Maybe.just(1)), (Function<Object[], Object>) _ -> 1)
         .blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
-        Maybe.zip(Arrays.asList(Maybe.just(1), null), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        })
+        Maybe.zip(Arrays.asList(Maybe.just(1), null), (Function<Object[], Object>) _ -> 1)
         .blockingGet();
     }
 
@@ -214,19 +166,9 @@ public class MaybeZipIterableTest extends RxJavaTest {
 
     @Test
     public void maybeSourcesInIterable() {
-        MaybeSource<Integer> source = new MaybeSource<Integer>() {
-            @Override
-            public void subscribe(MaybeObserver<? super Integer> observer) {
-                Maybe.just(1).subscribe(observer);
-            }
-        };
+        MaybeSource<Integer> source = observer -> Maybe.just(1).subscribe(observer);
 
-        Maybe.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Maybe.zip(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -73,7 +73,7 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
 
         for (int i = 0; i < subCount; ++i) {
             TestObserver<Long> observer = new TestObserver<>();
-            subscriptions.add(observer);
+            subscriptions.add(observer.asDisposable());
             longs.subscribe(observer);
             subscribers.add(observer);
         }
@@ -137,7 +137,7 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
         for (int i = 0; i < subCount; ++i) {
             TestObserver<Long> observer = new TestObserver<>();
             longs.subscribe(observer);
-            subscriptions.add(observer);
+            subscriptions.add(observer.asDisposable());
             subscribers.add(observer);
         }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -759,8 +759,8 @@ public class ObservableRefCountTest extends RxJavaTest {
         .publish()
         .refCount();
 
-        Disposable d1 = source.test();
-        Disposable d2 = source.test();
+        Disposable d1 = source.test().asDisposable();
+        Disposable d2 = source.test().asDisposable();
 
         d1.dispose();
         d2.dispose();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -230,7 +230,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         TestScheduler sch = new TestScheduler();
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -274,7 +273,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         TestScheduler sch = new TestScheduler();
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -313,7 +311,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         TestScheduler sch = new TestScheduler();
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -464,7 +461,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         TestScheduler sch = new TestScheduler();
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -492,7 +488,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         TestScheduler sch = new TestScheduler();
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -559,7 +554,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         Action whenDisposed = mock(Action.class);
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 
@@ -598,7 +592,6 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
 
         Action whenDisposed = mock(Action.class);
 
-        @SuppressWarnings("resource")
         TestObserver<Object> drops = new TestObserver<>();
         drops.onSubscribe(Disposable.empty());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
@@ -104,7 +104,6 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldCompleteIfUnderlyingComletes() {
         Observer<String> observer = TestHelper.mockObserver();
-        @SuppressWarnings("resource")
         TestObserver<String> to = new TestObserver<>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
@@ -118,7 +117,6 @@ public class ObservableTimeoutTests extends RxJavaTest {
     @Test
     public void shouldErrorIfUnderlyingErrors() {
         Observer<String> observer = TestHelper.mockObserver();
-        @SuppressWarnings("resource")
         TestObserver<String> to = new TestObserver<>(observer);
         withTimeout.subscribe(observer);
         testScheduler.advanceTimeBy(2, TimeUnit.SECONDS);

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/InstantPeriodicTaskTest.java
@@ -35,11 +35,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             try {
@@ -62,11 +59,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             assertFalse(task.isDisposed());
@@ -90,11 +84,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             task.setFirst(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
@@ -121,11 +112,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             task.runner = Thread.currentThread();
@@ -154,11 +142,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             task.dispose();
@@ -184,11 +169,8 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
 
             @SuppressWarnings("resource")
-            InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                throw new TestException();
             }, exec);
 
             task.runner = Thread.currentThread();
@@ -216,26 +198,13 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
                 @SuppressWarnings("resource")
-                final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                    @Override
-                    public void run() {
-                        throw new TestException();
-                    }
+                final InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                    throw new TestException();
                 }, exec);
 
                 final FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        task.setFirst(f1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        task.dispose();
-                    }
-                };
+                Runnable r1 = () -> task.setFirst(f1);
+                Runnable r2 = task::dispose;
 
                 TestHelper.race(r1, r2);
 
@@ -254,26 +223,13 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
                 @SuppressWarnings("resource")
-                final InstantPeriodicTask task = new InstantPeriodicTask(new Runnable() {
-                    @Override
-                    public void run() {
-                        throw new TestException();
-                    }
+                final InstantPeriodicTask task = new InstantPeriodicTask(() -> {
+                    throw new TestException();
                 }, exec);
 
                 final FutureTask<Void> f1 = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        task.setRest(f1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        task.dispose();
-                    }
-                };
+                Runnable r1 = () -> task.setRest(f1);
+                Runnable r2 = task::dispose;
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
@@ -39,7 +39,6 @@ public class ParallelSchedulerTest implements Runnable {
         calls.getAndIncrement();
     }
 
-
     @Test
     public void normalNonTracking() {
         Scheduler s = new ParallelScheduler(2, false, ParallelScheduler.DEFAULT_FACTORY);

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
@@ -39,16 +39,21 @@ public class ParallelSchedulerTest implements Runnable {
         calls.getAndIncrement();
     }
 
+
     @Test
     public void normalNonTracking() {
         Scheduler s = new ParallelScheduler(2, false, ParallelScheduler.DEFAULT_FACTORY);
 
-        for (int i = 0; i < 100; i++) {
-            Flowable.range(1, 10).hide()
-            .observeOn(s, false, 4)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        try {
+            for (int i = 0; i < 100; i++) {
+                Flowable.range(1, 10).hide()
+                .observeOn(s, false, 4)
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+            }
+        } finally {
+            s.shutdown();
         }
     }
 
@@ -56,12 +61,16 @@ public class ParallelSchedulerTest implements Runnable {
     public void normalNonTrackingVia() {
         Scheduler s = Schedulers.createParallel(new ParallelSchedulerConfig(2, false, ParallelScheduler.DEFAULT_FACTORY));
 
-        for (int i = 0; i < 100; i++) {
-            Flowable.range(1, 10).hide()
-            .observeOn(s, false, 4)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        try {
+            for (int i = 0; i < 100; i++) {
+                Flowable.range(1, 10).hide()
+                .observeOn(s, false, 4)
+                .test()
+                .awaitDone(5, TimeUnit.SECONDS)
+                .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+            }
+        } finally {
+            s.shutdown();
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.Scheduler;
-import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
 public class SchedulerToExecutorServiceTest {
@@ -30,6 +29,7 @@ public class SchedulerToExecutorServiceTest {
     @Test
     public void invokeAnyShouldReturnResultOfCompletedTask() throws Exception {
         Scheduler scheduler = Schedulers.trampoline();
+        @SuppressWarnings("resource")
         SchedulerToExecutorService executor = new SchedulerToExecutorService(
                 scheduler, new AtomicReference<>(null));
 
@@ -46,6 +46,7 @@ public class SchedulerToExecutorServiceTest {
     @Test
     public void invokeAnyWithSingleTask() throws Exception {
         Scheduler scheduler = Schedulers.trampoline();
+        @SuppressWarnings("resource")
         SchedulerToExecutorService executor = new SchedulerToExecutorService(
                 scheduler, new AtomicReference<>(null));
 
@@ -59,6 +60,7 @@ public class SchedulerToExecutorServiceTest {
     @Test
     public void invokeAnyWithEmptyTasksShouldThrow() throws Exception {
         Scheduler scheduler = Schedulers.trampoline();
+        @SuppressWarnings("resource")
         SchedulerToExecutorService executor = new SchedulerToExecutorService(
                 scheduler, new AtomicReference<>(null));
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/FutureSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/FutureSubscriberTest.java
@@ -130,12 +130,7 @@ public class FutureSubscriberTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final FutureSubscriber<Integer> fs = new FutureSubscriber<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    fs.cancel(false);
-                }
-            };
+            Runnable r = () -> fs.cancel(false);
 
             TestHelper.race(r, r);
         }
@@ -143,12 +138,9 @@ public class FutureSubscriberTest extends RxJavaTest {
 
     @Test
     public void await() throws Exception {
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                fs.onNext(1);
-                fs.onComplete();
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            fs.onNext(1);
+            fs.onComplete();
         }, 100, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fs.get(5, TimeUnit.SECONDS).intValue());
@@ -162,19 +154,9 @@ public class FutureSubscriberTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    fs.cancel(false);
-                }
-            };
+            Runnable r1 = () -> fs.cancel(false);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    fs.onError(ex);
-                }
-            };
+            Runnable r2 = () -> fs.onError(ex);
 
             TestHelper.race(r1, r2);
         }
@@ -194,19 +176,9 @@ public class FutureSubscriberTest extends RxJavaTest {
                 fs.onNext(1);
             }
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    fs.cancel(false);
-                }
-            };
+            Runnable r1 = () -> fs.cancel(false);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    fs.onComplete();
-                }
-            };
+            Runnable r2 = fs::onComplete;
 
             TestHelper.race(r1, r2);
         }
@@ -278,12 +250,9 @@ public class FutureSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeAsync() throws Exception {
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                fs.onNext(1);
-                fs.onComplete();
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            fs.onNext(1);
+            fs.onComplete();
         }, 500, TimeUnit.MILLISECONDS);
 
         assertEquals(1, fs.get().intValue());

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
@@ -18,11 +18,9 @@ import static org.junit.Assert.*;
 import java.util.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.operators.flowable.FlowableInternalHelper;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
@@ -36,28 +34,10 @@ public class LambdaSubscriberTest extends RxJavaTest {
     public void onSubscribeThrows() {
         final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                throw new TestException();
-            }
-        });
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(received::add,
+                received::add, () -> received.add(100), _ -> {
+                    throw new TestException();
+                });
 
         assertFalse(subscriber.isDisposed());
 
@@ -73,28 +53,10 @@ public class LambdaSubscriberTest extends RxJavaTest {
     public void onNextThrows() {
         final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                throw new TestException();
-            }
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(_ -> {
+            throw new TestException();
         },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                s.request(Long.MAX_VALUE);
-            }
-        });
+                received::add, () -> received.add(100), s -> s.request(Long.MAX_VALUE));
 
         assertFalse(subscriber.isDisposed());
 
@@ -113,28 +75,10 @@ public class LambdaSubscriberTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            throw new TestException("Inner");
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    received.add(100);
-                }
-            }, new Consumer<Subscription>() {
-                @Override
-                public void accept(Subscription s) throws Exception {
-                    s.request(Long.MAX_VALUE);
-                }
-            });
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(received::add,
+                    _ -> {
+                        throw new TestException("Inner");
+                    }, () -> received.add(100), s -> s.request(Long.MAX_VALUE));
 
             assertFalse(subscriber.isDisposed());
 
@@ -160,28 +104,10 @@ public class LambdaSubscriberTest extends RxJavaTest {
         try {
             final List<Object> received = new ArrayList<>();
 
-            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    received.add(v);
-                }
-            },
-                    new Consumer<Throwable>() {
-                        @Override
-                        public void accept(Throwable e) throws Exception {
-                            received.add(e);
-                        }
-                    }, new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
-            }, new Consumer<Subscription>() {
-                @Override
-                public void accept(Subscription s) throws Exception {
-                    s.request(Long.MAX_VALUE);
-                }
-            });
+            LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(received::add,
+                    received::add, () -> {
+                        throw new TestException();
+                    }, s -> s.request(Long.MAX_VALUE));
 
             assertFalse(subscriber.isDisposed());
 
@@ -199,46 +125,23 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void badSourceOnSubscribe() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription s1 = new BooleanSubscription();
-                s.onSubscribe(s1);
-                BooleanSubscription s2 = new BooleanSubscription();
-                s.onSubscribe(s2);
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            BooleanSubscription s1 = new BooleanSubscription();
+            s.onSubscribe(s1);
+            BooleanSubscription s2 = new BooleanSubscription();
+            s.onSubscribe(s2);
 
-                assertFalse(s1.isCancelled());
-                assertTrue(s2.isCancelled());
+            assertFalse(s1.isCancelled());
+            assertTrue(s2.isCancelled());
 
-                s.onNext(1);
-                s.onComplete();
-            }
+            s.onNext(1);
+            s.onComplete();
         });
 
         final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                s.request(Long.MAX_VALUE);
-            }
-        });
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(received::add,
+                received::add, () -> received.add(100), s -> s.request(Long.MAX_VALUE));
 
         source.subscribe(subscriber);
 
@@ -248,44 +151,21 @@ public class LambdaSubscriberTest extends RxJavaTest {
     @Test
     @SuppressUndeliverable
     public void badSourceEmitAfterDone() {
-        Flowable<Integer> source = Flowable.fromPublisher(new Publisher<Integer>() {
-            @Override
-            public void subscribe(Subscriber<? super Integer> s) {
-                BooleanSubscription s1 = new BooleanSubscription();
-                s.onSubscribe(s1);
+        Flowable<Integer> source = Flowable.fromPublisher(s -> {
+            BooleanSubscription s1 = new BooleanSubscription();
+            s.onSubscribe(s1);
 
-                s.onNext(1);
-                s.onComplete();
-                s.onNext(2);
-                s.onError(new TestException());
-                s.onComplete();
-            }
+            s.onNext(1);
+            s.onComplete();
+            s.onNext(2);
+            s.onError(new TestException());
+            s.onComplete();
         });
 
         final List<Object> received = new ArrayList<>();
 
-        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                received.add(v);
-            }
-        },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        received.add(e);
-                    }
-                }, new Action() {
-            @Override
-            public void run() throws Exception {
-                received.add(100);
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                s.request(Long.MAX_VALUE);
-            }
-        });
+        LambdaSubscriber<Object> subscriber = new LambdaSubscriber<>(received::add,
+                received::add, () -> received.add(100), s -> s.request(Long.MAX_VALUE));
 
         source.subscribe(subscriber);
 
@@ -298,17 +178,9 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        pp.subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        });
+        pp.subscribe(_ -> {
+            throw new TestException();
+        }, errors::add);
 
         assertTrue("No observers?!", pp.hasSubscribers());
         assertTrue("Has errors already?!", errors.isEmpty());
@@ -327,24 +199,10 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
         final List<Throwable> errors = new ArrayList<>();
 
-        pp.subscribe(new LambdaSubscriber<>(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                errors.add(e);
-            }
-        }, new Action() {
-            @Override
-            public void run() throws Exception {
-            }
-        }, new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                throw new TestException();
-            }
+        pp.subscribe(new LambdaSubscriber<>(_ -> {
+        }, errors::add, () -> {
+        }, _ -> {
+            throw new TestException();
         }));
 
         assertFalse("Has observers?!", pp.hasSubscribers());

--- a/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerObserverTest.java
@@ -36,7 +36,6 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final Observer[] a = { null };
 
-        @SuppressWarnings("resource")
         final TestObserver to = new TestObserver();
 
         Observer observer = new Observer() {
@@ -81,7 +80,6 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final Observer[] a = { null };
 
-        @SuppressWarnings("resource")
         final TestObserver to = new TestObserver();
 
         Observer observer = new Observer() {
@@ -126,7 +124,6 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final Observer[] a = { null };
 
-        @SuppressWarnings("resource")
         final TestObserver to = new TestObserver();
 
         Observer observer = new Observer() {
@@ -172,7 +169,6 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final Observer[] a = { null };
 
-        @SuppressWarnings("resource")
         final TestObserver to = new TestObserver();
 
         Observer observer = new Observer() {
@@ -217,19 +213,9 @@ public class HalfSerializerObserverTest extends RxJavaTest {
             final TestObserver<Integer> to = new TestObserver<>();
             to.onSubscribe(Disposable.empty());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onNext(to, 1, wip, error);
-                }
-            };
+            Runnable r1 = () -> HalfSerializer.onNext(to, 1, wip, error);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onComplete(to, wip, error);
-                }
-            };
+            Runnable r2 = () -> HalfSerializer.onComplete(to, wip, error);
 
             TestHelper.race(r1, r2);
 
@@ -253,19 +239,9 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onError(to, ex, wip, error);
-                }
-            };
+            Runnable r1 = () -> HalfSerializer.onError(to, ex, wip, error);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onComplete(to, wip, error);
-                }
-            };
+            Runnable r2 = () -> HalfSerializer.onComplete(to, wip, error);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerSubscriberTest.java
@@ -219,19 +219,9 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
             ts.onSubscribe(new BooleanSubscription());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onNext(ts, 1, wip, error);
-                }
-            };
+            Runnable r1 = () -> HalfSerializer.onNext(ts, 1, wip, error);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onComplete(ts, wip, error);
-                }
-            };
+            Runnable r2 = () -> HalfSerializer.onComplete(ts, wip, error);
 
             TestHelper.race(r1, r2);
 
@@ -255,19 +245,9 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onError(ts, ex, wip, error);
-                }
-            };
+            Runnable r1 = () -> HalfSerializer.onError(ts, ex, wip, error);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    HalfSerializer.onComplete(ts, wip, error);
-                }
-            };
+            Runnable r2 = () -> HalfSerializer.onComplete(ts, wip, error);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/MergerBiFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/MergerBiFunctionTest.java
@@ -25,12 +25,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void firstEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(Integer::compareTo);
         List<Integer> list = merger.apply(Collections.<Integer>emptyList(), Arrays.asList(3, 5));
 
         assertEquals(Arrays.asList(3, 5), list);
@@ -38,12 +33,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void bothEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(Integer::compareTo);
         List<Integer> list = merger.apply(Collections.<Integer>emptyList(), Collections.<Integer>emptyList());
 
         assertEquals(Collections.<Integer>emptyList(), list);
@@ -51,12 +41,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void secondEmpty() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(Integer::compareTo);
         List<Integer> list = merger.apply(Arrays.asList(2, 4), Collections.<Integer>emptyList());
 
         assertEquals(Arrays.asList(2, 4), list);
@@ -64,12 +49,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void sameSize() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(Integer::compareTo);
         List<Integer> list = merger.apply(Arrays.asList(2, 4), Arrays.asList(3, 5));
 
         assertEquals(Arrays.asList(2, 3, 4, 5), list);
@@ -77,12 +57,7 @@ public class MergerBiFunctionTest extends RxJavaTest {
 
     @Test
     public void sameSizeReverse() throws Exception {
-        MergerBiFunction<Integer> merger = new MergerBiFunction<>(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                return o1.compareTo(o2);
-            }
-        });
+        MergerBiFunction<Integer> merger = new MergerBiFunction<>(Integer::compareTo);
         List<Integer> list = merger.apply(Arrays.asList(3, 5), Arrays.asList(2, 4));
 
         assertEquals(Arrays.asList(2, 3, 4, 5), list);

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeCreateTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -33,16 +32,13 @@ public class MaybeCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onSuccess(1);
-                    e.onError(new TestException());
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                }
+                e.onSuccess(1);
+                e.onError(new TestException());
+                e.onSuccess(2);
+                e.onError(new TestException());
             }).test().assertResult(1);
 
             assertTrue(d.isDisposed());
@@ -59,22 +55,14 @@ public class MaybeCreateTest extends RxJavaTest {
             final Disposable d1 = Disposable.empty();
             final Disposable d2 = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d1);
-                    e.setCancellable(new Cancellable() {
-                        @Override
-                        public void cancel() throws Exception {
-                            d2.dispose();
-                        }
-                    });
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d1);
+                e.setCancellable(d2::dispose);
 
-                    e.onSuccess(1);
-                    e.onError(new TestException());
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                }
+                e.onSuccess(1);
+                e.onError(new TestException());
+                e.onSuccess(2);
+                e.onError(new TestException());
             }).test().assertResult(1);
 
             assertTrue(d1.isDisposed());
@@ -92,15 +80,12 @@ public class MaybeCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onError(new TestException());
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                }
+                e.onError(new TestException());
+                e.onSuccess(2);
+                e.onError(new TestException());
             }).test().assertFailure(TestException.class);
 
             assertTrue(d.isDisposed());
@@ -117,15 +102,12 @@ public class MaybeCreateTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onComplete();
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                }
+                e.onComplete();
+                e.onSuccess(2);
+                e.onError(new TestException());
             }).test().assertComplete();
 
             assertTrue(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeRetryTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 public class MaybeRetryTest extends RxJavaTest {
@@ -31,22 +30,16 @@ public class MaybeRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Maybe.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Maybe.fromCallable((Callable<Boolean>) () -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                throw new IllegalArgumentException();
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            throw new IllegalArgumentException();
         })
-            .retry(Integer.MAX_VALUE, new Predicate<Throwable>() {
-                @Override public boolean test(final Throwable throwable) throws Exception {
-                    return !(throwable instanceof IllegalArgumentException);
-                }
-            })
+            .retry(Integer.MAX_VALUE, throwable -> !(throwable instanceof IllegalArgumentException))
             .test()
             .assertFailure(IllegalArgumentException.class);
 
@@ -58,16 +51,14 @@ public class MaybeRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Maybe.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Maybe.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(2, Functions.alwaysTrue())
             .test()
@@ -81,16 +72,14 @@ public class MaybeRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(3);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Maybe.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Maybe.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(1, Functions.alwaysTrue())
             .test()
@@ -104,16 +93,14 @@ public class MaybeRetryTest extends RxJavaTest {
         final AtomicInteger atomicInteger = new AtomicInteger(2);
         final AtomicInteger numberOfSubscribeCalls = new AtomicInteger(0);
 
-        Maybe.fromCallable(new Callable<Boolean>() {
-            @Override public Boolean call() throws Exception {
-                numberOfSubscribeCalls.incrementAndGet();
+        Maybe.fromCallable(() -> {
+            numberOfSubscribeCalls.incrementAndGet();
 
-                if (atomicInteger.decrementAndGet() != 0) {
-                    throw new RuntimeException();
-                }
-
-                return true;
+            if (atomicInteger.decrementAndGet() != 0) {
+                throw new RuntimeException();
             }
+
+            return true;
         })
             .retry(0, Functions.alwaysTrue())
             .test()

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -212,12 +212,9 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void wrapCustom() {
-        Maybe.wrap(new MaybeSource<Integer>() {
-            @Override
-            public void subscribe(MaybeObserver<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onSuccess(1);
-            }
+        Maybe.wrap((MaybeSource<Integer>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onSuccess(1);
         })
         .test()
         .assertResult(1);
@@ -240,23 +237,15 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void liftJust() {
-        Maybe.just(1).lift(new MaybeOperator<Integer, Integer>() {
-            @Override
-            public MaybeObserver<? super Integer> apply(MaybeObserver<? super Integer> t) throws Exception {
-                return t;
-            }
-        })
+        Maybe.just(1).lift((MaybeOperator<Integer, Integer>) t -> t)
         .test()
         .assertResult(1);
     }
 
     @Test
     public void liftThrows() {
-        Maybe.just(1).lift(new MaybeOperator<Integer, Integer>() {
-            @Override
-            public MaybeObserver<? super Integer> apply(MaybeObserver<? super Integer> t) throws Exception {
-                throw new TestException();
-            }
+        Maybe.just(1).lift((MaybeOperator<Integer, Integer>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -264,11 +253,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void deferThrows() {
-        Maybe.defer(new Supplier<Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        Maybe.defer((Supplier<Maybe<Integer>>) () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -276,12 +262,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void deferReturnsNull() {
-        Maybe.defer(new Supplier<Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> get() throws Exception {
-                return null;
-            }
-        })
+        Maybe.defer((Supplier<Maybe<Integer>>) () -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -323,12 +304,9 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void unsafeCreate() {
-        Maybe.unsafeCreate(new MaybeSource<Integer>() {
-            @Override
-            public void subscribe(MaybeObserver<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onSuccess(1);
-            }
+        Maybe.unsafeCreate((MaybeSource<Integer>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onSuccess(1);
         })
         .test()
         .assertResult(1);
@@ -336,143 +314,79 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void to() {
-        Maybe.just(1).to(new MaybeConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Maybe<Integer> v) {
-                return v.toFlowable();
-            }
-        })
+        Maybe.just(1).to(Maybe::toFlowable)
         .test()
         .assertResult(1);
     }
 
     @Test
     public void as() {
-        Maybe.just(1).to(new MaybeConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Maybe<Integer> v) {
-                return v.toFlowable();
-            }
-        })
+        Maybe.just(1).to(Maybe::toFlowable)
         .test()
         .assertResult(1);
     }
 
     @Test
     public void compose() {
-        Maybe.just(1).compose(new MaybeTransformer<Integer, Integer>() {
-            @Override
-            public MaybeSource<Integer> apply(Maybe<Integer> m) {
-                return m.map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer w) throws Exception {
-                        return w + 1;
-                    }
-                });
-            }
-        })
+        Maybe.just(1).compose(m -> m.map(w -> w + 1))
         .test()
         .assertResult(2);
     }
 
     @Test
     public void mapReturnNull() {
-        Maybe.just(1).map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                return null;
-            }
-        }).test().assertFailure(NullPointerException.class);
+        Maybe.just(1).map(_ -> null).test().assertFailure(NullPointerException.class);
     }
 
     @Test
     public void mapThrows() {
-        Maybe.just(1).map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new IOException();
-            }
+        Maybe.just(1).map(_ -> {
+            throw new IOException();
         }).test().assertFailure(IOException.class);
     }
 
     @Test
     public void map() {
-        Maybe.just(1).map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer v) throws Exception {
-                return v.toString();
-            }
-        }).test().assertResult("1");
+        Maybe.just(1).map(Object::toString).test().assertResult("1");
     }
 
     @Test
     public void filterThrows() {
-        Maybe.just(1).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new IOException();
-            }
+        Maybe.just(1).filter(_ -> {
+            throw new IOException();
         }).test().assertFailure(IOException.class);
     }
 
     @Test
     public void filterTrue() {
-        Maybe.just(1).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v == 1;
-            }
-        }).test().assertResult(1);
+        Maybe.just(1).filter(v -> v == 1).test().assertResult(1);
     }
 
     @Test
     public void filterFalse() {
-        Maybe.just(2).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v == 1;
-            }
-        }).test().assertResult();
+        Maybe.just(2).filter(v -> v == 1).test().assertResult();
     }
 
     @Test
     public void filterEmpty() {
-        Maybe.<Integer>empty().filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v == 1;
-            }
-        }).test().assertResult();
+        Maybe.<Integer>empty().filter(v -> v == 1).test().assertResult();
     }
 
     @Test
     public void singleFilterThrows() {
-        Single.just(1).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new IOException();
-            }
+        Single.just(1).filter(_ -> {
+            throw new IOException();
         }).test().assertFailure(IOException.class);
     }
 
     @Test
     public void singleFilterTrue() {
-        Single.just(1).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v == 1;
-            }
-        }).test().assertResult(1);
+        Single.just(1).filter(v -> v == 1).test().assertResult(1);
     }
 
     @Test
     public void singleFilterFalse() {
-        Single.just(2).filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v == 1;
-            }
-        }).test().assertResult();
+        Single.just(2).filter(v -> v == 1).test().assertResult();
     }
 
     @Test
@@ -487,12 +401,7 @@ public class MaybeTest extends RxJavaTest {
         String main = Thread.currentThread().getName();
         TestObserver<String> to = Maybe.just(1)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer v) throws Exception {
-                return v + ": " + Thread.currentThread().getName();
-            }
-        })
+        .map(v -> v + ": " + Thread.currentThread().getName())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -528,23 +437,13 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void observeOnDoubleSubscribe() {
-        TestHelper.checkDoubleOnSubscribeMaybe(new Function<Maybe<Object>, MaybeSource<Object>>() {
-            @Override
-            public MaybeSource<Object> apply(Maybe<Object> m) throws Exception {
-                return m.observeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeMaybe(m -> m.observeOn(Schedulers.single()));
     }
 
     @Test
     public void subscribeOnSuccess() {
         String main = Thread.currentThread().getName();
-        TestObserver<String> to = Maybe.fromCallable(new Callable<String>() {
-            @Override
-            public String call() throws Exception {
-                return Thread.currentThread().getName();
-            }
-        })
+        TestObserver<String> to = Maybe.fromCallable(() -> Thread.currentThread().getName())
         .subscribeOn(Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -561,12 +460,7 @@ public class MaybeTest extends RxJavaTest {
         final String[] name = { null };
 
         Maybe.error(new TestException()).observeOn(Schedulers.single())
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                name[0] = Thread.currentThread().getName();
-            }
-        })
+        .doOnError(_ -> name[0] = Thread.currentThread().getName())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class)
@@ -582,12 +476,7 @@ public class MaybeTest extends RxJavaTest {
         final String[] name = { null };
 
         Maybe.empty().observeOn(Schedulers.single())
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                name[0] = Thread.currentThread().getName();
-            }
-        })
+        .doOnComplete(() -> name[0] = Thread.currentThread().getName())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult()
@@ -620,12 +509,7 @@ public class MaybeTest extends RxJavaTest {
     public void fromAction() {
         final int[] call = { 0 };
 
-        Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        Maybe.fromAction(() -> call[0]++)
         .test()
         .assertResult();
 
@@ -634,11 +518,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void fromActionThrows() {
-        Maybe.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new TestException();
-            }
+        Maybe.fromAction(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -648,12 +529,7 @@ public class MaybeTest extends RxJavaTest {
     public void fromRunnable() {
         final int[] call = { 0 };
 
-        Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                call[0]++;
-            }
-        })
+        Maybe.fromRunnable(() -> call[0]++)
         .test()
         .assertResult();
 
@@ -662,11 +538,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void fromRunnableThrows() {
-        Maybe.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new TestException();
-            }
+        Maybe.fromRunnable(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -674,11 +547,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void fromCallableThrows() {
-        Maybe.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        Maybe.fromCallable(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -688,12 +558,7 @@ public class MaybeTest extends RxJavaTest {
     public void doOnSuccess() {
         final Integer[] value = { null };
 
-        Maybe.just(1).doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                value[0] = v;
-            }
-        })
+        Maybe.just(1).doOnSuccess(v -> value[0] = v)
         .test()
         .assertResult(1);
 
@@ -704,12 +569,7 @@ public class MaybeTest extends RxJavaTest {
     public void doOnSuccessEmpty() {
         final Integer[] value = { null };
 
-        Maybe.<Integer>empty().doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                value[0] = v;
-            }
-        })
+        Maybe.<Integer>empty().doOnSuccess(v -> value[0] = v)
         .test()
         .assertResult();
 
@@ -718,11 +578,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void doOnSuccessThrows() {
-        Maybe.just(1).doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        Maybe.just(1).doOnSuccess(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -732,12 +589,7 @@ public class MaybeTest extends RxJavaTest {
     public void doOnSubscribe() {
         final Disposable[] value = { null };
 
-        Maybe.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable v) throws Exception {
-                value[0] = v;
-            }
-        })
+        Maybe.just(1).doOnSubscribe(v -> value[0] = v)
         .test()
         .assertResult(1);
 
@@ -746,11 +598,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void doOnSubscribeThrows() {
-        Maybe.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable v) throws Exception {
-                throw new TestException();
-            }
+        Maybe.just(1).doOnSubscribe(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -758,11 +607,8 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void doOnCompleteThrows() {
-        Maybe.empty().doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new TestException();
-            }
+        Maybe.empty().doOnComplete(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -772,12 +618,7 @@ public class MaybeTest extends RxJavaTest {
     public void doOnDispose() {
         final int[] call = { 0 };
 
-        Maybe.just(1).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        Maybe.just(1).doOnDispose(() -> call[0]++)
         .to(TestHelper.<Integer>testConsumer(true))
         .assertSubscribed()
         .assertNoValues()
@@ -794,11 +635,8 @@ public class MaybeTest extends RxJavaTest {
         try {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
-            TestObserverEx<Integer> to = pp.singleElement().doOnDispose(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            TestObserverEx<Integer> to = pp.singleElement().doOnDispose(() -> {
+                throw new TestException();
             })
             .to(TestHelper.<Integer>testConsumer());
 
@@ -827,12 +665,9 @@ public class MaybeTest extends RxJavaTest {
 
         Maybe.just(1)
         .observeOn(Schedulers.single())
-        .doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (!cdl.await(5, TimeUnit.SECONDS)) {
-                    throw new TimeoutException();
-                }
+        .doOnSuccess(_ -> {
+            if (!cdl.await(5, TimeUnit.SECONDS)) {
+                throw new TimeoutException();
             }
         })
         .toFlowable().subscribe(ts);
@@ -850,18 +685,10 @@ public class MaybeTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.just(1)
-        .doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doAfterTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                if (call[0] == 1) {
-                    call[0] = -1;
-                }
+        .doOnSuccess(_ -> call[0]++)
+        .doAfterTerminate(() -> {
+            if (call[0] == 1) {
+                call[0] = -1;
             }
         })
         .test()
@@ -875,18 +702,10 @@ public class MaybeTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.error(new TestException())
-        .doOnError(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doAfterTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                if (call[0] == 1) {
-                    call[0] = -1;
-                }
+        .doOnError((Consumer<Object>) _ -> call[0]++)
+        .doAfterTerminate(() -> {
+            if (call[0] == 1) {
+                call[0] = -1;
             }
         })
         .test()
@@ -900,18 +719,10 @@ public class MaybeTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Maybe.empty()
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
-        .doAfterTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                if (call[0] == 1) {
-                    call[0] = -1;
-                }
+        .doOnComplete(() -> call[0]++)
+        .doAfterTerminate(() -> {
+            if (call[0] == 1) {
+                call[0] = -1;
             }
         })
         .test()
@@ -923,11 +734,8 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void sourceThrowsNPE() {
         try {
-            Maybe.unsafeCreate(new MaybeSource<Object>() {
-                @Override
-                public void subscribe(MaybeObserver<? super Object> observer) {
-                    throw new NullPointerException("Forced failure");
-                }
+            Maybe.unsafeCreate(_ -> {
+                throw new NullPointerException("Forced failure");
             }).test();
 
             fail("Should have thrown!");
@@ -939,11 +747,8 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void sourceThrowsIAE() {
         try {
-            Maybe.unsafeCreate(new MaybeSource<Object>() {
-                @Override
-                public void subscribe(MaybeObserver<? super Object> observer) {
-                    throw new IllegalArgumentException("Forced failure");
-                }
+            Maybe.unsafeCreate(_ -> {
+                throw new IllegalArgumentException("Forced failure");
             }).test();
 
             fail("Should have thrown!");
@@ -955,48 +760,28 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void flatMap() {
-        Maybe.just(1).flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v * 10);
-            }
-        })
+        Maybe.just(1).flatMap(v -> Maybe.just(v * 10))
         .test()
         .assertResult(10);
     }
 
     @Test
     public void concatMap() {
-        Maybe.just(1).concatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v * 10);
-            }
-        })
+        Maybe.just(1).concatMap(v -> Maybe.just(v * 10))
         .test()
         .assertResult(10);
     }
 
     @Test
     public void flatMapEmpty() {
-        Maybe.just(1).flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        })
+        Maybe.just(1).flatMap(_ -> Maybe.empty())
         .test()
         .assertResult();
     }
 
     @Test
     public void flatMapError() {
-        Maybe.just(1).flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        })
+        Maybe.just(1).flatMap(_ -> Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
@@ -1004,25 +789,10 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void flatMapNotifySuccess() {
         Maybe.just(1)
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v * 10);
-            }
-        },
-        new Function<Throwable, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Throwable v) throws Exception {
-                return Maybe.just(100);
-            }
-        },
+        .flatMap(v -> Maybe.just(v * 10),
+                (Function<Throwable, MaybeSource<Integer>>) _ -> Maybe.just(100),
 
-        new Supplier<MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> get() throws Exception {
-                return Maybe.just(200);
-            }
-        })
+                (Supplier<MaybeSource<Integer>>) () -> Maybe.just(200))
         .test()
         .assertResult(10);
     }
@@ -1030,25 +800,10 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void flatMapNotifyError() {
         Maybe.<Integer>error(new TestException())
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v * 10);
-            }
-        },
-        new Function<Throwable, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Throwable v) throws Exception {
-                return Maybe.just(100);
-            }
-        },
+        .flatMap(v -> Maybe.just(v * 10),
+                (Function<Throwable, MaybeSource<Integer>>) _ -> Maybe.just(100),
 
-        new Supplier<MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> get() throws Exception {
-                return Maybe.just(200);
-            }
-        })
+                (Supplier<MaybeSource<Integer>>) () -> Maybe.just(200))
         .test()
         .assertResult(100);
     }
@@ -1056,25 +811,10 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void flatMapNotifyComplete() {
         Maybe.<Integer>empty()
-        .flatMap(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v * 10);
-            }
-        },
-        new Function<Throwable, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Throwable v) throws Exception {
-                return Maybe.just(100);
-            }
-        },
+        .flatMap(v -> Maybe.just(v * 10),
+                (Function<Throwable, MaybeSource<Integer>>) _ -> Maybe.just(100),
 
-        new Supplier<MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> get() throws Exception {
-                return Maybe.just(200);
-            }
-        })
+                (Supplier<MaybeSource<Integer>>) () -> Maybe.just(200))
         .test()
         .assertResult(200);
     }
@@ -1419,17 +1159,14 @@ public class MaybeTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onSuccess(1);
-                    e.onError(new TestException());
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                    e.onComplete();
-                }
+                e.onSuccess(1);
+                e.onError(new TestException());
+                e.onSuccess(2);
+                e.onError(new TestException());
+                e.onComplete();
             })
             .test()
             .assertResult(1);
@@ -1449,16 +1186,13 @@ public class MaybeTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onError(new TestException());
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                    e.onComplete();
-                }
+                e.onError(new TestException());
+                e.onSuccess(2);
+                e.onError(new TestException());
+                e.onComplete();
             })
             .test()
             .assertFailure(TestException.class);
@@ -1477,18 +1211,15 @@ public class MaybeTest extends RxJavaTest {
         try {
             final Disposable d = Disposable.empty();
 
-            Maybe.<Integer>create(new MaybeOnSubscribe<Integer>() {
-                @Override
-                public void subscribe(MaybeEmitter<Integer> e) throws Exception {
-                    e.setDisposable(d);
+            Maybe.<Integer>create(e -> {
+                e.setDisposable(d);
 
-                    e.onComplete();
-                    e.onSuccess(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                    e.onSuccess(2);
-                    e.onError(new TestException());
-                }
+                e.onComplete();
+                e.onSuccess(1);
+                e.onError(new TestException());
+                e.onComplete();
+                e.onSuccess(2);
+                e.onError(new TestException());
             })
             .test()
             .assertResult();
@@ -1850,12 +1581,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void ambIterableIteratorNull() {
-        Maybe.amb(new Iterable<Maybe<Object>>() {
-            @Override
-            public Iterator<Maybe<Object>> iterator() {
-                return null;
-            }
-        }).test().assertError(NullPointerException.class);
+        Maybe.amb((Iterable<Maybe<Object>>) () -> null).test().assertError(NullPointerException.class);
     }
 
     @Test
@@ -2005,18 +1731,12 @@ public class MaybeTest extends RxJavaTest {
             .assertFusionMode(QueueFuseable.ASYNC)
             ;
 
-            TestHelper.race(new Runnable() {
-                @Override
-                public void run() {
-                    pp1.onNext(1);
-                    pp1.onComplete();
-                }
-            }, new Runnable() {
-                @Override
-                public void run() {
-                    pp2.onNext(1);
-                    pp2.onComplete();
-                }
+            TestHelper.race(() -> {
+                pp1.onNext(1);
+                pp1.onComplete();
+            }, () -> {
+                pp2.onNext(1);
+                pp2.onComplete();
             });
 
             ts
@@ -2163,12 +1883,7 @@ public class MaybeTest extends RxJavaTest {
     public void subscribeToOnSuccess() {
         final List<Integer> values = new ArrayList<>();
 
-        Consumer<Integer> onSuccess = new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                values.add(e);
-            }
-        };
+        Consumer<Integer> onSuccess = values::add;
 
         Maybe<Integer> source = Maybe.just(1);
 
@@ -2183,12 +1898,7 @@ public class MaybeTest extends RxJavaTest {
     public void subscribeToOnError() {
         final List<Throwable> values = new ArrayList<>();
 
-        Consumer<Throwable> onError = new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                values.add(e);
-            }
-        };
+        Consumer<Throwable> onError = values::add;
 
         TestException ex = new TestException();
 
@@ -2204,12 +1914,7 @@ public class MaybeTest extends RxJavaTest {
     public void subscribeToOnComplete() {
         final List<Integer> values = new ArrayList<>();
 
-        Action onComplete = new Action() {
-            @Override
-            public void run() throws Exception {
-                values.add(100);
-            }
-        };
+        Action onComplete = () -> values.add(100);
 
         Maybe<Integer> source = Maybe.empty();
 
@@ -2252,12 +1957,9 @@ public class MaybeTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         assertTrue(Maybe.just(1)
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                list.add(v);
-                list.add(e);
-            }
+        .doOnEvent((v, e) -> {
+            list.add(v);
+            list.add(e);
         })
         .subscribe().isDisposed());
 
@@ -2273,12 +1975,9 @@ public class MaybeTest extends RxJavaTest {
             TestException ex = new TestException();
 
             assertTrue(Maybe.<Integer>error(ex)
-            .doOnEvent(new BiConsumer<Integer, Throwable>() {
-                @Override
-                public void accept(Integer v, Throwable e) throws Exception {
-                    list.add(v);
-                    list.add(e);
-                }
+            .doOnEvent((v, e) -> {
+                list.add(v);
+                list.add(e);
             })
             .subscribe().isDisposed());
 
@@ -2295,12 +1994,9 @@ public class MaybeTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         assertTrue(Maybe.<Integer>empty()
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                list.add(v);
-                list.add(e);
-            }
+        .doOnEvent((v, e) -> {
+            list.add(v);
+            list.add(e);
         })
         .subscribe().isDisposed());
 
@@ -2310,11 +2006,8 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void doOnEventSuccessThrows() {
         Maybe.just(1)
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .doOnEvent((_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -2323,11 +2016,8 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void doOnEventErrorThrows() {
         TestObserverEx<Integer> to = Maybe.<Integer>error(new TestException("Outer"))
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnEvent((_, _) -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
@@ -2341,11 +2031,8 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void doOnEventCompleteThrows() {
         Maybe.<Integer>empty()
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .doOnEvent((_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -2468,13 +2155,9 @@ public class MaybeTest extends RxJavaTest {
     static Future<Integer> emptyFuture() {
         final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
 
-        return exec.schedule(new Callable<Integer>() {
-
-            @Override
-            public Integer call() throws Exception {
-                exec.shutdown();
-                return null;
-            }
+        return exec.schedule(() -> {
+            exec.shutdown();
+            return null;
         }, 200, TimeUnit.MILLISECONDS);
     }
 
@@ -2607,11 +2290,8 @@ public class MaybeTest extends RxJavaTest {
             RxJavaPlugins.reset();
         }
 
-        Maybe.sequenceEqual(Maybe.just(1), Maybe.error(new TestException()), new BiPredicate<Object, Object>() {
-            @Override
-            public boolean test(Object t1, Object t2) throws Exception {
-                throw new TestException();
-            }
+        Maybe.sequenceEqual(Maybe.just(1), Maybe.error(new TestException()), (BiPredicate<Object, Object>) (_, _) -> {
+            throw new TestException();
         })
         .test().assertFailure(TestException.class);
     }
@@ -2647,52 +2327,22 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void flatMapContinuation() {
-        Maybe.just(1).flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        Maybe.just(1).flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete())
         .test().assertResult();
 
-        Maybe.just(1).flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        })
+        Maybe.just(1).flatMapCompletable((Function<Integer, Completable>) _ -> Completable.error(new TestException()))
         .test().assertFailure(TestException.class);
 
-        Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(1, 5);
-            }
-        })
+        Maybe.just(1).flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.range(1, 5))
         .test().assertResult(1, 2, 3, 4, 5);
 
-        Maybe.just(1).flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.error(new TestException());
-            }
-        })
+        Maybe.just(1).flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.error(new TestException()))
         .test().assertFailure(TestException.class);
 
-        Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 5);
-            }
-        })
+        Maybe.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) _ -> Observable.range(1, 5))
         .test().assertResult(1, 2, 3, 4, 5);
 
-        Maybe.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        })
+        Maybe.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) _ -> Observable.error(new TestException()))
         .test().assertFailure(TestException.class);
     }
 
@@ -2700,23 +2350,8 @@ public class MaybeTest extends RxJavaTest {
     public void using() {
         final AtomicInteger disposeCount = new AtomicInteger();
 
-        Maybe.using(Functions.justSupplier(1), new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) throws Exception {
-                disposeCount.set(d);
-            }
-        })
-        .map(new Function<Integer, Object>() {
-            @Override
-            public String apply(Integer v) throws Exception {
-                return "" + disposeCount.get() + v * 10;
-            }
-        })
+        Maybe.using(Functions.justSupplier(1), Maybe::just, disposeCount::set)
+        .map((Function<Integer, Object>) v -> "" + disposeCount.get() + v * 10)
         .test()
         .assertResult("110");
     }
@@ -2725,35 +2360,15 @@ public class MaybeTest extends RxJavaTest {
     public void usingNonEager() {
         final AtomicInteger disposeCount = new AtomicInteger();
 
-        Maybe.using(Functions.justSupplier(1), new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, new Consumer<Integer>() {
-            @Override
-            public void accept(Integer d) throws Exception {
-                disposeCount.set(d);
-            }
-        }, false)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public String apply(Integer v) throws Exception {
-                return "" + disposeCount.get() + v * 10;
-            }
-        })
+        Maybe.using(Functions.justSupplier(1), Maybe::just, disposeCount::set, false)
+        .map((Function<Integer, Object>) v -> "" + disposeCount.get() + v * 10)
         .test()
         .assertResult("010");
 
         assertEquals(1, disposeCount.get());
     }
 
-    Function<Object[], String> arrayToString = new Function<Object[], String>() {
-        @Override
-        public String apply(Object[] a) throws Exception {
-            return Arrays.toString(a);
-        }
-    };
+    Function<Object[], String> arrayToString = Arrays::toString;
 
     @SuppressWarnings("unchecked")
     @Test
@@ -2925,15 +2540,12 @@ public class MaybeTest extends RxJavaTest {
     @Test
     public void zipIterableObject() {
         final List<Maybe<Integer>> maybes = Arrays.asList(Maybe.just(1), Maybe.just(4));
-        Maybe.zip(maybes, new Function<Object[], Object>() {
-            @Override
-            public Object apply(final Object[] o) throws Exception {
-                int sum = 0;
-                for (Object i : o) {
-                    sum += (Integer) i;
-                }
-                return sum;
+        Maybe.zip(maybes, (Function<Object[], Object>) o -> {
+            int sum = 0;
+            for (Object i : o) {
+                sum += (Integer) i;
             }
+            return sum;
         }).test().assertResult(5);
     }
 
@@ -3012,19 +2624,9 @@ public class MaybeTest extends RxJavaTest {
 
         Maybe.just(1).repeat(5).test().assertResult(1, 1, 1, 1, 1);
 
-        Maybe.just(1).repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        }).take(5).test().assertResult(1, 1, 1, 1, 1);
+        Maybe.just(1).repeatUntil(() -> false).take(5).test().assertResult(1, 1, 1, 1, 1);
 
-        Maybe.just(1).repeatWhen(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> v) throws Exception {
-                return v;
-            }
-        }).take(5).test().assertResult(1, 1, 1, 1, 1);
+        Maybe.just(1).repeatWhen((Function<Flowable<Object>, Publisher<Object>>) v -> v).take(5).test().assertResult(1, 1, 1, 1, 1);
     }
 
     @Test
@@ -3037,36 +2639,17 @@ public class MaybeTest extends RxJavaTest {
 
         Maybe.just(1).retry(5, Functions.alwaysTrue()).test().assertResult(1);
 
-        Maybe.just(1).retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer a, Throwable e) throws Exception {
-                return true;
-            }
-        }).test().assertResult(1);
+        Maybe.just(1).retry((_, _) -> true).test().assertResult(1);
 
-        Maybe.just(1).retryUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        }).test().assertResult(1);
+        Maybe.just(1).retryUntil(() -> false).test().assertResult(1);
 
-        Maybe.just(1).retryWhen(new Function<Flowable<? extends Throwable>, Publisher<Object>>() {
-            @SuppressWarnings({ "rawtypes", "unchecked" })
-            @Override
-            public Publisher<Object> apply(Flowable<? extends Throwable> v) throws Exception {
-                return (Publisher)v;
-            }
-        }).test().assertResult(1);
+        Maybe.just(1).retryWhen(v -> v).test().assertResult(1);
 
         final AtomicInteger calls = new AtomicInteger();
         try {
-            Maybe.error(new Supplier<Throwable>() {
-                @Override
-                public Throwable get() {
-                    calls.incrementAndGet();
-                    return new TestException();
-                }
+            Maybe.error(() -> {
+                calls.incrementAndGet();
+                return new TestException();
             }).retry(5).test();
         } finally {
             assertEquals(6, calls.get());

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -646,7 +646,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>();
 
         try {
@@ -672,7 +671,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>();
 
         Thread.currentThread().interrupt();
@@ -686,7 +684,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>();
 
         TestException e = new TestException();
@@ -715,7 +712,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        @SuppressWarnings("resource")
         TestObserver<Object> to = new TestObserver<>();
         to.onError(new RuntimeException());
         try {
@@ -734,7 +730,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>();
 
         to.onSubscribe(Disposable.empty());
@@ -762,7 +757,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>();
 
         to.onComplete();
@@ -772,7 +766,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
 
             @Override
@@ -809,7 +802,6 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        @SuppressWarnings("resource")
         TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
@@ -256,19 +256,9 @@ public class MaybeSubjectTest extends RxJavaTest {
 
             final TestObserver<Integer> to = ms.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ms.test();
-                }
-            };
+            Runnable r1 = ms::test;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = to::dispose;
             TestHelper.race(r1, r2);
         }
     }


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080

Also fixed the ParallelScheduler test leak, detected in #8159.