### PR TITLE
4.x: Unit test lambdaification 19 of N

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava4/core/MemoryPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/MemoryPerf.java
@@ -20,6 +20,10 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.processors.*;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+import io.reactivex.rxjava4.subjects.*;
 
 /**
  * Measure various prepared flows about their memory usage and print the result
@@ -141,390 +145,117 @@ public final class MemoryPerf {
 
         // ---------------------------------------------------------------------------------------------------------------------
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.just(1);
-            }
-        }, "just", "Rx2Observable");
+        checkMemory(() -> Observable.just(1), "just", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10);
-            }
-        }, "range", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10), "range", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.empty();
-            }
-        }, "empty", "Rx2Observable");
+        checkMemory(Observable::empty, "empty", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() {
-                        return 1;
-                    }
-                });
-            }
-        }, "fromCallable", "Rx2Observable");
+        checkMemory(() -> Observable.fromCallable(() -> 1), "fromCallable", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return new MyRx2Observer();
-            }
-        }, "consumer", "Rx2Observable");
+        checkMemory(MyRx2Observer::new, "consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return new io.reactivex.rxjava4.observers.TestObserver<>();
-            }
-        }, "test-consumer", "Rx2Observable");
+        checkMemory(TestObserver::new, "test-consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.just(1).subscribeWith(new MyRx2Observer());
-            }
-        }, "just+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.just(1).subscribeWith(new MyRx2Observer()), "just+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).subscribeWith(new MyRx2Observer());
-            }
-        }, "range+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10).subscribeWith(new MyRx2Observer()), "range+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) {
-                        return v;
-                    }
-                }).subscribeWith(new MyRx2Observer());
-            }
-        }, "range+map+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10).map((Function<Integer, Object>) v -> v).subscribeWith(new MyRx2Observer()), "range+map+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) {
-                        return v;
-                    }
-                }).filter(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) {
-                        return true;
-                    }
-                }).subscribeWith(new MyRx2Observer());
-            }
-        }, "range+map+filter+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10).map((Function<Integer, Object>) v -> v).filter(_ -> true)
+                .subscribeWith(new MyRx2Observer()), "range+map+filter+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10)
-                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Observer());
-            }
-        }, "range+subscribeOn+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10)
+                .subscribeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Observer()), "range+subscribeOn+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10)
-                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Observer());
-            }
-        }, "range+observeOn+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10)
+                .observeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Observer()), "range+observeOn+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Observable.range(1, 10)
-                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Observer());
-            }
-        }, "range+subscribeOn+observeOn+consumer", "Rx2Observable");
+        checkMemory(() -> Observable.range(1, 10)
+                .subscribeOn(Schedulers.computation())
+                .observeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Observer()), "range+subscribeOn+observeOn+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.AsyncSubject.create();
-            }
-        }, "Async", "Rx2Observable");
+        checkMemory(AsyncSubject::create, "Async", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.PublishSubject.create();
-            }
-        }, "Publish", "Rx2Observable");
+        checkMemory(PublishSubject::create, "Publish", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.ReplaySubject.create();
-            }
-        }, "Replay", "Rx2Observable");
+        checkMemory(ReplaySubject::create, "Replay", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.BehaviorSubject.create();
-            }
-        }, "Behavior", "Rx2Observable");
+        checkMemory(BehaviorSubject::create, "Behavior", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.UnicastSubject.create();
-            }
-        }, "Unicast", "Rx2Observable");
+        checkMemory(UnicastSubject::create, "Unicast", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.AsyncSubject.create().subscribeWith(new MyRx2Observer());
-            }
-        }, "Async+consumer", "Rx2Observable");
+        checkMemory(() -> AsyncSubject.create().subscribeWith(new MyRx2Observer()), "Async+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.PublishSubject.create().subscribeWith(new MyRx2Observer());
-            }
-        }, "Publish+consumer", "Rx2Observable");
+        checkMemory(() -> PublishSubject.create().subscribeWith(new MyRx2Observer()), "Publish+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.ReplaySubject.create().subscribeWith(new MyRx2Observer());
-            }
-        }, "Replay+consumer", "Rx2Observable");
+        checkMemory(() -> ReplaySubject.create().subscribeWith(new MyRx2Observer()), "Replay+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.BehaviorSubject.create().subscribeWith(new MyRx2Observer());
-            }
-        }, "Behavior+consumer", "Rx2Observable");
+        checkMemory(() -> BehaviorSubject.create().subscribeWith(new MyRx2Observer()), "Behavior+consumer", "Rx2Observable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.subjects.UnicastSubject.create().subscribeWith(new MyRx2Observer());
-            }
-        }, "Unicast+consumer", "Rx2Observable");
+        checkMemory(() -> UnicastSubject.create().subscribeWith(new MyRx2Observer()), "Unicast+consumer", "Rx2Observable");
 
         // ---------------------------------------------------------------------------------------------------------------------
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.just(1);
-            }
-        }, "just", "Rx2Flowable");
+        checkMemory(() -> Flowable.just(1), "just", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10);
-            }
-        }, "range", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10), "range", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.empty();
-            }
-        }, "empty", "Rx2Flowable");
+        checkMemory(Flowable::empty, "empty", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.empty();
-            }
-        }, "empty", "Rx2Flowable", 10000000);
+        checkMemory(Flowable::empty, "empty", "Rx2Flowable", 10000000);
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() {
-                        return 1;
-                    }
-                });
-            }
-        }, "fromCallable", "Rx2Flowable");
+        checkMemory(() -> Flowable.fromCallable(() -> 1), "fromCallable", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return new MyRx2Subscriber();
-            }
-        }, "consumer", "Rx2Flowable");
+        checkMemory(MyRx2Subscriber::new, "consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return new io.reactivex.rxjava4.observers.TestObserver<>();
-            }
-        }, "test-consumer", "Rx2Flowable");
+        checkMemory(TestObserver::new, "test-consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.just(1).subscribeWith(new MyRx2Subscriber());
-            }
-        }, "just+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.just(1).subscribeWith(new MyRx2Subscriber()), "just+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10).subscribeWith(new MyRx2Subscriber()), "range+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) {
-                        return v;
-                    }
-                }).subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+map+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10).map((Function<Integer, Object>) v -> v).subscribeWith(new MyRx2Subscriber()), "range+map+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) {
-                        return v;
-                    }
-                }).filter(new Predicate<Object>() {
-                    @Override
-                    public boolean test(Object v) {
-                        return true;
-                    }
-                }).subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+map+filter+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10).map((Function<Integer, Object>) v -> v).filter(_ -> true)
+                .subscribeWith(new MyRx2Subscriber()), "range+map+filter+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
-                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+subscribeOn+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10)
+                .subscribeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Subscriber()), "range+subscribeOn+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
-                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+observeOn+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10)
+                .observeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Subscriber()), "range+observeOn+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.core.Flowable.range(1, 10)
-                        .subscribeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .observeOn(io.reactivex.rxjava4.schedulers.Schedulers.computation())
-                        .subscribeWith(new MyRx2Subscriber());
-            }
-        }, "range+subscribeOn+observeOn+consumer", "Rx2Flowable");
+        checkMemory(() -> Flowable.range(1, 10)
+                .subscribeOn(Schedulers.computation())
+                .observeOn(Schedulers.computation())
+                .subscribeWith(new MyRx2Subscriber()), "range+subscribeOn+observeOn+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.AsyncProcessor.create();
-            }
-        }, "Async", "Rx2Flowable");
+        checkMemory(AsyncProcessor::create, "Async", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.PublishProcessor.create();
-            }
-        }, "Publish", "Rx2Flowable");
+        checkMemory(PublishProcessor::create, "Publish", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.ReplayProcessor.create();
-            }
-        }, "Replay", "Rx2Flowable");
+        checkMemory(ReplayProcessor::create, "Replay", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.BehaviorProcessor.create();
-            }
-        }, "Behavior", "Rx2Flowable");
+        checkMemory(BehaviorProcessor::create, "Behavior", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.UnicastProcessor.create();
-            }
-        }, "Unicast", "Rx2Flowable");
+        checkMemory(UnicastProcessor::create, "Unicast", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.AsyncProcessor.create().subscribeWith(new MyRx2Subscriber());
-            }
-        }, "Async+consumer", "Rx2Flowable");
+        checkMemory(() -> AsyncProcessor.create().subscribeWith(new MyRx2Subscriber()), "Async+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.PublishProcessor.create().subscribeWith(new MyRx2Subscriber());
-            }
-        }, "Publish+consumer", "Rx2Flowable");
+        checkMemory(() -> PublishProcessor.create().subscribeWith(new MyRx2Subscriber()), "Publish+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.ReplayProcessor.create().subscribeWith(new MyRx2Subscriber());
-            }
-        }, "Replay+consumer", "Rx2Flowable");
+        checkMemory(() -> ReplayProcessor.create().subscribeWith(new MyRx2Subscriber()), "Replay+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.BehaviorProcessor.create().subscribeWith(new MyRx2Subscriber());
-            }
-        }, "Behavior+consumer", "Rx2Flowable");
+        checkMemory(() -> BehaviorProcessor.create().subscribeWith(new MyRx2Subscriber()), "Behavior+consumer", "Rx2Flowable");
 
-        checkMemory(new Callable<Object>() {
-            @Override
-            public Object call() {
-                return io.reactivex.rxjava4.processors.UnicastProcessor.create().subscribeWith(new MyRx2Subscriber());
-            }
-        }, "Unicast+consumer", "Rx2Flowable");
+        checkMemory(() -> UnicastProcessor.create().subscribeWith(new MyRx2Subscriber()), "Unicast+consumer", "Rx2Flowable");
 
         // ---------------------------------------------------------------------------------------------------------------------
     }

--- a/src/jmh/java/io/reactivex/rxjava4/core/OperatorFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/OperatorFlatMapPerf.java
@@ -41,23 +41,13 @@ public class OperatorFlatMapPerf {
 
     @Benchmark
     public void flatMapIntPassthruSync(Input input) {
-        input.flowable.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        }).subscribe(input.newSubscriber());
+        input.flowable.flatMap((Function<Integer, Publisher<Integer>>) Flowable::just).subscribe(input.newSubscriber());
     }
 
     @Benchmark
     public void flatMapIntPassthruAsync(Input input) throws InterruptedException {
         PerfSubscriber latchedObserver = input.newLatchedObserver();
-        input.flowable.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer i) {
-                    return Flowable.just(i).subscribeOn(Schedulers.computation());
-            }
-        }).subscribe(latchedObserver);
+        input.flowable.flatMap((Function<Integer, Publisher<Integer>>) i -> Flowable.just(i).subscribeOn(Schedulers.computation())).subscribe(latchedObserver);
         if (input.size == 1) {
             while (latchedObserver.latch.getCount() != 0) { }
         } else {
@@ -67,12 +57,7 @@ public class OperatorFlatMapPerf {
 
     @Benchmark
     public void flatMapTwoNestedSync(final Input input) {
-        Flowable.range(1, 2).flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer i) {
-                    return input.flowable;
-            }
-        }).subscribe(input.newSubscriber());
+        Flowable.range(1, 2).flatMap((Function<Integer, Publisher<Integer>>) _ -> input.flowable).subscribe(input.newSubscriber());
     }
 
     // this runs out of memory currently

--- a/src/jmh/java/io/reactivex/rxjava4/core/OperatorMergePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/OperatorMergePerf.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
 @SuppressWarnings("exports")
@@ -31,12 +30,7 @@ public class OperatorMergePerf {
     @Benchmark
     public void oneStreamOfNthatMergesIn1(final InputMillion input) throws InterruptedException {
         Flowable<Flowable<Integer>> os = Flowable.range(1, input.size)
-                .map(new Function<Integer, Flowable<Integer>>() {
-                    @Override
-                    public Flowable<Integer> apply(Integer v) {
-                        return Flowable.just(v);
-                    }
-                });
+                .map(Flowable::just);
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
 
@@ -50,12 +44,7 @@ public class OperatorMergePerf {
     // flatMap
     @Benchmark
     public void merge1SyncStreamOfN(final InputMillion input) throws InterruptedException {
-        Flowable<Flowable<Integer>> os = Flowable.just(1).map(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer i) {
-                    return Flowable.range(0, input.size);
-            }
-        });
+        Flowable<Flowable<Integer>> os = Flowable.just(1).map(_ -> Flowable.range(0, input.size));
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
 
@@ -68,12 +57,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeNSyncStreamsOfN(final InputThousand input) throws InterruptedException {
-        Flowable<Flowable<Integer>> os = input.flowable.map(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer i) {
-                    return Flowable.range(0, input.size);
-            }
-        });
+        Flowable<Flowable<Integer>> os = input.flowable.map(_ -> Flowable.range(0, input.size));
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {
@@ -85,12 +69,7 @@ public class OperatorMergePerf {
 
     @Benchmark
     public void mergeNAsyncStreamsOfN(final InputThousand input) throws InterruptedException {
-        Flowable<Flowable<Integer>> os = input.flowable.map(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer i) {
-                    return Flowable.range(0, input.size).subscribeOn(Schedulers.computation());
-            }
-        });
+        Flowable<Flowable<Integer>> os = input.flowable.map(_ -> Flowable.range(0, input.size).subscribeOn(Schedulers.computation()));
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {

--- a/src/jmh/java/io/reactivex/rxjava4/core/RxVsStreamPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/RxVsStreamPerf.java
@@ -51,35 +51,15 @@ public class RxVsStreamPerf {
     public void setup() {
         range = Flowable.range(1, times);
 
-        rangeFlatMapJust = range.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        rangeFlatMapJust = range.flatMap((Function<Integer, Publisher<Integer>>) Flowable::just);
 
-        rangeFlatMap = range.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.range(v, 2);
-            }
-        });
+        rangeFlatMap = range.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v, 2));
 
         rangeObservable = Observable.range(1, times);
 
-        rangeObservableFlatMapJust = rangeObservable.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        rangeObservableFlatMapJust = rangeObservable.flatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        rangeObservableFlatMap = rangeObservable.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.range(v, 2);
-            }
-        });
+        rangeObservableFlatMap = rangeObservable.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.range(v, 2));
 
         values = range.toList().blockingGet();
     }

--- a/src/jmh/java/io/reactivex/rxjava4/core/XMapYPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/XMapYPerf.java
@@ -102,237 +102,77 @@ public class XMapYPerf {
 
         Flowable<Integer> fsource = Flowable.fromArray(values);
 
-        flowFlatMapFlowable1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v);
-            }
-        });
+        flowFlatMapFlowable1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) Flowable::just);
 
-        flowFlatMapFlowable0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.empty();
-            }
-        });
+        flowFlatMapFlowable0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.empty());
 
-        flowFlatMapSingle1 = fsource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        flowFlatMapSingle1 = fsource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
-        flowFlatMapMaybe1 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        flowFlatMapMaybe1 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        flowFlatMapMaybe0 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
 
-        flowFlatMapCompletable0 = fsource.flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        flowFlatMapCompletable0 = fsource.flatMapCompletable(v -> Completable.complete());
 
-        flowFlatMapIterable1 = fsource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Collections.singletonList(v);
-            }
-        });
+        flowFlatMapIterable1 = fsource.flatMapIterable((Function<Integer, Iterable<Integer>>) Collections::singletonList);
 
-        flowFlatMapIterable0 = fsource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Collections.emptyList();
-            }
-        });
+        flowFlatMapIterable0 = fsource.flatMapIterable((Function<Integer, Iterable<Integer>>) v -> Collections.emptyList());
 
-        flowFlatMapSingle1 = fsource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        flowFlatMapSingle1 = fsource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
-        flowFlatMapMaybe1 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        flowFlatMapMaybe1 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        flowFlatMapMaybe0 = fsource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
 
-        flowFlatMapCompletable0 = fsource.flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        flowFlatMapCompletable0 = fsource.flatMapCompletable(v -> Completable.complete());
 
         // ooooooooooooooooooooooooo
 
-        flowFlatMapSingleAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Single.just(v).toFlowable();
-            }
-        });
+        flowFlatMapSingleAsFlow1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Single.just(v).toFlowable());
 
-        flowFlatMapMaybeAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Maybe.just(v).toFlowable();
-            }
-        });
+        flowFlatMapMaybeAsFlow1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Maybe.just(v).toFlowable());
 
-        flowFlatMapMaybeAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toFlowable();
-            }
-        });
+        flowFlatMapMaybeAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Maybe.<Integer>empty().toFlowable());
 
-        flowFlatMapCompletableAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Completable.complete().toFlowable();
-            }
-        });
+        flowFlatMapCompletableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Completable.complete().toFlowable());
 
-        flowFlatMapIterableAsFlow1 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.fromIterable(Collections.singletonList(v));
-            }
-        });
+        flowFlatMapIterableAsFlow1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(Collections.singletonList(v)));
 
-        flowFlatMapIterableAsFlow0 = fsource.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.fromIterable(Collections.emptyList());
-            }
-        });
+        flowFlatMapIterableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(Collections.emptyList()));
 
         // -------------------------------------------------------------------
 
         Observable<Integer> osource = Observable.fromArray(values);
 
-        obsFlatMapObservable1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        obsFlatMapObservable1 = osource.flatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        obsFlatMapObservable0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.empty();
-            }
-        });
+        obsFlatMapObservable0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.empty());
 
-        obsFlatMapSingle1 = osource.flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        obsFlatMapSingle1 = osource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
-        obsFlatMapMaybe1 = osource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        obsFlatMapMaybe1 = osource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        obsFlatMapMaybe0 = osource.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) {
-                return Maybe.empty();
-            }
-        });
+        obsFlatMapMaybe0 = osource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
 
-        obsFlatMapCompletable0 = osource.flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        obsFlatMapCompletable0 = osource.flatMapCompletable(v -> Completable.complete());
 
-        obsFlatMapIterable1 = osource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Collections.singletonList(v);
-            }
-        });
+        obsFlatMapIterable1 = osource.flatMapIterable((Function<Integer, Iterable<Integer>>) Collections::singletonList);
 
-        obsFlatMapIterable0 = osource.flatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) {
-                return Collections.emptyList();
-            }
-        });
+        obsFlatMapIterable0 = osource.flatMapIterable((Function<Integer, Iterable<Integer>>) v -> Collections.emptyList());
 
         // ooooooooooooooooooooooooo
 
-        obsFlatMapSingleAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Single.just(v).toObservable();
-            }
-        });
+        obsFlatMapSingleAsObs1 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Single.just(v).toObservable());
 
-        obsFlatMapMaybeAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.just(v).toObservable();
-            }
-        });
+        obsFlatMapMaybeAsObs1 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Maybe.just(v).toObservable());
 
-        obsFlatMapMaybeAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.<Integer>empty().toObservable();
-            }
-        });
+        obsFlatMapMaybeAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Maybe.<Integer>empty().toObservable());
 
-        obsFlatMapCompletableAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Completable.complete().toObservable();
-            }
-        });
+        obsFlatMapCompletableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Completable.complete().toObservable());
 
-        obsFlatMapIterableAsObs1 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.fromIterable(Collections.singletonList(v));
-            }
-        });
+        obsFlatMapIterableAsObs1 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.fromIterable(Collections.singletonList(v)));
 
-        obsFlatMapIterableAsObs0 = osource.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.fromIterable(Collections.emptyList());
-            }
-        });
+        obsFlatMapIterableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.fromIterable(Collections.emptyList()));
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/parallel/ParallelPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/parallel/ParallelPerf.java
@@ -66,13 +66,8 @@ public class ParallelPerf implements Function<Integer, Integer> {
 
         Flowable<Integer> source = Flowable.fromArray(ints);
 
-        flatMap = source.flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) {
-                return Flowable.just(v).subscribeOn(Schedulers.computation())
-                        .map(ParallelPerf.this);
-            }
-        }, new FlatMapConfig(cpu));
+        flatMap = source.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.just(v).subscribeOn(Schedulers.computation())
+                .map(ParallelPerf.this), new FlatMapConfig(cpu));
 
         groupBy = source.groupBy(new Function<Integer, Integer>() {
             int i;
@@ -81,12 +76,7 @@ public class ParallelPerf implements Function<Integer, Integer> {
                 return (i++) % cpu;
             }
         })
-        .flatMap(new Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(GroupedFlowable<Integer, Integer> g) {
-                return g.observeOn(Schedulers.computation()).map(ParallelPerf.this);
-            }
-        });
+        .flatMap((Function<GroupedFlowable<Integer, Integer>, Publisher<Integer>>) g -> g.observeOn(Schedulers.computation()).map(ParallelPerf.this));
 
         parallel = source.parallel(cpu).runOn(Schedulers.computation()).map(this).sequential();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
@@ -211,12 +211,9 @@ public class ParallelSchedulerTest implements Runnable {
 
             Worker w = s.createWorker();
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    calls.getAndIncrement();
-                    throw new IllegalStateException();
-                }
+            w.schedule(() -> {
+                calls.getAndIncrement();
+                throw new IllegalStateException();
             });
 
             while (errors.isEmpty()) {
@@ -323,12 +320,7 @@ public class ParallelSchedulerTest implements Runnable {
             final Scheduler s = new ParallelScheduler(2, true, ParallelScheduler.DEFAULT_FACTORY);
             s.shutdown();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    s.start();
-                }
-            };
+            Runnable r = s::start;
 
             TestHelper.race(r, r, Schedulers.single());
         }
@@ -341,19 +333,9 @@ public class ParallelSchedulerTest implements Runnable {
             for (int i = 0; i < 1000; i++) {
                 final Worker w = s.createWorker();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        w.schedule(ParallelSchedulerTest.this);
-                    }
-                };
+                Runnable r1 = () -> w.schedule(ParallelSchedulerTest.this);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        w.dispose();
-                    }
-                };
+                Runnable r2 = w::dispose;
                 TestHelper.race(r1, r2, Schedulers.single());
             }
         } finally {
@@ -370,19 +352,9 @@ public class ParallelSchedulerTest implements Runnable {
                 try (final TrackedAction tt = new TrackedAction(this, cd)) {
                     final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            tt.setFuture(ft);
-                        }
-                    };
+                    Runnable r1 = () -> tt.setFuture(ft);
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            tt.future.set(TrackedAction.FINISHED);
-                        }
-                    };
+                    Runnable r2 = () -> tt.future.set(TrackedAction.FINISHED);
                     TestHelper.race(r1, r2, Schedulers.single());
                 }
             }
@@ -400,19 +372,9 @@ public class ParallelSchedulerTest implements Runnable {
                 try (final TrackedAction tt = new TrackedAction(this, cd)) {
                     final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            tt.setFuture(ft);
-                        }
-                    };
+                    Runnable r1 = () -> tt.setFuture(ft);
 
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            tt.future.set(TrackedAction.DISPOSED);
-                        }
-                    };
+                    Runnable r2 = () -> tt.future.set(TrackedAction.DISPOSED);
                     TestHelper.race(r1, r2, Schedulers.single());
                 }
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
@@ -31,11 +31,8 @@ public class ScheduledDirectPeriodicTaskTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             @SuppressWarnings("resource")
-            ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(() -> {
+                throw new TestException();
             }, true);
 
             try {

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
@@ -15,7 +15,6 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import static org.junit.Assert.*;
 
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.List;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.*;
@@ -67,19 +66,9 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
             final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, 0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    run.setFuture(ft);
-                }
-            };
+            Runnable r1 = () -> run.setFuture(ft);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    run.dispose();
-                }
-            };
+            Runnable r2 = run::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -96,19 +85,9 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
             final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, 0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    run.setFuture(ft);
-                }
-            };
+            Runnable r1 = () -> run.setFuture(ft);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    run.run();
-                }
-            };
+            Runnable r2 = run::run;
 
             TestHelper.race(r1, r2);
 
@@ -123,12 +102,7 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    run.dispose();
-                }
-            };
+            Runnable r1 = run::dispose;
 
             TestHelper.race(r1, r1);
 
@@ -143,19 +117,9 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, set);
             set.add(run);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    run.call();
-                }
-            };
+            Runnable r1 = run::call;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    run.dispose();
-                }
-            };
+            Runnable r2 = run::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -165,19 +129,13 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void pluginCrash() {
-        Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
-            @Override
-            public void uncaughtException(Thread t, Throwable e) {
-                throw new TestException("Second");
-            }
+        Thread.currentThread().setUncaughtExceptionHandler((_, _) -> {
+            throw new TestException("Second");
         });
 
         CompositeDisposable set = new CompositeDisposable();
-        final ScheduledRunnable run = new ScheduledRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new TestException("First");
-            }
+        final ScheduledRunnable run = new ScheduledRunnable(() -> {
+            throw new TestException("First");
         }, set);
         set.add(run);
 
@@ -200,11 +158,8 @@ public class ScheduledRunnableTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             CompositeDisposable set = new CompositeDisposable();
-            final ScheduledRunnable run = new ScheduledRunnable(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException("First");
-                }
+            final ScheduledRunnable run = new ScheduledRunnable(() -> {
+                throw new TestException("First");
             }, set);
             set.add(run);
 
@@ -278,19 +233,9 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
             final FutureTask<Void> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    run.call();
-                }
-            };
+            Runnable r1 = run::call;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    run.setFuture(ft);
-                }
-            };
+            Runnable r2 = () -> run.setFuture(ft);
 
             TestHelper.race(r1, r2);
         }
@@ -304,21 +249,18 @@ public class ScheduledRunnableTest extends RxJavaTest {
             final AtomicInteger sync = new AtomicInteger(2);
             final AtomicInteger syncb = new AtomicInteger(2);
 
-            Runnable r0 = new Runnable() {
-                @Override
-                public void run() {
-                    set.dispose();
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    if (syncb.decrementAndGet() != 0) {
-                        while (syncb.get() != 0) { }
-                    }
-                    for (int j = 0; j < 1000; j++) {
-                        if (Thread.currentThread().isInterrupted()) {
-                            interrupted.set(true);
-                            break;
-                        }
+            Runnable r0 = () -> {
+                set.dispose();
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                if (syncb.decrementAndGet() != 0) {
+                    while (syncb.get() != 0) { }
+                }
+                for (int j = 0; j < 1000; j++) {
+                    if (Thread.currentThread().isInterrupted()) {
+                        interrupted.set(true);
+                        break;
                     }
                 }
             };
@@ -328,16 +270,13 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
             final FutureTask<Void> ft = new FutureTask<>(run, null);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
-                    }
-                    run.setFuture(ft);
-                    if (syncb.decrementAndGet() != 0) {
-                        while (syncb.get() != 0) { }
-                    }
+            Runnable r2 = () -> {
+                if (sync.decrementAndGet() != 0) {
+                    while (sync.get() != 0) { }
+                }
+                run.setFuture(ft);
+                if (syncb.decrementAndGet() != 0) {
+                    while (syncb.get() != 0) { }
                 }
             };
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerMultiWorkerSupportTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerMultiWorkerSupportTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.CompositeDisposable;
-import io.reactivex.rxjava4.internal.schedulers.SchedulerMultiWorkerSupport.WorkerCallback;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -37,12 +36,7 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
 
         SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 
-        mws.createWorkers(max * 2, new WorkerCallback() {
-            @Override
-            public void onWorker(int i, Worker w) {
-                list.add(w);
-            }
-        });
+        mws.createWorkers(max * 2, (_, w) -> list.add(w));
 
         assertEquals(max * 2, list.size());
     }
@@ -51,12 +45,7 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
     public void getShutdownWorkers() {
         final List<Worker> list = new ArrayList<>();
 
-        ComputationScheduler.NONE.createWorkers(max * 2, new WorkerCallback() {
-            @Override
-            public void onWorker(int i, Worker w) {
-                list.add(w);
-            }
-        });
+        ComputationScheduler.NONE.createWorkers(max * 2, (_, w) -> list.add(w));
 
         assertEquals(max * 2, list.size());
 
@@ -79,61 +68,43 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
 
                 final Set<String> threads2 = Collections.synchronizedSet(new HashSet<>());
 
-                Runnable parallel1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        final List<Worker> list1 = new ArrayList<>();
+                Runnable parallel1 = () -> {
+                    final List<Worker> list1 = new ArrayList<>();
 
-                        SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
+                    SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 
-                        mws.createWorkers(max, new WorkerCallback() {
-                            @Override
-                            public void onWorker(int i, Worker w) {
-                                list1.add(w);
-                                composite.add(w);
-                            }
-                        });
+                    mws.createWorkers(max, (_, w) -> {
+                        list1.add(w);
+                        composite.add(w);
+                    });
 
-                        Runnable run = new Runnable() {
-                            @Override
-                            public void run() {
-                                threads1.add(Thread.currentThread().getName());
-                                cdl.countDown();
-                            }
-                        };
+                    Runnable run = () -> {
+                        threads1.add(Thread.currentThread().getName());
+                        cdl.countDown();
+                    };
 
-                        for (Worker w : list1) {
-                            w.schedule(run);
-                        }
+                    for (Worker w : list1) {
+                        w.schedule(run);
                     }
                 };
 
-                Runnable parallel2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        final List<Worker> list2 = new ArrayList<>();
+                Runnable parallel2 = () -> {
+                    final List<Worker> list2 = new ArrayList<>();
 
-                        SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
+                    SchedulerMultiWorkerSupport mws = (SchedulerMultiWorkerSupport)Schedulers.computation();
 
-                        mws.createWorkers(max, new WorkerCallback() {
-                            @Override
-                            public void onWorker(int i, Worker w) {
-                                list2.add(w);
-                                composite.add(w);
-                            }
-                        });
+                    mws.createWorkers(max, (_, w) -> {
+                        list2.add(w);
+                        composite.add(w);
+                    });
 
-                        Runnable run = new Runnable() {
-                            @Override
-                            public void run() {
-                                threads2.add(Thread.currentThread().getName());
-                                cdl.countDown();
-                            }
-                        };
+                    Runnable run = () -> {
+                        threads2.add(Thread.currentThread().getName());
+                        cdl.countDown();
+                    };
 
-                        for (Worker w : list2) {
-                            w.schedule(run);
-                        }
+                    for (Worker w : list2) {
+                        w.schedule(run);
                     }
                 };
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactoryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactoryTest.java
@@ -53,17 +53,9 @@ public class SchedulerPoolFactoryTest extends RxJavaTest {
         assertFalse(SchedulerPoolFactory.getBooleanProperty(true, "false", false, true, Functions.<String>identity()));
     }
 
-    static final Function<String, String> failingPropertiesAccessor = new Function<String, String>() {
-        @Override
-        public String apply(String v) throws Throwable {
-            throw new SecurityException();
-        }
+    static final Function<String, String> failingPropertiesAccessor = v -> {
+        throw new SecurityException();
     };
 
-    static final Function<String, String> missingPropertiesAccessor = new Function<String, String>() {
-        @Override
-        public String apply(String v) throws Throwable {
-            return null;
-        }
-    };
+    static final Function<String, String> missingPropertiesAccessor = v -> null;
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
@@ -47,12 +47,7 @@ public class SharedSchedulerTest implements Runnable {
 
             for (int i = 0; i < 100; i++) {
                 Flowable.just(1).subscribeOn(scheduler)
-                .map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) throws Exception {
-                        return threads.add(Thread.currentThread().getName());
-                    }
-                })
+                .map((Function<Integer, Object>) v -> threads.add(Thread.currentThread().getName()))
                 .blockingLast();
             }
 
@@ -70,12 +65,7 @@ public class SharedSchedulerTest implements Runnable {
 
             for (int i = 0; i < 100; i++) {
                 Flowable.just(1).delay(1, TimeUnit.MILLISECONDS, scheduler)
-                .map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) throws Exception {
-                        return threads.add(Thread.currentThread().getName());
-                    }
-                })
+                .map((Function<Integer, Object>) v -> threads.add(Thread.currentThread().getName()))
                 .blockingLast();
             }
 
@@ -193,11 +183,8 @@ public class SharedSchedulerTest implements Runnable {
 
         var scheduler = test.share();
 
-        Disposable d = scheduler.createWorker().schedule(new Runnable() {
-            @Override
-            public void run() {
-                throw new IllegalArgumentException();
-            }
+        Disposable d = scheduler.createWorker().schedule(() -> {
+            throw new IllegalArgumentException();
         });
 
         assertFalse(d.isDisposed());
@@ -235,19 +222,9 @@ public class SharedSchedulerTest implements Runnable {
 
                 final Disposable d = Disposable.empty();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sa.setFuture(d);
-                    }
-                };
+                Runnable r1 = () -> sa.setFuture(d);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sa.dispose();
-                    }
-                };
+                Runnable r2 = sa::dispose;
 
                 TestHelper.race(r1, r2, Schedulers.single());
 
@@ -262,19 +239,9 @@ public class SharedSchedulerTest implements Runnable {
             try (final SharedAction sa = new SharedAction(this, new CompositeDisposable())) {
                 final Disposable d = Disposable.empty();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sa.setFuture(d);
-                    }
-                };
+                Runnable r1 = () -> sa.setFuture(d);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sa.run();
-                    }
-                };
+                Runnable r2 = sa::run;
 
                 TestHelper.race(r1, r2, Schedulers.single());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/QueueDrainSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/QueueDrainSubscriberTest.java
@@ -267,12 +267,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
             ts.onSubscribe(new BooleanSubscription());
 
             qd.requested(Long.MAX_VALUE);
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    qd.onNext(1);
-                }
-            };
+            Runnable r1 = () -> qd.onNext(1);
 
             TestHelper.race(r1, r1);
 
@@ -290,12 +285,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
             ts.onSubscribe(new BooleanSubscription());
 
             qd.requested(Long.MAX_VALUE);
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    qd.onNext(1);
-                }
-            };
+            Runnable r1 = () -> qd.onNext(1);
 
             TestHelper.race(r1, r1);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SubscriberResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SubscriberResourceWrapperTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.internal.subscribers;
 import static org.junit.Assert.*;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
@@ -87,28 +86,11 @@ public class SubscriberResourceWrapperTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Flowable<Object>>() {
-            @Override
-            public Flowable<Object> apply(Flowable<Object> f) throws Exception {
-                return f.lift(new FlowableOperator<Object, Object>() {
-                    @Override
-                    public Subscriber<? super Object> apply(
-                            Subscriber<? super Object> s) throws Exception {
-                        return new SubscriberResourceWrapper<>(s);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable((Function<Flowable<Object>, Flowable<Object>>) f -> f.lift(SubscriberResourceWrapper::new));
     }
 
     @Test
     public void badRequest() {
-        TestHelper.assertBadRequestReported(Flowable.never().lift(new FlowableOperator<Object, Object>() {
-            @Override
-            public Subscriber<? super Object> apply(
-                    Subscriber<? super Object> s) throws Exception {
-                return new SubscriberResourceWrapper<>(s);
-            }
-        }));
+        TestHelper.assertBadRequestReported(Flowable.never().lift(SubscriberResourceWrapper::new));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionHelperTest.java
@@ -91,12 +91,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final AtomicReference<Subscription> atomicSubscription = new AtomicReference<>();
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.cancel(atomicSubscription);
-                }
-            };
+            Runnable r = () -> SubscriptionHelper.cancel(atomicSubscription);
 
             TestHelper.race(r, r);
         }
@@ -110,19 +105,9 @@ public class SubscriptionHelperTest extends RxJavaTest {
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.set(atomicSubscription, bs1);
-                }
-            };
+            Runnable r1 = () -> SubscriptionHelper.set(atomicSubscription, bs1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.set(atomicSubscription, bs2);
-                }
-            };
+            Runnable r2 = () -> SubscriptionHelper.set(atomicSubscription, bs2);
 
             TestHelper.race(r1, r2);
 
@@ -138,19 +123,9 @@ public class SubscriptionHelperTest extends RxJavaTest {
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.replace(atomicSubscription, bs1);
-                }
-            };
+            Runnable r1 = () -> SubscriptionHelper.replace(atomicSubscription, bs1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.replace(atomicSubscription, bs2);
-                }
-            };
+            Runnable r2 = () -> SubscriptionHelper.replace(atomicSubscription, bs2);
 
             TestHelper.race(r1, r2);
 
@@ -213,19 +188,9 @@ public class SubscriptionHelperTest extends RxJavaTest {
                 }
             };
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.deferredSetOnce(atomicSubscription, r, a);
-                }
-            };
+            Runnable r1 = () -> SubscriptionHelper.deferredSetOnce(atomicSubscription, r, a);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    SubscriptionHelper.deferredRequest(atomicSubscription, r, 1);
-                }
-            };
+            Runnable r2 = () -> SubscriptionHelper.deferredRequest(atomicSubscription, r, 1);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.functions.BiPredicate;
-import io.reactivex.rxjava4.internal.util.AppendOnlyLinkedArrayList.NonThrowingPredicate;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class MiscUtilTest extends RxJavaTest {
@@ -80,12 +79,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(new NonThrowingPredicate<Integer>() {
-            @Override
-            public boolean test(Integer t2) {
-                out.add(t2);
-                return t2 == 2;
-            }
+        list.forEachWhile(t2 -> {
+            out.add(t2);
+            return t2 == 2;
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -101,12 +97,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer t1, Integer t2) throws Throwable {
-                out.add(t2);
-                return t1.equals(t2);
-            }
+        list.forEachWhile(2, (BiPredicate<Integer, Integer>) (t1, t2) -> {
+            out.add(t2);
+            return t1.equals(t2);
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -122,12 +115,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(new NonThrowingPredicate<Integer>() {
-            @Override
-            public boolean test(Integer t2) {
-                out.add(t2);
-                return t2 == 2;
-            }
+        list.forEachWhile(t2 -> {
+            out.add(t2);
+            return t2 == 2;
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -143,12 +133,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(new NonThrowingPredicate<Integer>() {
-            @Override
-            public boolean test(Integer t2) {
-                out.add(t2);
-                return t2 == 2;
-            }
+        list.forEachWhile(t2 -> {
+            out.add(t2);
+            return t2 == 2;
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -164,12 +151,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(new NonThrowingPredicate<Integer>() {
-            @Override
-            public boolean test(Integer t2) {
-                out.add(t2);
-                return t2 == 3;
-            }
+        list.forEachWhile(t2 -> {
+            out.add(t2);
+            return t2 == 3;
         });
 
         assertEquals(Arrays.asList(1, 2, 3), out);
@@ -185,12 +169,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(new NonThrowingPredicate<Integer>() {
-            @Override
-            public boolean test(Integer t2) {
-                out.add(t2);
-                return false;
-            }
+        list.forEachWhile(t2 -> {
+            out.add(t2);
+            return false;
         });
 
         assertEquals(Arrays.asList(1, 2, 3), out);
@@ -206,12 +187,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer t1, Integer t2) throws Throwable {
-                out.add(t2);
-                return t1.equals(t2);
-            }
+        list.forEachWhile(2, (BiPredicate<Integer, Integer>) (t1, t2) -> {
+            out.add(t2);
+            return t1.equals(t2);
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -227,12 +205,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(2, new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer t1, Integer t2) throws Exception {
-                out.add(t2);
-                return t1.equals(t2);
-            }
+        list.forEachWhile(2, (BiPredicate<Integer, Integer>) (t1, t2) -> {
+            out.add(t2);
+            return t1.equals(t2);
         });
 
         assertEquals(Arrays.asList(1, 2), out);
@@ -248,12 +223,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(3, new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer t1, Integer t2) throws Exception {
-                out.add(t2);
-                return false;
-            }
+        list.forEachWhile(3, (BiPredicate<Integer, Integer>) (_, t2) -> {
+            out.add(t2);
+            return false;
         });
 
         assertEquals(Arrays.asList(1, 2, 3), out);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
@@ -37,11 +37,8 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void isCancelled() {
-        assertTrue(QueueDrainHelper.isCancelled(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                throw new IOException();
-            }
+        assertTrue(QueueDrainHelper.isCancelled(() -> {
+            throw new IOException();
         }));
     }
 
@@ -92,12 +89,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
-        BooleanSupplier isCancelled = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        };
+        BooleanSupplier isCancelled = () -> false;
 
         ts.onSubscribe(new BooleanSubscription());
 
@@ -111,12 +103,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
-        BooleanSupplier isCancelled = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        };
+        BooleanSupplier isCancelled = () -> false;
 
         ts.onSubscribe(new BooleanSubscription());
         queue.offer(1);
@@ -133,29 +120,14 @@ public class QueueDrainHelperTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
             final ArrayDeque<Integer> queue = new ArrayDeque<>();
             final AtomicLong state = new AtomicLong();
-            final BooleanSupplier isCancelled = new BooleanSupplier() {
-                @Override
-                public boolean getAsBoolean() throws Exception {
-                    return false;
-                }
-            };
+            final BooleanSupplier isCancelled = () -> false;
 
             ts.onSubscribe(new BooleanSubscription());
             queue.offer(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    QueueDrainHelper.postCompleteRequest(1, ts, queue, state, isCancelled);
-                }
-            };
+            Runnable r1 = () -> QueueDrainHelper.postCompleteRequest(1, ts, queue, state, isCancelled);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    QueueDrainHelper.postComplete(ts, queue, state, isCancelled);
-                }
-            };
+            Runnable r2 = () -> QueueDrainHelper.postComplete(ts, queue, state, isCancelled);
 
             TestHelper.race(r1, r2);
 
@@ -168,12 +140,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
         ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
-        BooleanSupplier isCancelled = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return ts.isCancelled();
-            }
-        };
+        BooleanSupplier isCancelled = ts::isCancelled;
 
         ts.onSubscribe(new BooleanSubscription());
         queue.offer(1);
@@ -196,12 +163,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         };
         ArrayDeque<Integer> queue = new ArrayDeque<>();
         AtomicLong state = new AtomicLong();
-        BooleanSupplier isCancelled = new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return ts.isCancelled();
-            }
-        };
+        BooleanSupplier isCancelled = ts::isCancelled;
 
         ts.onSubscribe(new BooleanSubscription());
         queue.offer(1);
@@ -873,11 +835,6 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
         AtomicLong state = new AtomicLong(QueueDrainHelper.COMPLETED_MASK);
 
-        QueueDrainHelper.postComplete(ts, q, state, new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return false;
-            }
-        });
+        QueueDrainHelper.postComplete(ts, q, state, () -> false);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -444,18 +444,13 @@ public class SerializedObserverTest extends RxJavaTest {
     }
 
     private static Observable<String> infinite(final AtomicInteger produced) {
-        return Observable.unsafeCreate(new ObservableSource<String>() {
-
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                Disposable bs = Disposable.empty();
-                observer.onSubscribe(bs);
-                while (!bs.isDisposed()) {
-                    observer.onNext("onNext");
-                    produced.incrementAndGet();
-                }
+        return Observable.unsafeCreate((ObservableSource<String>) observer -> {
+            Disposable bs = Disposable.empty();
+            observer.onSubscribe(bs);
+            while (!bs.isDisposed()) {
+                observer.onNext("onNext");
+                produced.incrementAndGet();
             }
-
         }).subscribeOn(Schedulers.newThread());
     }
 
@@ -655,22 +650,17 @@ public class SerializedObserverTest extends RxJavaTest {
         public void subscribe(final Observer<? super String> observer) {
             observer.onSubscribe(Disposable.empty());
             System.out.println("TestSingleThreadedObservable subscribed to ...");
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestSingleThreadedObservable thread");
-                        for (String s : values) {
-                            System.out.println("TestSingleThreadedObservable onNext: " + s);
-                            observer.onNext(s);
-                        }
-                        observer.onComplete();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestSingleThreadedObservable thread");
+                    for (String s : values) {
+                        System.out.println("TestSingleThreadedObservable onNext: " + s);
+                        observer.onNext(s);
                     }
+                    observer.onComplete();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
-
             });
             System.out.println("starting TestSingleThreadedObservable thread");
             t.start();
@@ -708,65 +698,57 @@ public class SerializedObserverTest extends RxJavaTest {
             observer.onSubscribe(Disposable.empty());
             final NullPointerException npe = new NullPointerException();
             System.out.println("TestMultiThreadedObservable subscribed to ...");
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestMultiThreadedObservable thread");
-                        int j = 0;
-                        for (final String s : values) {
-                            final int fj = ++j;
-                            threadPool.execute(new Runnable() {
-
-                                @Override
-                                public void run() {
-                                    threadsRunning.incrementAndGet();
-                                    try {
-                                        // perform onNext call
-                                        System.out.println("TestMultiThreadedObservable onNext: " + s + " on thread " + Thread.currentThread().getName());
-                                        if (s == null) {
-                                            // force an error
-                                            throw npe;
-                                        } else {
-                                             // allow the exception to queue up
-                                            int sleep = (fj % 3) * 10;
-                                            if (sleep != 0) {
-                                                Thread.sleep(sleep);
-                                            }
-                                        }
-                                        observer.onNext(s);
-                                        // capture 'maxThreads'
-                                        int concurrentThreads = threadsRunning.get();
-                                        int maxThreads = maxConcurrentThreads.get();
-                                        if (concurrentThreads > maxThreads) {
-                                            maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
-                                        }
-                                    } catch (Throwable e) {
-                                        observer.onError(e);
-                                    } finally {
-                                        threadsRunning.decrementAndGet();
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestMultiThreadedObservable thread");
+                    int j = 0;
+                    for (final String s : values) {
+                        final int fj = ++j;
+                        threadPool.execute(() -> {
+                            threadsRunning.incrementAndGet();
+                            try {
+                                // perform onNext call
+                                System.out.println("TestMultiThreadedObservable onNext: " + s + " on thread " + Thread.currentThread().getName());
+                                if (s == null) {
+                                    // force an error
+                                    throw npe;
+                                } else {
+                                     // allow the exception to queue up
+                                    int sleep = (fj % 3) * 10;
+                                    if (sleep != 0) {
+                                        Thread.sleep(sleep);
                                     }
                                 }
-                            });
-                        }
-                        // we are done spawning threads
-                        threadPool.shutdown();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+                                observer.onNext(s);
+                                // capture 'maxThreads'
+                                int concurrentThreads = threadsRunning.get();
+                                int maxThreads = maxConcurrentThreads.get();
+                                if (concurrentThreads > maxThreads) {
+                                    maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                                }
+                            } catch (Throwable e) {
+                                observer.onError(e);
+                            } finally {
+                                threadsRunning.decrementAndGet();
+                            }
+                        });
                     }
-
-                    // wait until all threads are done, then mark it as COMPLETED
-                    try {
-                        // wait for all the threads to finish
-                        if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
-                            System.out.println("Threadpool did not terminate in time.");
-                        }
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    observer.onComplete();
+                    // we are done spawning threads
+                    threadPool.shutdown();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
+
+                // wait until all threads are done, then mark it as COMPLETED
+                try {
+                    // wait for all the threads to finish
+                    if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                        System.out.println("Threadpool did not terminate in time.");
+                    }
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                observer.onComplete();
             });
             System.out.println("starting TestMultiThreadedObservable thread");
             t.start();
@@ -930,12 +912,7 @@ public class SerializedObserverTest extends RxJavaTest {
 
             so.onSubscribe(d);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    so.onComplete();
-                }
-            };
+            Runnable r = so::onComplete;
 
             TestHelper.race(r, r);
 
@@ -957,19 +934,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
             so.onSubscribe(d);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onComplete();
-                }
-            };
+            Runnable r1 = so::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -996,19 +963,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onError(ex);
-                }
-            };
+            Runnable r1 = () -> so.onError(ex);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -1035,19 +992,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onError(ex);
-                }
-            };
+            Runnable r1 = () -> so.onError(ex);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -1102,19 +1049,9 @@ public class SerializedObserverTest extends RxJavaTest {
 
                 final Throwable ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> so.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.onComplete();
-                    }
-                };
+                Runnable r2 = so::onComplete;
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -30,7 +30,6 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -260,12 +259,7 @@ public class TestObserverTest extends RxJavaTest {
 
         to.assertError(Functions.<Throwable>alwaysTrue());
 
-        to.assertError(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable t) throws Exception {
-                return t.getMessage() != null && t.getMessage().contains("Forced");
-            }
-        });
+        to.assertError(t -> t.getMessage() != null && t.getMessage().contains("Forced"));
 
         try {
             to.assertError(new RuntimeException());
@@ -409,12 +403,7 @@ public class TestObserverTest extends RxJavaTest {
 
         to1.onSubscribe(Disposable.empty());
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                to1.onComplete();
-            }
-        }, 200, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(to1::onComplete, 200, TimeUnit.MILLISECONDS);
 
         to1.await();
     }
@@ -715,11 +704,8 @@ public class TestObserverTest extends RxJavaTest {
         TestObserver<Object> to = new TestObserver<>();
         to.onError(new RuntimeException());
         try {
-            to.assertError(new Predicate<Throwable>() {
-                @Override
-                public boolean test(Throwable throwable) throws Exception {
-                    throw new TestException();
-                }
+            to.assertError(_ -> {
+                throw new TestException();
             });
         } catch (TestException ex) {
             // expected
@@ -859,11 +845,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.empty().subscribe(to);
 
-            to.assertValue(new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            to.assertValue(_ -> false);
         });
     }
 
@@ -873,11 +855,7 @@ public class TestObserverTest extends RxJavaTest {
 
         Observable.just(1).subscribe(to);
 
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        to.assertValue(o -> o == 1);
     }
 
     @Test
@@ -888,11 +866,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.just(1).subscribe(to);
 
-            to.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 1;
-                }
-            });
+            to.assertValue(o -> o != 1);
         });
     }
 
@@ -904,11 +878,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.just(1, 2).subscribe(to);
 
-            to.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertValue(o -> o == 1);
         });
     }
 
@@ -919,11 +889,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.empty().subscribe(to);
 
-            to.assertValueAt(0, new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            to.assertValueAt(0, _ -> false);
         });
     }
 
@@ -933,11 +899,7 @@ public class TestObserverTest extends RxJavaTest {
 
         Observable.just(1, 2).subscribe(to);
 
-        to.assertValueAt(1, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 2;
-            }
-        });
+        to.assertValueAt(1, o -> o == 2);
     }
 
     @Test
@@ -948,11 +910,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.just(1, 2, 3).subscribe(to);
 
-            to.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 3;
-                }
-            });
+            to.assertValueAt(2, o -> o != 3);
         });
     }
 
@@ -963,11 +921,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.just(1, 2).subscribe(to);
 
-            to.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertValueAt(2, o -> o == 1);
         });
     }
 
@@ -978,11 +932,7 @@ public class TestObserverTest extends RxJavaTest {
 
             Observable.just(1, 2).subscribe(to);
 
-            to.assertValueAt(-2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertValueAt(-2, o -> o == 1);
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelCollectTest.java
@@ -32,34 +32,16 @@ public class ParallelCollectTest extends RxJavaTest {
     @Test
     public void subscriberCount() {
         ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        }));
+        .collect((Supplier<List<Integer>>) ArrayList::new, List::add));
     }
 
     @Test
     public void initialCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                throw new TestException();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        })
+        .collect(() -> {
+            throw new TestException();
+        }, (BiConsumer<List<Integer>, Integer>) List::add)
         .sequential()
         .test()
         .assertFailure(TestException.class);
@@ -69,19 +51,11 @@ public class ParallelCollectTest extends RxJavaTest {
     public void reducerCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
+        .collect((Supplier<List<Integer>>) ArrayList::new, (a, b) -> {
+            if (b == 3) {
+                throw new TestException();
             }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                if (b == 3) {
-                    throw new TestException();
-                }
-                a.add(b);
-            }
+            a.add(b);
         })
         .sequential()
         .test()
@@ -94,17 +68,7 @@ public class ParallelCollectTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = pp
         .parallel()
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        })
+        .collect((Supplier<List<Integer>>) ArrayList::new, List::add)
         .sequential()
         .test();
 
@@ -119,17 +83,7 @@ public class ParallelCollectTest extends RxJavaTest {
     public void error() {
         Flowable.<Integer>error(new TestException())
         .parallel()
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        })
+        .collect((Supplier<List<Integer>>) ArrayList::new, List::add)
         .sequential()
         .test()
         .assertFailure(TestException.class);
@@ -140,17 +94,7 @@ public class ParallelCollectTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             new ParallelInvalid()
-            .collect(new Supplier<List<Object>>() {
-                @Override
-                public List<Object> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            }, new BiConsumer<List<Object>, Object>() {
-                @Override
-                public void accept(List<Object> a, Object b) throws Exception {
-                    a.add(b);
-                }
-            })
+            .collect((Supplier<List<Object>>) ArrayList::new, List::add)
             .sequential()
             .test()
             .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
@@ -99,12 +99,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithError() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.ERROR)
         .sequential()
@@ -116,12 +113,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithStop() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.STOP)
         .sequential()
@@ -154,19 +148,11 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetryLimited() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        }, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -176,12 +162,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithSkip() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.SKIP)
         .sequential()
@@ -193,18 +176,12 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        }, (_, _) -> {
+            throw new TestException();
         })
         .sequential()
         .to(TestHelper.<Integer>testConsumer())
@@ -240,12 +217,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithErrorConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.ERROR)
         .filter(Functions.alwaysTrue())
@@ -258,12 +232,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithStopConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.STOP)
         .filter(Functions.alwaysTrue())
@@ -298,19 +269,11 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetryLimitedConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        }, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -321,12 +284,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithSkipConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
         }, ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
@@ -339,18 +299,12 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (1 / v < 0) {
-                    System.out.println("Should not happen!");
-                }
+        .doOnNext(v -> {
+            if (1 / v < 0) {
+                System.out.println("Should not happen!");
             }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        }, (_, _) -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -38,18 +37,8 @@ public class ParallelFilterTest extends RxJavaTest {
     public void doubleFilter() {
         Flowable.range(1, 10)
         .parallel()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 3 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
+        .filter(v -> v % 3 == 0)
         .sequential()
         .test()
         .assertResult(6);
@@ -108,11 +97,8 @@ public class ParallelFilterTest extends RxJavaTest {
     public void predicateThrows() {
         Flowable.just(1)
         .parallel()
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .filter(_ -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
@@ -112,12 +112,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithError() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.ERROR)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.ERROR)
         .sequential()
         .test()
         .assertFailure(ArithmeticException.class);
@@ -127,12 +122,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithStop() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.STOP)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.STOP)
         .sequential()
         .test()
         .assertResult();
@@ -161,17 +151,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetryLimited() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .filter(v -> 1 / v > 0, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -181,12 +161,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithSkip() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.SKIP)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -196,16 +171,8 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .filter(v -> 1 / v > 0, (_, _) -> {
+            throw new TestException();
         })
         .sequential()
         .to(TestHelper.<Integer>testConsumer())
@@ -241,12 +208,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithErrorConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.ERROR)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.ERROR)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -257,12 +219,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithStopConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.STOP)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.STOP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -293,17 +250,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetryLimitedConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .filter(v -> 1 / v > 0, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -314,12 +261,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithSkipConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, ParallelFailureHandling.SKIP)
+        .filter(v -> 1 / v > 0, ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -330,16 +272,8 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return 1 / v > 0;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .filter(v -> 1 / v > 0, (_, _) -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFlowableTest.java
@@ -40,12 +40,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.range(1, 1000000).hide();
         for (int i = 1; i < 33; i++) {
             Flowable<Integer> result = ParallelFlowable.from(source, i)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    return v + 1;
-                }
-            })
+            .map(v -> v + 1)
             .sequential()
             ;
 
@@ -68,12 +63,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         Flowable<Integer> source = Flowable.range(1, 1000000);
         for (int i = 1; i < 33; i++) {
             Flowable<Integer> result = ParallelFlowable.from(source, i)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Exception {
-                    return v + 1;
-                }
-            })
+            .map(v -> v + 1)
             .sequential()
             ;
 
@@ -104,12 +94,7 @@ public class ParallelFlowableTest extends RxJavaTest {
             try {
                 Flowable<Integer> result = ParallelFlowable.from(source, i)
                 .runOn(scheduler)
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                })
+                .map(v -> v + 1)
                 .sequential()
                 ;
 
@@ -145,12 +130,7 @@ public class ParallelFlowableTest extends RxJavaTest {
             try {
                 Flowable<Integer> result = ParallelFlowable.from(source, i)
                 .runOn(scheduler)
-                .map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                })
+                .map(v -> v + 1)
                 .sequential()
                 ;
 
@@ -180,12 +160,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
             Flowable.range(1, 10)
             .parallel(i)
-            .reduce(new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return a + b;
-                }
-            })
+            .reduce(Integer::sum)
             .subscribe(ts);
 
             ts.assertResult(55);
@@ -208,20 +183,10 @@ public class ParallelFlowableTest extends RxJavaTest {
                     TestSubscriber<Long> ts = new TestSubscriber<>();
 
                     Flowable.range(1, n)
-                    .map(new Function<Integer, Long>() {
-                        @Override
-                        public Long apply(Integer v) throws Exception {
-                            return (long)v;
-                        }
-                    })
+                    .map(v -> (long)v)
                     .parallel(i)
                     .runOn(scheduler)
-                    .reduce(new BiFunction<Long, Long, Long>() {
-                        @Override
-                        public Long apply(Long a, Long b) throws Exception {
-                            return a + b;
-                        }
-                    })
+                    .reduce(Long::sum)
                     .subscribe(ts);
 
                     ts.awaitDone(500, TimeUnit.SECONDS);
@@ -274,29 +239,14 @@ public class ParallelFlowableTest extends RxJavaTest {
 
     @Test
     public void collect() {
-        Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        };
+        Supplier<List<Integer>> as = ArrayList::new;
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         Flowable.range(1, 10)
         .parallel()
-        .collect(as, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        })
+        .collect(as, List::add)
         .sequential()
-        .flatMapIterable(new Function<List<Integer>, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(List<Integer> v) throws Exception {
-                return v;
-            }
-        })
+        .flatMapIterable((Function<List<Integer>, Iterable<Integer>>) v -> v)
         .subscribe(ts);
 
         ts
@@ -327,12 +277,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel()
-        .concatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(v * 10 + 1, 3);
-            }
-        })
+        .concatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v * 10 + 1, 3))
         .sequential()
         .subscribe(ts);
 
@@ -349,12 +294,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel()
-        .flatMap(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(v * 10 + 1, 3);
-            }
-        })
+        .flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v * 10 + 1, 3))
         .sequential()
         .subscribe(ts);
 
@@ -372,29 +312,14 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -419,29 +344,14 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -466,30 +376,15 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .observeOn(s)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -514,30 +409,15 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000).hide()
             .observeOn(s)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -562,30 +442,15 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
             .observeOn(s)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -610,12 +475,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             Flowable.range(1, 100000)
@@ -623,18 +483,8 @@ public class ParallelFlowableTest extends RxJavaTest {
             .observeOn(s)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -659,12 +509,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         Scheduler s = Schedulers.from(exec);
 
         try {
-            Supplier<List<Integer>> as = new Supplier<List<Integer>>() {
-                @Override
-                public List<Integer> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            };
+            Supplier<List<Integer>> as = ArrayList::new;
             TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
             UnicastProcessor<Integer> up = UnicastProcessor.create();
@@ -678,18 +523,8 @@ public class ParallelFlowableTest extends RxJavaTest {
             .observeOn(s)
             .parallel(3)
             .runOn(s)
-            .collect(as, new BiConsumer<List<Integer>, Integer>() {
-                @Override
-                public void accept(List<Integer> a, Integer b) throws Exception {
-                    a.add(b);
-                }
-            })
-            .doOnNext(new Consumer<List<Integer>>() {
-                @Override
-                public void accept(List<Integer> v) throws Exception {
-                    System.out.println(v.size());
-                }
-            })
+            .collect(as, List::add)
+            .doOnNext(v -> System.out.println(v.size()))
             .sequential()
             .subscribe(ts);
 
@@ -790,12 +625,7 @@ public class ParallelFlowableTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 20)
         .parallel()
         .runOn(Schedulers.computation())
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .sequential()
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -809,22 +639,14 @@ public class ParallelFlowableTest extends RxJavaTest {
     public void filterThrows() throws Exception {
         final boolean[] cancelled = { false };
         Flowable.range(1, 20).concatWith(Flowable.<Integer>never())
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                cancelled[0] = true;
-            }
-        })
+        .doOnCancel(() -> cancelled[0] = true)
         .parallel()
         .runOn(Schedulers.computation())
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                if (v == 10) {
-                    throw new TestException();
-                }
-                return v % 2 == 0;
+        .filter(v -> {
+            if (v == 10) {
+                throw new TestException();
             }
+            return v % 2 == 0;
         })
         .sequential()
         .test()
@@ -843,12 +665,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel()
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                count[0]++;
-            }
-        })
+        .doAfterNext(_ -> count[0]++)
         .sequential()
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -860,14 +677,11 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel()
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (v == 3) {
-                    throw new TestException();
-                } else {
-                    count[0]++;
-                }
+        .doOnNext(v -> {
+            if (v == 3) {
+                throw new TestException();
+            } else {
+                count[0]++;
             }
         })
         .sequential()
@@ -884,14 +698,11 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel()
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (v == 3) {
-                    throw new TestException();
-                } else {
-                    count[0]++;
-                }
+        .doAfterNext(v -> {
+            if (v == 3) {
+                throw new TestException();
+            } else {
+                count[0]++;
             }
         })
         .sequential()
@@ -932,21 +743,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                if (v == 3) {
-                    throw new TestException();
-                }
-                return v;
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
             }
+            return v;
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()
@@ -961,21 +766,15 @@ public class ParallelFlowableTest extends RxJavaTest {
     public void doOnErrorThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(1, 5)
         .parallel(2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                if (v == 3) {
-                    throw new TestException();
-                }
-                return v;
+        .map(v -> {
+            if (v == 3) {
+                throw new TestException();
             }
+            return v;
         })
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    throw new IOException();
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                throw new IOException();
             }
         })
         .sequential()
@@ -994,12 +793,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                count[0]++;
-            }
-        })
+        .doOnComplete(() -> count[0]++)
         .sequential()
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -1013,12 +807,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .doAfterTerminated(new Action() {
-            @Override
-            public void run() throws Exception {
-                count[0]++;
-            }
-        })
+        .doAfterTerminated(() -> count[0]++)
         .sequential()
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -1032,12 +821,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                count[0]++;
-            }
-        })
+        .doOnSubscribe(_ -> count[0]++)
         .sequential()
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -1051,12 +835,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .doOnRequest(new LongConsumer() {
-            @Override
-            public void accept(long s) throws Exception {
-                count[0]++;
-            }
-        })
+        .doOnRequest(_ -> count[0]++)
         .sequential()
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -1070,12 +849,7 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                count[0]++;
-            }
-        })
+        .doOnCancel(() -> count[0]++)
         .sequential()
         .take(2)
         .test()
@@ -1094,12 +868,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     public void to() {
         Flowable.range(1, 5)
         .parallel()
-        .to(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
-                return pf.sequential();
-            }
-        })
+        .to(ParallelFlowable::sequential)
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -1108,11 +877,8 @@ public class ParallelFlowableTest extends RxJavaTest {
     public void toThrows() {
         Flowable.range(1, 5)
         .parallel()
-        .to(new ParallelFlowableConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(ParallelFlowable<Integer> pf) {
-                throw new TestException();
-            }
+        .to((ParallelFlowableConverter<Integer, Flowable<Integer>>) _ -> {
+            throw new TestException();
         });
     }
 
@@ -1120,17 +886,7 @@ public class ParallelFlowableTest extends RxJavaTest {
     public void compose() {
         Flowable.range(1, 5)
         .parallel()
-        .compose(new ParallelTransformer<Integer, Integer>() {
-            @Override
-            public ParallelFlowable<Integer> apply(ParallelFlowable<Integer> pf) {
-                return pf.map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                });
-            }
-        })
+        .compose(pf -> pf.map(v -> v + 1))
         .sequential()
         .test()
         .assertResult(2, 3, 4, 5, 6);
@@ -1142,21 +898,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                if (v == 3) {
-                   return Flowable.error(new TestException());
-                }
-                return Flowable.just(v);
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> {
+            if (v == 3) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(v);
         }, true)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()
@@ -1174,21 +924,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .flatMap(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                if (v == 3) {
-                   return Flowable.error(new TestException());
-                }
-                return Flowable.just(v);
+        .flatMap((Function<Integer, Flowable<Integer>>) v -> {
+            if (v == 3) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(v);
         }, true, 1)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()
@@ -1206,21 +950,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                if (v == 3) {
-                   return Flowable.error(new TestException());
-                }
-                return Flowable.just(v);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> {
+            if (v == 3) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(v);
         }, true)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()
@@ -1238,21 +976,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                if (v == 3) {
-                   return Flowable.error(new TestException());
-                }
-                return Flowable.just(v);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> {
+            if (v == 3) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(v);
         }, 1, true)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()
@@ -1270,21 +1002,15 @@ public class ParallelFlowableTest extends RxJavaTest {
 
         Flowable.range(1, 5)
         .parallel(2)
-        .concatMapDelayError(new Function<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Integer v) throws Exception {
-                if (v == 3) {
-                   return Flowable.error(new TestException());
-                }
-                return Flowable.just(v);
+        .concatMapDelayError((Function<Integer, Flowable<Integer>>) v -> {
+            if (v == 3) {
+                return Flowable.error(new TestException());
             }
+            return Flowable.just(v);
         }, false)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                if (e instanceof TestException) {
-                    count[0]++;
-                }
+        .doOnError(e -> {
+            if (e instanceof TestException) {
+                count[0]++;
             }
         })
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
@@ -113,11 +113,8 @@ public class ParallelFromPublisherTest extends RxJavaTest {
     @Test
     public void syncFusedMapCrash() {
         Flowable.just(1)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .compose(new StripBoundary<>(null))
         .parallel()
@@ -133,11 +130,8 @@ public class ParallelFromPublisherTest extends RxJavaTest {
         up.onNext(1);
 
         up
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .compose(new StripBoundary<>(null))
         .parallel()
@@ -155,20 +149,12 @@ public class ParallelFromPublisherTest extends RxJavaTest {
 
         TestSubscriberEx<Object> ts = Flowable.range(1, 10)
         .observeOn(Schedulers.single(), false, 1)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                between.add(Thread.currentThread().getName());
-            }
-        })
+        .doOnNext(_ -> between.add(Thread.currentThread().getName()))
         .parallel(2, 1)
         .runOn(Schedulers.computation(), 1)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                processing.putIfAbsent(Thread.currentThread().getName(), "");
-                return v;
-            }
+        .map((Function<Integer, Object>) v -> {
+            processing.putIfAbsent(Thread.currentThread().getName(), "");
+            return v;
         })
         .sequential()
         .to(TestHelper.<Object>testConsumer())

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
@@ -164,11 +164,8 @@ public class ParallelJoinTest extends RxJavaTest {
     public void delayError() {
         TestSubscriberEx<Integer> flow = Flowable.range(1, 2)
         .parallel(2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
         .sequentialDelayError()
         .to(TestHelper.<Integer>testConsumer())
@@ -298,14 +295,11 @@ public class ParallelJoinTest extends RxJavaTest {
     public void failedRailIsIgnored() {
         Flowable.range(1, 4)
         .parallel(2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                if (v == 1) {
-                    throw new TestException();
-                }
-                return v;
+        .map(v -> {
+            if (v == 1) {
+                throw new TestException();
             }
+            return v;
         })
         .sequentialDelayError()
         .test()
@@ -316,14 +310,11 @@ public class ParallelJoinTest extends RxJavaTest {
     public void failedRailIsIgnoredHidden() {
         Flowable.range(1, 4).hide()
         .parallel(2)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                if (v == 1) {
-                    throw new TestException();
-                }
-                return v;
+        .map(v -> {
+            if (v == 1) {
+                throw new TestException();
             }
+            return v;
         })
         .sequentialDelayError()
         .test()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
@@ -24,7 +24,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.operators.ConditionalSubscriber;
@@ -45,18 +44,8 @@ public class ParallelMapTest extends RxJavaTest {
         Flowable.range(1, 10)
         .parallel()
         .map(Functions.<Integer>identity())
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 3 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
+        .filter(v -> v % 3 == 0)
         .sequential()
         .test()
         .assertResult(6);
@@ -68,18 +57,8 @@ public class ParallelMapTest extends RxJavaTest {
         .parallel()
         .runOn(Schedulers.computation())
         .map(Functions.<Integer>identity())
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 3 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
+        .filter(v -> v % 3 == 0)
         .sequential()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -139,11 +118,8 @@ public class ParallelMapTest extends RxJavaTest {
     public void mapCrash() {
         Flowable.just(1)
         .parallel()
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(_ -> {
+            throw new TestException();
         })
         .sequential()
         .test()
@@ -154,11 +130,8 @@ public class ParallelMapTest extends RxJavaTest {
     public void mapCrashConditional() {
         Flowable.just(1)
         .parallel()
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(v -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()
@@ -171,11 +144,8 @@ public class ParallelMapTest extends RxJavaTest {
         Flowable.just(1)
         .parallel()
         .runOn(Schedulers.computation())
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map(v -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTryTest.java
@@ -87,12 +87,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithError() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.ERROR)
+        .map(v -> 1 / v, ParallelFailureHandling.ERROR)
         .sequential()
         .test()
         .assertFailure(ArithmeticException.class);
@@ -102,12 +97,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithStop() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.STOP)
+        .map(v -> 1 / v, ParallelFailureHandling.STOP)
         .sequential()
         .test()
         .assertResult();
@@ -136,17 +126,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithRetryLimited() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .map(v -> 1 / v, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -156,12 +136,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithSkip() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.SKIP)
+        .map(v -> 1 / v, ParallelFailureHandling.SKIP)
         .sequential()
         .test()
         .assertResult(1);
@@ -171,16 +146,8 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailHandlerThrows() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .map(v -> 1 / v, (_, _) -> {
+            throw new TestException();
         })
         .sequential()
         .to(TestHelper.<Integer>testConsumer())
@@ -216,12 +183,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithErrorConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.ERROR)
+        .map(v -> 1 / v, ParallelFailureHandling.ERROR)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -232,12 +194,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithStopConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.STOP)
+        .map(v -> 1 / v, ParallelFailureHandling.STOP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -268,17 +225,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithRetryLimitedConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                return n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP;
-            }
-        })
+        .map(v -> 1 / v, (n, _) -> n < 5 ? ParallelFailureHandling.RETRY : ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -289,12 +236,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithSkipConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, ParallelFailureHandling.SKIP)
+        .map(v -> 1 / v, ParallelFailureHandling.SKIP)
         .filter(Functions.alwaysTrue())
         .sequential()
         .test()
@@ -305,16 +247,8 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailHandlerThrowsConditional() {
         TestSubscriberEx<Integer> ts = Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                return 1 / v;
-            }
-        }, new BiFunction<Long, Throwable, ParallelFailureHandling>() {
-            @Override
-            public ParallelFailureHandling apply(Long n, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .map(v -> 1 / v, (_, _) -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .sequential()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelPeekTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelPeekTest.java
@@ -19,11 +19,9 @@ import java.io.IOException;
 import java.util.List;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.*;
@@ -41,11 +39,8 @@ public class ParallelPeekTest extends RxJavaTest {
     public void onSubscribeCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .doOnSubscribe(new Consumer<Subscription>() {
-            @Override
-            public void accept(Subscription s) throws Exception {
-                throw new TestException();
-            }
+        .doOnSubscribe(_ -> {
+            throw new TestException();
         })
         .sequential()
         .test()
@@ -78,11 +73,8 @@ public class ParallelPeekTest extends RxJavaTest {
         try {
             Flowable.range(1, 5)
             .parallel()
-            .doOnRequest(new LongConsumer() {
-                @Override
-                public void accept(long n) throws Exception {
-                    throw new TestException();
-                }
+            .doOnRequest(_ -> {
+                throw new TestException();
             })
             .sequential()
             .test()
@@ -105,11 +97,8 @@ public class ParallelPeekTest extends RxJavaTest {
         try {
             Flowable.<Integer>never()
             .parallel()
-            .doOnCancel(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doOnCancel(() -> {
+                throw new TestException();
             })
             .sequential()
             .test()
@@ -130,11 +119,8 @@ public class ParallelPeekTest extends RxJavaTest {
     public void onCompleteCrash() {
         Flowable.just(1)
         .parallel()
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new TestException();
-            }
+        .doOnComplete(() -> {
+            throw new TestException();
         })
         .sequential()
         .test()
@@ -148,11 +134,8 @@ public class ParallelPeekTest extends RxJavaTest {
         try {
             Flowable.just(1)
             .parallel()
-            .doAfterTerminated(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doAfterTerminated(() -> {
+                throw new TestException();
             })
             .sequential()
             .test()
@@ -175,11 +158,8 @@ public class ParallelPeekTest extends RxJavaTest {
         try {
             Flowable.<Integer>error(new IOException())
             .parallel()
-            .doAfterTerminated(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doAfterTerminated(() -> {
+                throw new TestException();
             })
             .sequential()
             .test()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelReduceFullTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelReduceFullTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -36,12 +35,7 @@ public class ParallelReduceFullTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = pp
         .parallel()
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        .reduce(Integer::sum)
         .test();
 
         assertTrue(pp.hasSubscribers());
@@ -58,12 +52,7 @@ public class ParallelReduceFullTest extends RxJavaTest {
         try {
             Flowable.<Integer>error(new TestException())
             .parallel()
-            .reduce(new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return a + b;
-                }
-            })
+            .reduce(Integer::sum)
             .test()
             .assertFailure(TestException.class);
 
@@ -79,12 +68,7 @@ public class ParallelReduceFullTest extends RxJavaTest {
 
         try {
             ParallelFlowable.fromArray(Flowable.<Integer>error(new IOException()), Flowable.<Integer>error(new TestException()))
-            .reduce(new BiFunction<Integer, Integer, Integer>() {
-                @Override
-                public Integer apply(Integer a, Integer b) throws Exception {
-                    return a + b;
-                }
-            })
+            .reduce(Integer::sum)
             .test()
             .assertFailure(IOException.class);
 
@@ -98,12 +82,7 @@ public class ParallelReduceFullTest extends RxJavaTest {
     public void empty() {
         Flowable.<Integer>empty()
         .parallel()
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        .reduce(Integer::sum)
         .test()
         .assertResult();
     }
@@ -113,12 +92,7 @@ public class ParallelReduceFullTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             new ParallelInvalid()
-            .reduce(new BiFunction<Object, Object, Object>() {
-                @Override
-                public Object apply(Object a, Object b) throws Exception {
-                    return "" + a + b;
-                }
-            })
+            .reduce((a, b) -> "" + a + b)
             .test()
             .assertFailure(TestException.class);
 
@@ -135,14 +109,11 @@ public class ParallelReduceFullTest extends RxJavaTest {
     public void reducerCrash() {
         Flowable.range(1, 4)
         .parallel(2)
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                if (b == 3) {
-                    throw new TestException();
-                }
-                return a + b;
+        .reduce((a, b) -> {
+            if (b == 3) {
+                throw new TestException();
             }
+            return a + b;
         })
         .test()
         .assertFailure(TestException.class);
@@ -152,14 +123,11 @@ public class ParallelReduceFullTest extends RxJavaTest {
     public void reducerCrash2() {
         Flowable.range(1, 4)
         .parallel(2)
-        .reduce(new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                if (a == 1 + 3) {
-                    throw new TestException();
-                }
-                return a + b;
+        .reduce((a, b) -> {
+            if (a == 1 + 3) {
+                throw new TestException();
             }
+            return a + b;
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelReduceTest.java
@@ -32,17 +32,9 @@ public class ParallelReduceTest extends RxJavaTest {
     @Test
     public void subscriberCount() {
         ParallelFlowableTest.checkSubscriberCount(Flowable.range(1, 5).parallel()
-        .reduce(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-                return a;
-            }
+        .reduce(ArrayList::new, (BiFunction<List<Integer>, Integer, List<Integer>>) (a, b) -> {
+            a.add(b);
+            return a;
         }));
     }
 
@@ -50,17 +42,11 @@ public class ParallelReduceTest extends RxJavaTest {
     public void initialCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .reduce(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                throw new TestException();
-            }
-        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-                return a;
-            }
+        .reduce(() -> {
+            throw new TestException();
+        }, (BiFunction<List<Integer>, Integer, List<Integer>>) (a, b) -> {
+            a.add(b);
+            return a;
         })
         .sequential()
         .test()
@@ -71,20 +57,12 @@ public class ParallelReduceTest extends RxJavaTest {
     public void reducerCrash() {
         Flowable.range(1, 5)
         .parallel()
-        .reduce(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
+        .reduce(ArrayList::new, (BiFunction<List<Integer>, Integer, List<Integer>>) (a, b) -> {
+            if (b == 3) {
+                throw new TestException();
             }
-        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
-                if (b == 3) {
-                    throw new TestException();
-                }
-                a.add(b);
-                return a;
-            }
+            a.add(b);
+            return a;
         })
         .sequential()
         .test()
@@ -97,17 +75,9 @@ public class ParallelReduceTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = pp
         .parallel()
-        .reduce(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-                return a;
-            }
+        .reduce(ArrayList::new, (BiFunction<List<Integer>, Integer, List<Integer>>) (a, b) -> {
+            a.add(b);
+            return a;
         })
         .sequential()
         .test();
@@ -123,17 +93,9 @@ public class ParallelReduceTest extends RxJavaTest {
     public void error() {
         Flowable.<Integer>error(new TestException())
         .parallel()
-        .reduce(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiFunction<List<Integer>, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-                return a;
-            }
+        .reduce(ArrayList::new, (BiFunction<List<Integer>, Integer, List<Integer>>) (a, b) -> {
+            a.add(b);
+            return a;
         })
         .sequential()
         .test()
@@ -145,17 +107,9 @@ public class ParallelReduceTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             new ParallelInvalid()
-            .reduce(new Supplier<List<Object>>() {
-                @Override
-                public List<Object> get() throws Exception {
-                    return new ArrayList<>();
-                }
-            }, new BiFunction<List<Object>, Object, List<Object>>() {
-                @Override
-                public List<Object> apply(List<Object> a, Object b) throws Exception {
-                    a.add(b);
-                    return a;
-                }
+            .reduce(ArrayList::new, (BiFunction<List<Object>, Object, List<Object>>) (a, b) -> {
+                a.add(b);
+                return a;
             })
             .sequential()
             .test()

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
@@ -23,7 +23,6 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
@@ -65,12 +64,7 @@ public class ParallelRunOnTest extends RxJavaTest {
         Flowable.range(1, 1000)
         .parallel(2)
         .runOn(Schedulers.computation())
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .sequential()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -172,19 +166,9 @@ public class ParallelRunOnTest extends RxJavaTest {
             .sequential()
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -202,19 +186,9 @@ public class ParallelRunOnTest extends RxJavaTest {
             .runOn(Schedulers.computation())
             .subscribe(new Subscriber[] { ts });
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -231,19 +205,9 @@ public class ParallelRunOnTest extends RxJavaTest {
             .sequential()
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -262,19 +226,9 @@ public class ParallelRunOnTest extends RxJavaTest {
             .filter(Functions.alwaysTrue())
             .subscribe(new Subscriber[] { ts });
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onNext(1);
-                }
-            };
+            Runnable r1 = () -> pp.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
@@ -103,14 +103,11 @@ public class ParallelSortedJoinTest extends RxJavaTest {
     public void comparerCrash() {
         Flowable.fromArray(4, 3, 2, 1)
         .parallel(2)
-        .sorted(new Comparator<Integer>() {
-            @Override
-            public int compare(Integer o1, Integer o2) {
-                if (o1 == 4 && o2 == 3) {
-                    throw new TestException();
-                }
-                return o1.compareTo(o2);
+        .sorted((o1, o2) -> {
+            if (o1 == 4 && o2 == 3) {
+                throw new TestException();
             }
+            return o1.compareTo(o2);
         })
         .test()
         .assertFailure(TestException.class, 1, 2);
@@ -162,19 +159,9 @@ public class ParallelSortedJoinTest extends RxJavaTest {
             .sorted(Functions.naturalComparator())
             .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = pp::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -191,19 +178,9 @@ public class ParallelSortedJoinTest extends RxJavaTest {
             .sorted(Functions.naturalComparator())
             .test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
+            Runnable r1 = pp::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -16,7 +16,6 @@ package io.reactivex.rxjava4.plugins;
 import static org.junit.Assert.*;
 
 import java.io.*;
-import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -63,26 +62,11 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             assertTrue(RxJavaPlugins.isLockdown());
             Consumer a1 = Functions.emptyConsumer();
-            Supplier f0 = new Supplier() {
-                @Override
-                public Object get() {
-                    return null;
-                }
-            };
+            Supplier f0 = () -> null;
             Function f1 = Functions.identity();
-            BiFunction f2 = new BiFunction() {
-                @Override
-                public Object apply(Object t1, Object t2) {
-                    return t2;
-                }
-            };
+            BiFunction f2 = (_, t2) -> t2;
 
-            BooleanSupplier bs = new BooleanSupplier() {
-                @Override
-                public boolean getAsBoolean() throws Exception {
-                    return true;
-                }
-            };
+            BooleanSupplier bs = () -> true;
 
             for (Method m : RxJavaPlugins.class.getMethods()) {
                 if (m.getName().startsWith("set")) {
@@ -142,12 +126,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         }
     }
 
-    Function<Scheduler, Scheduler> replaceWithImmediate = new Function<Scheduler, Scheduler>() {
-        @Override
-        public Scheduler apply(Scheduler t) {
-            return ImmediateThinScheduler.INSTANCE;
-        }
-    };
+    Function<Scheduler, Scheduler> replaceWithImmediate = _ -> ImmediateThinScheduler.INSTANCE;
 
     @Test
     public void overrideSingleScheduler() {
@@ -201,22 +180,12 @@ public class RxJavaPluginsTest extends RxJavaTest {
         assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.newThread());
     }
 
-    Function<Supplier<Scheduler>, Scheduler> initReplaceWithImmediate = new Function<Supplier<Scheduler>, Scheduler>() {
-        @Override
-        public Scheduler apply(Supplier<Scheduler> t) {
-            return ImmediateThinScheduler.INSTANCE;
-        }
-    };
+    Function<Supplier<Scheduler>, Scheduler> initReplaceWithImmediate = _ -> ImmediateThinScheduler.INSTANCE;
 
     @Test
     public void overrideInitSingleScheduler() {
         final Scheduler s = Schedulers.single(); // make sure the Schedulers is initialized
-        Supplier<Scheduler> c = new Supplier<Scheduler>() {
-            @Override
-            public Scheduler get() throws Exception {
-                return s;
-            }
-        };
+        Supplier<Scheduler> c = () -> s;
         try {
             RxJavaPlugins.setInitSingleSchedulerHandler(initReplaceWithImmediate);
 
@@ -231,12 +200,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideInitComputationScheduler() {
         final Scheduler s = Schedulers.computation(); // make sure the Schedulers is initialized
-        Supplier<Scheduler> c = new Supplier<Scheduler>() {
-            @Override
-            public Scheduler get() throws Exception {
-                return s;
-            }
-        };
+        Supplier<Scheduler> c = () -> s;
         try {
             RxJavaPlugins.setInitComputationSchedulerHandler(initReplaceWithImmediate);
 
@@ -251,12 +215,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideInitCachedScheduler() {
         final Scheduler s = Schedulers.cached(); // make sure the Schedulers is initialized;
-        Supplier<Scheduler> c = new Supplier<Scheduler>() {
-            @Override
-            public Scheduler get() throws Exception {
-                return s;
-            }
-        };
+        Supplier<Scheduler> c = () -> s;
         try {
             RxJavaPlugins.setInitCachedSchedulerHandler(initReplaceWithImmediate);
 
@@ -271,12 +230,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideInitVirtualScheduler() {
         final Scheduler s = Schedulers.virtual(); // make sure the Schedulers is initialized;
-        Supplier<Scheduler> c = new Supplier<Scheduler>() {
-            @Override
-            public Scheduler get() throws Exception {
-                return s;
-            }
-        };
+        Supplier<Scheduler> c = () -> s;
         try {
             RxJavaPlugins.setInitVirtualSchedulerHandler(initReplaceWithImmediate);
 
@@ -291,12 +245,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideInitNewThreadScheduler() {
         final Scheduler s = Schedulers.newThread(); // make sure the Schedulers is initialized;
-        Supplier<Scheduler> c = new Supplier<Scheduler>() {
-            @Override
-            public Scheduler get() throws Exception {
-                return s;
-            }
-        };
+        Supplier<Scheduler> c = () -> s;
         try {
             RxJavaPlugins.setInitNewThreadSchedulerHandler(initReplaceWithImmediate);
 
@@ -308,12 +257,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         assertSame(s, RxJavaPlugins.initNewThreadScheduler(c));
     }
 
-    Supplier<Scheduler> nullResultSupplier = new Supplier<Scheduler>() {
-        @Override
-        public Scheduler get() throws Exception {
-            return null;
-        }
-    };
+    Supplier<Scheduler> nullResultSupplier = () -> null;
 
     @Test
     public void overrideInitSingleSchedulerCrashes() {
@@ -411,11 +355,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
         }
     }
 
-    Supplier<Scheduler> unsafeDefault = new Supplier<Scheduler>() {
-        @Override
-        public Scheduler get() throws Exception {
-            throw new AssertionError("Default Scheduler instance should not have been evaluated");
-        }
+    Supplier<Scheduler> unsafeDefault = () -> {
+        throw new AssertionError("Default Scheduler instance should not have been evaluated");
     };
 
     @Test
@@ -492,12 +433,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void observableCreate() {
         try {
-            RxJavaPlugins.setOnObservableAssembly(new Function<Observable, Observable>() {
-                @Override
-                public Observable apply(Observable t) {
-                    return new ObservableRange(1, 2);
-                }
-            });
+            RxJavaPlugins.setOnObservableAssembly(_ -> new ObservableRange(1, 2));
 
             Observable.range(10, 3)
             .test()
@@ -519,12 +455,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void flowableCreate() {
         try {
-            RxJavaPlugins.setOnFlowableAssembly(new Function<Flowable, Flowable>() {
-                @Override
-                public Flowable apply(Flowable t) {
-                    return new FlowableRange(1, 2);
-                }
-            });
+            RxJavaPlugins.setOnFlowableAssembly(_ -> new FlowableRange(1, 2));
 
             Flowable.range(10, 3)
             .test()
@@ -546,34 +477,29 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void observableStart() {
         try {
-            RxJavaPlugins.setOnObservableSubscribe(new BiFunction<Observable, Observer, Observer>() {
+            RxJavaPlugins.setOnObservableSubscribe((_, t) -> new Observer() {
+
                 @Override
-                public Observer apply(Observable o, final Observer t) {
-                    return new Observer() {
-
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            t.onSubscribe(d);
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public void onNext(Object value) {
-                            t.onNext((Integer)value - 9);
-                        }
-
-                        @Override
-                        public void onError(Throwable e) {
-                            t.onError(e);
-                        }
-
-                        @Override
-                        public void onComplete() {
-                            t.onComplete();
-                        }
-
-                    };
+                public void onSubscribe(Disposable d) {
+                    t.onSubscribe(d);
                 }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public void onNext(Object value) {
+                    t.onNext((Integer)value - 9);
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
+
+                @Override
+                public void onComplete() {
+                    t.onComplete();
+                }
+
             });
 
             Observable.range(10, 3)
@@ -596,34 +522,29 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void flowableStart() {
         try {
-            RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
+            RxJavaPlugins.setOnFlowableSubscribe((_, t) -> new Subscriber() {
+
                 @Override
-                public Subscriber apply(Flowable f, final Subscriber t) {
-                    return new Subscriber() {
-
-                        @Override
-                        public void onSubscribe(Subscription s) {
-                            t.onSubscribe(s);
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public void onNext(Object value) {
-                            t.onNext((Integer)value - 9);
-                        }
-
-                        @Override
-                        public void onError(Throwable e) {
-                            t.onError(e);
-                        }
-
-                        @Override
-                        public void onComplete() {
-                            t.onComplete();
-                        }
-
-                    };
+                public void onSubscribe(Subscription s) {
+                    t.onSubscribe(s);
                 }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public void onNext(Object value) {
+                    t.onNext((Integer)value - 9);
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
+
+                @Override
+                public void onComplete() {
+                    t.onComplete();
+                }
+
             });
 
             Flowable.range(10, 3)
@@ -700,12 +621,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void singleCreate() {
         try {
-            RxJavaPlugins.setOnSingleAssembly(new Function<Single, Single>() {
-                @Override
-                public Single apply(Single t) {
-                    return new SingleJust<>(10);
-                }
-            });
+            RxJavaPlugins.setOnSingleAssembly(_ -> new SingleJust<>(10));
 
             Single.just(1)
             .test()
@@ -727,29 +643,24 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void singleStart() {
         try {
-            RxJavaPlugins.setOnSingleSubscribe(new BiFunction<Single, SingleObserver, SingleObserver>() {
+            RxJavaPlugins.setOnSingleSubscribe((_, t) -> new SingleObserver<Object>() {
+
                 @Override
-                public SingleObserver apply(Single o, final SingleObserver t) {
-                    return new SingleObserver<Object>() {
-
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            t.onSubscribe(d);
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public void onSuccess(Object value) {
-                            t.onSuccess(10);
-                        }
-
-                        @Override
-                        public void onError(Throwable e) {
-                            t.onError(e);
-                        }
-
-                    };
+                public void onSubscribe(Disposable d) {
+                    t.onSubscribe(d);
                 }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public void onSuccess(Object value) {
+                    t.onSuccess(10);
+                }
+
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
+
             });
 
             Single.just(1)
@@ -771,12 +682,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void completableCreate() {
         try {
-            RxJavaPlugins.setOnCompletableAssembly(new Function<Completable, Completable>() {
-                @Override
-                public Completable apply(Completable t) {
-                    return new CompletableError(new TestException());
-                }
-            });
+            RxJavaPlugins.setOnCompletableAssembly(_ -> new CompletableError(new TestException()));
 
             Completable.complete()
             .test()
@@ -797,25 +703,20 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void completableStart() {
         try {
-            RxJavaPlugins.setOnCompletableSubscribe(new BiFunction<Completable, CompletableObserver, CompletableObserver>() {
+            RxJavaPlugins.setOnCompletableSubscribe((_, t) -> new CompletableObserver() {
                 @Override
-                public CompletableObserver apply(Completable o, final CompletableObserver t) {
-                    return new CompletableObserver() {
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            t.onSubscribe(d);
-                        }
+                public void onSubscribe(Disposable d) {
+                    t.onSubscribe(d);
+                }
 
-                        @Override
-                        public void onError(Throwable e) {
-                            t.onError(e);
-                        }
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
 
-                        @Override
-                        public void onComplete() {
-                            t.onError(new TestException());
-                        }
-                    };
+                @Override
+                public void onComplete() {
+                    t.onError(new TestException());
                 }
             });
 
@@ -842,25 +743,14 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 final AtomicInteger value = new AtomicInteger();
                 final CountDownLatch cdl = new CountDownLatch(1);
 
-                RxJavaPlugins.setScheduleHandler(new Function<Runnable, Runnable>() {
-                    @Override
-                    public Runnable apply(Runnable t) {
-                        return new Runnable() {
-                            @Override
-                            public void run() {
-                                value.set(10);
-                                cdl.countDown();
-                            }
-                        };
-                    }
+                RxJavaPlugins.setScheduleHandler(_ -> (Runnable) () -> {
+                    value.set(10);
+                    cdl.countDown();
                 });
 
-                w.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        value.set(1);
-                        cdl.countDown();
-                    }
+                w.schedule(() -> {
+                    value.set(1);
+                    cdl.countDown();
                 });
 
                 cdl.await();
@@ -876,12 +766,9 @@ public class RxJavaPluginsTest extends RxJavaTest {
             final AtomicInteger value = new AtomicInteger();
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    value.set(1);
-                    cdl.countDown();
-                }
+            w.schedule(() -> {
+                value.set(1);
+                cdl.countDown();
             });
 
             cdl.await();
@@ -912,12 +799,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             final List<Throwable> list = new ArrayList<>();
 
-            RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    list.add(t);
-                }
-            });
+            RxJavaPlugins.setErrorHandler(list::add);
 
             RxJavaPlugins.onError(new TestException("Forced failure"));
 
@@ -935,14 +817,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             RxJavaPlugins.setErrorHandler(null);
 
-            Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread t, Throwable e) {
-                    list.add(e);
-
-                }
-            });
+            Thread.currentThread().setUncaughtExceptionHandler((_, e) -> list.add(e));
 
             RxJavaPlugins.onError(new TestException("Forced failure"));
 
@@ -964,21 +839,11 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             final List<Throwable> list = new ArrayList<>();
 
-            RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    throw new TestException("Forced failure 2");
-                }
+            RxJavaPlugins.setErrorHandler(_ -> {
+                throw new TestException("Forced failure 2");
             });
 
-            Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread t, Throwable e) {
-                    list.add(e);
-
-                }
-            });
+            Thread.currentThread().setUncaughtExceptionHandler((_, e) -> list.add(e));
 
             RxJavaPlugins.onError(new TestException("Forced failure"));
 
@@ -999,21 +864,11 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             final List<Throwable> list = new ArrayList<>();
 
-            RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    throw new TestException("Forced failure 2");
-                }
+            RxJavaPlugins.setErrorHandler(_ -> {
+                throw new TestException("Forced failure 2");
             });
 
-            Thread.currentThread().setUncaughtExceptionHandler(new UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread t, Throwable e) {
-                    list.add(e);
-
-                }
-            });
+            Thread.currentThread().setUncaughtExceptionHandler((_, e) -> list.add(e));
 
             RxJavaPlugins.onError(null);
 
@@ -1042,103 +897,34 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @SuppressWarnings("rawtypes")
     public void onErrorWithSuper() throws Exception {
         try {
-            Consumer<? super Throwable> errorHandler = new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) {
-                    throw new TestException("Forced failure 2");
-                }
+            Consumer<? super Throwable> errorHandler = (Consumer<Throwable>) _ -> {
+                throw new TestException("Forced failure 2");
             };
             RxJavaPlugins.setErrorHandler(errorHandler);
 
             Consumer<? super Throwable> errorHandler1 = RxJavaPlugins.getErrorHandler();
             assertSame(errorHandler, errorHandler1);
 
-            Function<? super Scheduler, ? extends Scheduler> scheduler2scheduler = new Function<Scheduler, Scheduler>() {
-                @Override
-                public Scheduler apply(Scheduler scheduler) throws Exception {
-                    return scheduler;
-                }
-            };
-            Function<? super Supplier<Scheduler>, ? extends Scheduler> callable2scheduler = new Function<Supplier<Scheduler>, Scheduler>() {
-                @Override
-                public Scheduler apply(Supplier<Scheduler> schedulerSupplier) throws Throwable {
-                    return schedulerSupplier.get();
-                }
-            };
+            Function<? super Scheduler, ? extends Scheduler> scheduler2scheduler = (Function<Scheduler, Scheduler>) scheduler -> scheduler;
+            Function<? super Supplier<Scheduler>, ? extends Scheduler> callable2scheduler = (Function<Supplier<Scheduler>, Scheduler>) Supplier::get;
             Function<? super ConnectableFlowable, ? extends ConnectableFlowable> connectableFlowable2ConnectableFlowable
-                = new Function<ConnectableFlowable, ConnectableFlowable>() {
-                @Override
-                public ConnectableFlowable apply(ConnectableFlowable connectableFlowable) throws Exception {
-                    return connectableFlowable;
-                }
-            };
+                = (Function<ConnectableFlowable, ConnectableFlowable>) connectableFlowable -> connectableFlowable;
             Function<? super ConnectableObservable, ? extends ConnectableObservable> connectableObservable2ConnectableObservable
-                = new Function<ConnectableObservable, ConnectableObservable>() {
-                @Override
-                public ConnectableObservable apply(ConnectableObservable connectableObservable) throws Exception {
-                    return connectableObservable;
-                }
-            };
-            Function<? super Flowable, ? extends Flowable> flowable2Flowable = new Function<Flowable, Flowable>() {
-                @Override
-                public Flowable apply(Flowable flowable) throws Exception {
-                    return flowable;
-                }
-            };
-            BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> flowable2subscriber = new BiFunction<Flowable, Subscriber, Subscriber>() {
-                @Override
-                public Subscriber apply(Flowable flowable, Subscriber subscriber) throws Exception {
-                    return subscriber;
-                }
-            };
-            Function<Maybe, Maybe> maybe2maybe = new Function<Maybe, Maybe>() {
-                @Override
-                public Maybe apply(Maybe maybe) throws Exception {
-                    return maybe;
-                }
-            };
-            BiFunction<Maybe, MaybeObserver, MaybeObserver> maybe2observer = new BiFunction<Maybe, MaybeObserver, MaybeObserver>() {
-                @Override
-                public MaybeObserver apply(Maybe maybe, MaybeObserver maybeObserver) throws Exception {
-                    return maybeObserver;
-                }
-            };
-            Function<Observable, Observable> observable2observable = new Function<Observable, Observable>() {
-                @Override
-                public Observable apply(Observable observable) throws Exception {
-                    return observable;
-                }
-            };
-            BiFunction<? super Observable, ? super Observer, ? extends Observer> observable2observer = new BiFunction<Observable, Observer, Observer>() {
-                @Override
-                public Observer apply(Observable observable, Observer observer) throws Exception {
-                    return observer;
-                }
-            };
-            Function<? super ParallelFlowable, ? extends ParallelFlowable> parallelFlowable2parallelFlowable = new Function<ParallelFlowable, ParallelFlowable>() {
-                @Override
-                public ParallelFlowable apply(ParallelFlowable parallelFlowable) throws Exception {
-                    return parallelFlowable;
-                }
-            };
-            Function<Single, Single> single2single = new Function<Single, Single>() {
-                @Override
-                public Single apply(Single single) throws Exception {
-                    return single;
-                }
-            };
-            BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> single2observer = new BiFunction<Single, SingleObserver, SingleObserver>() {
-                @Override
-                public SingleObserver apply(Single single, SingleObserver singleObserver) throws Exception {
-                    return singleObserver;
-                }
-            };
-            Function<? super Runnable, ? extends Runnable> runnable2runnable = new Function<Runnable, Runnable>() {
-                @Override
-                public Runnable apply(Runnable runnable) throws Exception {
-                    return runnable;
-                }
-            };
+                = (Function<ConnectableObservable, ConnectableObservable>) connectableObservable -> connectableObservable;
+            Function<? super Flowable, ? extends Flowable> flowable2Flowable = (Function<Flowable, Flowable>) flowable -> flowable;
+            BiFunction<? super Flowable, ? super Subscriber, ? extends Subscriber> flowable2subscriber =
+                    (BiFunction<Flowable, Subscriber, Subscriber>) (_, subscriber) -> subscriber;
+            Function<Maybe, Maybe> maybe2maybe = maybe -> maybe;
+            BiFunction<Maybe, MaybeObserver, MaybeObserver> maybe2observer = (_, maybeObserver) -> maybeObserver;
+            Function<Observable, Observable> observable2observable = observable -> observable;
+            BiFunction<? super Observable, ? super Observer, ? extends Observer> observable2observer =
+                    (BiFunction<Observable, Observer, Observer>) (_, observer) -> observer;
+            Function<? super ParallelFlowable, ? extends ParallelFlowable> parallelFlowable2parallelFlowable =
+                    (Function<ParallelFlowable, ParallelFlowable>) parallelFlowable -> parallelFlowable;
+            Function<Single, Single> single2single = single -> single;
+            BiFunction<? super Single, ? super SingleObserver, ? extends SingleObserver> single2observer =
+                    (BiFunction<Single, SingleObserver, SingleObserver>) (_, singleObserver) -> singleObserver;
+            Function<? super Runnable, ? extends Runnable> runnable2runnable = (Function<Runnable, Runnable>) runnable -> runnable;
             BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver
                 = (_, completableObserver) -> completableObserver;
             Function<? super Completable, ? extends Completable> completable2completable = completable -> completable;
@@ -1302,12 +1088,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             assertSame(allArray, RxJavaPlugins.onSubscribe(Flowable.never().parallel(), allArray));
 
             final Scheduler s = ImmediateThinScheduler.INSTANCE;
-            Supplier<Scheduler> c = new Supplier<Scheduler>() {
-                @Override
-                public Scheduler get() throws Exception {
-                    return s;
-                }
-            };
+            Supplier<Scheduler> c = () -> s;
             assertSame(s, RxJavaPlugins.onComputationScheduler(s));
 
             assertSame(s, RxJavaPlugins.onCachedScheduler(s));
@@ -1351,29 +1132,24 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideConnectableObservable() {
         try {
-            RxJavaPlugins.setOnConnectableObservableAssembly(new Function<ConnectableObservable, ConnectableObservable>() {
+            RxJavaPlugins.setOnConnectableObservableAssembly(_ -> new ConnectableObservable() {
+
                 @Override
-                public ConnectableObservable apply(ConnectableObservable co) throws Exception {
-                    return new ConnectableObservable() {
+                public void connect(Consumer connection) {
 
-                        @Override
-                        public void connect(Consumer connection) {
+                }
 
-                        }
+                @Override
+                public void reset() {
+                    // nothing to do in this test
+                }
 
-                        @Override
-                        public void reset() {
-                            // nothing to do in this test
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        protected void subscribeActual(Observer observer) {
-                            observer.onSubscribe(Disposable.empty());
-                            observer.onNext(10);
-                            observer.onComplete();
-                        }
-                    };
+                @SuppressWarnings("unchecked")
+                @Override
+                protected void subscribeActual(Observer observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onNext(10);
+                    observer.onComplete();
                 }
             });
 
@@ -1400,27 +1176,22 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideConnectableFlowable() {
         try {
-            RxJavaPlugins.setOnConnectableFlowableAssembly(new Function<ConnectableFlowable, ConnectableFlowable>() {
+            RxJavaPlugins.setOnConnectableFlowableAssembly(_ -> new ConnectableFlowable() {
+
                 @Override
-                public ConnectableFlowable apply(ConnectableFlowable co) throws Exception {
-                    return new ConnectableFlowable() {
+                public void connect(Consumer connection) {
 
-                        @Override
-                        public void connect(Consumer connection) {
+                }
 
-                        }
+                @Override
+                public void reset() {
+                    // nothing to do in this test
+                }
 
-                        @Override
-                        public void reset() {
-                            // nothing to do in this test
-                        }
-
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        protected void subscribeActual(Subscriber subscriber) {
-                            subscriber.onSubscribe(new ScalarSubscription(subscriber, 10));
-                        }
-                    };
+                @SuppressWarnings("unchecked")
+                @Override
+                protected void subscribeActual(Subscriber subscriber) {
+                    subscriber.onSubscribe(new ScalarSubscription(subscriber, 10));
                 }
             });
 
@@ -1447,11 +1218,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void assemblyHookCrashes() {
         try {
-            RxJavaPlugins.setOnFlowableAssembly(new Function<Flowable, Flowable>() {
-                @Override
-                public Flowable apply(Flowable f) throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            RxJavaPlugins.setOnFlowableAssembly(_ -> {
+                throw new IllegalArgumentException();
             });
 
             try {
@@ -1461,11 +1229,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 // expected
             }
 
-            RxJavaPlugins.setOnFlowableAssembly(new Function<Flowable, Flowable>() {
-                @Override
-                public Flowable apply(Flowable f) throws Exception {
-                    throw new InternalError();
-                }
+            RxJavaPlugins.setOnFlowableAssembly(_ -> {
+                throw new InternalError();
             });
 
             try {
@@ -1475,11 +1240,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 // expected
             }
 
-            RxJavaPlugins.setOnFlowableAssembly(new Function<Flowable, Flowable>() {
-                @Override
-                public Flowable apply(Flowable f) throws Exception {
-                    throw new IOException();
-                }
+            RxJavaPlugins.setOnFlowableAssembly(_ -> {
+                throw new IOException();
             });
 
             try {
@@ -1499,11 +1261,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void subscribeHookCrashes() {
         try {
-            RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
-                @Override
-                public Subscriber apply(Flowable f, Subscriber s) throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            RxJavaPlugins.setOnFlowableSubscribe((_, _) -> {
+                throw new IllegalArgumentException();
             });
 
             try {
@@ -1515,11 +1274,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 }
             }
 
-            RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
-                @Override
-                public Subscriber apply(Flowable f, Subscriber s) throws Exception {
-                    throw new InternalError();
-                }
+            RxJavaPlugins.setOnFlowableSubscribe((_, _) -> {
+                throw new InternalError();
             });
 
             try {
@@ -1529,11 +1285,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
                 // expected
             }
 
-            RxJavaPlugins.setOnFlowableSubscribe(new BiFunction<Flowable, Subscriber, Subscriber>() {
-                @Override
-                public Subscriber apply(Flowable f, Subscriber s) throws Exception {
-                    throw new IOException();
-                }
+            RxJavaPlugins.setOnFlowableSubscribe((_, _) -> {
+                throw new IOException();
             });
 
             try {
@@ -1556,12 +1309,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void maybeCreate() {
         try {
-            RxJavaPlugins.setOnMaybeAssembly(new Function<Maybe, Maybe>() {
-                @Override
-                public Maybe apply(Maybe t) {
-                    return new MaybeError(new TestException());
-                }
-            });
+            RxJavaPlugins.setOnMaybeAssembly(_ -> new MaybeError(new TestException()));
 
             Maybe.empty()
             .test()
@@ -1583,31 +1331,26 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @SuppressWarnings("rawtypes")
     public void maybeStart() {
         try {
-            RxJavaPlugins.setOnMaybeSubscribe(new BiFunction<Maybe, MaybeObserver, MaybeObserver>() {
+            RxJavaPlugins.setOnMaybeSubscribe((_, t) -> new MaybeObserver() {
                 @Override
-                public MaybeObserver apply(Maybe o, final MaybeObserver t) {
-                    return new MaybeObserver() {
-                        @Override
-                        public void onSubscribe(Disposable d) {
-                            t.onSubscribe(d);
-                        }
+                public void onSubscribe(Disposable d) {
+                    t.onSubscribe(d);
+                }
 
-                        @SuppressWarnings("unchecked")
-                        @Override
-                        public void onSuccess(Object value) {
-                            t.onSuccess(value);
-                        }
+                @SuppressWarnings("unchecked")
+                @Override
+                public void onSuccess(Object value) {
+                    t.onSuccess(value);
+                }
 
-                        @Override
-                        public void onError(Throwable e) {
-                            t.onError(e);
-                        }
+                @Override
+                public void onError(Throwable e) {
+                    t.onError(e);
+                }
 
-                        @Override
-                        public void onComplete() {
-                            t.onError(new TestException());
-                        }
-                    };
+                @Override
+                public void onComplete() {
+                    t.onError(new TestException());
                 }
             });
 
@@ -1633,12 +1376,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             final AtomicReference<Throwable> t = new AtomicReference<>();
 
-            RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-                @Override
-                public void accept(final Throwable throwable) throws Exception {
-                    t.set(throwable);
-                }
-            });
+            RxJavaPlugins.setErrorHandler(t::set);
 
             RxJavaPlugins.onError(null);
 
@@ -1658,12 +1396,9 @@ public class RxJavaPluginsTest extends RxJavaTest {
             final AtomicReference<Thread> value = new AtomicReference<>();
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    value.set(Thread.currentThread());
-                    cdl.countDown();
-                }
+            w.schedule(() -> {
+                value.set(Thread.currentThread());
+                cdl.countDown();
             });
 
             cdl.await();
@@ -1681,20 +1416,10 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void createComputationScheduler() {
         final String name = "ComputationSchedulerTest";
-        ThreadFactory factory = new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                return new Thread(r, name);
-            }
-        };
+        ThreadFactory factory = r -> new Thread(r, name);
 
         final Scheduler customScheduler = RxJavaPlugins.createComputationScheduler(factory);
-        RxJavaPlugins.setComputationSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler scheduler) throws Exception {
-                return customScheduler;
-            }
-        });
+        RxJavaPlugins.setComputationSchedulerHandler(_ -> customScheduler);
 
         try {
             verifyThread(Schedulers.computation(), name);
@@ -1707,20 +1432,10 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void createCachedScheduler() {
         final String name = "CachedSchedulerTest";
-        ThreadFactory factory = new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                return new Thread(r, name);
-            }
-        };
+        ThreadFactory factory = r -> new Thread(r, name);
 
         final Scheduler customScheduler = RxJavaPlugins.createCachedScheduler(factory);
-        RxJavaPlugins.setCachedSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler scheduler) throws Exception {
-                return customScheduler;
-            }
-        });
+        RxJavaPlugins.setCachedSchedulerHandler(_ -> customScheduler);
 
         try {
             verifyThread(Schedulers.cached(), name);
@@ -1733,20 +1448,10 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void createNewThreadScheduler() {
         final String name = "NewThreadSchedulerTest";
-        ThreadFactory factory = new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                return new Thread(r, name);
-            }
-        };
+        ThreadFactory factory = r -> new Thread(r, name);
 
         final Scheduler customScheduler = RxJavaPlugins.createNewThreadScheduler(factory);
-        RxJavaPlugins.setNewThreadSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler scheduler) throws Exception {
-                return customScheduler;
-            }
-        });
+        RxJavaPlugins.setNewThreadSchedulerHandler(_ -> customScheduler);
 
         try {
             verifyThread(Schedulers.newThread(), name);
@@ -1759,21 +1464,11 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void createSingleScheduler() {
         final String name = "SingleSchedulerTest";
-        ThreadFactory factory = new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                return new Thread(r, name);
-            }
-        };
+        ThreadFactory factory = r -> new Thread(r, name);
 
         final Scheduler customScheduler = RxJavaPlugins.createSingleScheduler(factory);
 
-        RxJavaPlugins.setSingleSchedulerHandler(new Function<Scheduler, Scheduler>() {
-            @Override
-            public Scheduler apply(Scheduler scheduler) throws Exception {
-                return customScheduler;
-            }
-        });
+        RxJavaPlugins.setSingleSchedulerHandler(_ -> customScheduler);
 
         try {
             verifyThread(Schedulers.single(), name);
@@ -1786,11 +1481,8 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onBeforeBlocking() {
         try {
-            RxJavaPlugins.setOnBeforeBlocking(new BooleanSupplier() {
-                @Override
-                public boolean getAsBoolean() throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            RxJavaPlugins.setOnBeforeBlocking(() -> {
+                throw new IllegalArgumentException();
             });
 
             try {
@@ -1808,12 +1500,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void onParallelAssembly() {
         try {
-            RxJavaPlugins.setOnParallelAssembly(new Function<ParallelFlowable, ParallelFlowable>() {
-                @Override
-                public ParallelFlowable apply(ParallelFlowable pf) throws Exception {
-                    return new ParallelFromPublisher<>(Flowable.just(2), 2, 2);
-                }
-            });
+            RxJavaPlugins.setOnParallelAssembly(_ -> new ParallelFromPublisher<>(Flowable.just(2), 2, 2));
 
             Flowable.just(1)
             .parallel()

--- a/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
@@ -481,11 +481,8 @@ public class MulticastProcessorTest extends RxJavaTest {
     @Test
     public void fusionCrash() {
         MulticastProcessor<Integer> mp = Flowable.range(1, 5)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new IOException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new IOException();
         })
         .subscribeWith(MulticastProcessor.<Integer>create());
 
@@ -543,19 +540,9 @@ public class MulticastProcessorTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = mp.test();
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    mp.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> mp.subscribe(ts2);
 
             TestHelper.race(r1, r2);
 
@@ -572,19 +559,9 @@ public class MulticastProcessorTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = mp.test();
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    mp.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> mp.subscribe(ts2);
 
             TestHelper.race(r1, r2);
 
@@ -600,19 +577,9 @@ public class MulticastProcessorTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = mp.test();
             final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    mp.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> mp.subscribe(ts2);
 
             TestHelper.race(r1, r2);
         }
@@ -648,19 +615,9 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = mp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 
@@ -677,19 +634,9 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = mp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(5);
-                }
-            };
+            Runnable r1 = () -> ts.request(5);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    source.subscribe(mp);
-                }
-            };
+            Runnable r2 = () -> source.subscribe(mp);
 
             TestHelper.race(r1, r2);
 
@@ -707,19 +654,9 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts = mp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    mp.onNext(1);
-                }
-            };
+            Runnable r2 = () -> mp.onNext(1);
 
             TestHelper.race(r1, r2);
         }
@@ -735,19 +672,9 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             mp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = ts1::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts2.cancel();
-                }
-            };
+            Runnable r2 = ts2::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -760,19 +687,9 @@ public class MulticastProcessorTest extends RxJavaTest {
 
             final TestSubscriber<Integer> ts1 = mp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = ts1::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.request(1);
-                }
-            };
+            Runnable r2 = () -> ts1.request(1);
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -23,7 +23,6 @@ import org.junit.*;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.DefaultSubscriber;
 import io.reactivex.rxjava4.testsupport.TestSubscriberEx;
@@ -33,24 +32,14 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
         final ReplayProcessor<Long> replay = ReplayProcessor.createUnbounded();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Flowable.unsafeCreate(new Publisher<Long>() {
-
-                    @Override
-                    public void subscribe(Subscriber<? super Long> subscriber) {
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            subscriber.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        subscriber.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Flowable.unsafeCreate((Publisher<Long>) subscriber -> {
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                subscriber.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            subscriber.onComplete();
+        }).subscribe(replay));
         source.start();
 
         long v = replay.blockingLast();
@@ -58,76 +47,68 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
-        Thread slowThread = new Thread(new Runnable() {
+        Thread slowThread = new Thread(() -> {
+            Subscriber<Long> slow = new DefaultSubscriber<Long>() {
 
-            @Override
-            public void run() {
-                Subscriber<Long> slow = new DefaultSubscriber<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Slow Observer completed");
-                        slowLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Slow Observer STARTED");
-                        }
-                        try {
-                            if (args % 10 == 0) {
-                                Thread.sleep(1);
-                            }
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                };
-                replay.subscribe(slow);
-                try {
-                    slowLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Slow Observer completed");
+                    slowLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Slow Observer STARTED");
+                    }
+                    try {
+                        if (args % 10 == 0) {
+                            Thread.sleep(1);
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            replay.subscribe(slow);
+            try {
+                slowLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         slowThread.start();
 
-        Thread fastThread = new Thread(new Runnable() {
+        Thread fastThread = new Thread(() -> {
+            final CountDownLatch fastLatch = new CountDownLatch(1);
+            Subscriber<Long> fast = new DefaultSubscriber<Long>() {
 
-            @Override
-            public void run() {
-                final CountDownLatch fastLatch = new CountDownLatch(1);
-                Subscriber<Long> fast = new DefaultSubscriber<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Fast Observer completed");
-                        fastLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Fast Observer STARTED");
-                        }
-                    }
-                };
-                replay.subscribe(fast);
-                try {
-                    fastLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Fast Observer completed");
+                    fastLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Fast Observer STARTED");
+                    }
+                }
+            };
+            replay.subscribe(fast);
+            try {
+                fastLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         fastThread.start();
@@ -142,24 +123,14 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplayProcessor<Long> replay = ReplayProcessor.createUnbounded();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Flowable.unsafeCreate(new Publisher<Long>() {
-
-                    @Override
-                    public void subscribe(Subscriber<? super Long> subscriber) {
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            subscriber.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        subscriber.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Flowable.unsafeCreate((Publisher<Long>) subscriber -> {
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                subscriber.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            subscriber.onComplete();
+        }).subscribe(replay));
 
         // used to collect results of each thread
         final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
@@ -176,14 +147,10 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
                 // wait for source to finish then keep adding after it's done
                 source.join();
             }
-            Thread t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    List<Long> values = replay.toList().blockingGet();
-                    listOfListsOfValues.add(values);
-                    System.out.println("Finished thread: " + count);
-                }
+            Thread t = new Thread(() -> {
+                List<Long> values = replay.toList().blockingGet();
+                listOfListsOfValues.add(values);
+                System.out.println("Finished thread: " + count);
             });
             t.start();
             System.out.println("Started thread: " + i);
@@ -231,28 +198,19 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
             final ReplayProcessor<String> processor = ReplayProcessor.createUnbounded();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            processor.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            processor.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    processor.onNext("value");
-                    processor.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                processor.onNext("value");
+                processor.onComplete();
             });
 
             SubjectObserverThread t2 = new SubjectObserverThread(processor);
@@ -337,17 +295,14 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
 //                int j = i;
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-//                        System.out.println("> " + j);
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+//                        System.out.println("> " + j);
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -394,12 +349,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(rs::onComplete);
                 }
             }
         } finally {
@@ -412,22 +362,19 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         final ReplayProcessor<Object> rs = ReplayProcessor.createUnbounded();
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {
@@ -467,22 +414,19 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         final ReplayProcessor<Object> rs = ReplayProcessor.createWithSize(3);
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {
@@ -511,29 +455,26 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         final ReplayProcessor<Object> rs = ReplayProcessor.createWithTime(1, TimeUnit.MILLISECONDS, Schedulers.computation());
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                    if (i % 10000 == 0) {
-                        try {
-                            Thread.sleep(1);
-                        } catch (InterruptedException e) {
-                            return;
-                        }
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
+            }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+                if (i % 10000 == 0) {
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        return;
                     }
                 }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
             }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -23,7 +23,6 @@ import org.junit.*;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.DefaultSubscriber;
 import io.reactivex.rxjava4.testsupport.TestSubscriberEx;
@@ -33,24 +32,14 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
         final ReplayProcessor<Long> replay = ReplayProcessor.create();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Flowable.unsafeCreate(new Publisher<Long>() {
-
-                    @Override
-                    public void subscribe(Subscriber<? super Long> subscriber) {
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            subscriber.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        subscriber.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Flowable.unsafeCreate((Publisher<Long>) subscriber -> {
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                subscriber.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            subscriber.onComplete();
+        }).subscribe(replay));
         source.start();
 
         long v = replay.blockingLast();
@@ -58,76 +47,68 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
-        Thread slowThread = new Thread(new Runnable() {
+        Thread slowThread = new Thread(() -> {
+            Subscriber<Long> slow = new DefaultSubscriber<Long>() {
 
-            @Override
-            public void run() {
-                Subscriber<Long> slow = new DefaultSubscriber<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Slow Observer completed");
-                        slowLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Slow Observer STARTED");
-                        }
-                        try {
-                            if (args % 10 == 0) {
-                                Thread.sleep(1);
-                            }
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                };
-                replay.subscribe(slow);
-                try {
-                    slowLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Slow Observer completed");
+                    slowLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Slow Observer STARTED");
+                    }
+                    try {
+                        if (args % 10 == 0) {
+                            Thread.sleep(1);
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            replay.subscribe(slow);
+            try {
+                slowLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         slowThread.start();
 
-        Thread fastThread = new Thread(new Runnable() {
+        Thread fastThread = new Thread(() -> {
+            final CountDownLatch fastLatch = new CountDownLatch(1);
+            Subscriber<Long> fast = new DefaultSubscriber<Long>() {
 
-            @Override
-            public void run() {
-                final CountDownLatch fastLatch = new CountDownLatch(1);
-                Subscriber<Long> fast = new DefaultSubscriber<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Fast Observer completed");
-                        fastLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Fast Observer STARTED");
-                        }
-                    }
-                };
-                replay.subscribe(fast);
-                try {
-                    fastLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Fast Observer completed");
+                    fastLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Fast Observer STARTED");
+                    }
+                }
+            };
+            replay.subscribe(fast);
+            try {
+                fastLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         fastThread.start();
@@ -142,24 +123,14 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplayProcessor<Long> replay = ReplayProcessor.create();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Flowable.unsafeCreate(new Publisher<Long>() {
-
-                    @Override
-                    public void subscribe(Subscriber<? super Long> subscriber) {
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            subscriber.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        subscriber.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Flowable.unsafeCreate((Publisher<Long>) subscriber -> {
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                subscriber.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            subscriber.onComplete();
+        }).subscribe(replay));
 
         // used to collect results of each thread
         final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
@@ -176,14 +147,10 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                 // wait for source to finish then keep adding after it's done
                 source.join();
             }
-            Thread t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    List<Long> values = replay.toList().blockingGet();
-                    listOfListsOfValues.add(values);
-                    System.out.println("Finished thread: " + count);
-                }
+            Thread t = new Thread(() -> {
+                List<Long> values = replay.toList().blockingGet();
+                listOfListsOfValues.add(values);
+                System.out.println("Finished thread: " + count);
             });
             t.start();
             System.out.println("Started thread: " + i);
@@ -231,28 +198,19 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
             final ReplayProcessor<String> processor = ReplayProcessor.create();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            processor.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            processor.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    processor.onNext("value");
-                    processor.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                processor.onNext("value");
+                processor.onComplete();
             });
 
             SubjectObserverThread t2 = new SubjectObserverThread(processor);
@@ -335,16 +293,13 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                 final CountDownLatch finish = new CountDownLatch(1);
                 final CountDownLatch start = new CountDownLatch(1);
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -381,12 +336,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(rs::onComplete);
 
                 }
             }
@@ -400,22 +350,19 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         final ReplayProcessor<Object> rs = ReplayProcessor.create();
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
@@ -382,13 +382,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             src.onNext(v);
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
-                .flatMap(new Function<String, Flowable<String>>() {
-
-                    @Override
-                    public Flowable<String> apply(String t1) {
-                        return Flowable.just(t1 + ", " + t1);
-                    }
-                })
+                .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
                 .subscribe(new DefaultSubscriber<String>() {
                     @Override
                     public void onNext(String t) {
@@ -1035,19 +1029,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    rp.subscribe(ts);
-                }
-            };
+            Runnable r1 = () -> rp.subscribe(ts);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -1070,12 +1054,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final ReplayProcessor<Integer> rp = ReplayProcessor.create();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    rp.test();
-                }
-            };
+            Runnable r1 = rp::test;
 
             TestHelper.race(r1, r1);
         }
@@ -1102,19 +1081,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             final TestSubscriber<Integer> ts1 = rp.test();
             final TestSubscriber<Integer> ts2 = rp.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts1.cancel();
-                }
-            };
+            Runnable r1 = ts1::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts2.cancel();
-                }
-            };
+            Runnable r2 = ts2::cancel;
 
             TestHelper.race(r1, r2);
 
@@ -1157,19 +1126,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.DAYS, Schedulers.single(), 2);
             final TestSubscriber<Integer> ts = rp.test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r1 = () -> ts.request(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    rp.onNext(1);
-                }
-            };
+            Runnable r2 = () -> rp.onNext(1);
 
             TestHelper.race(r1, r2);
         }
@@ -1338,19 +1297,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Integer> ts = source.test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.onComplete();
-                }
-            };
+            Runnable r1 = source::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 
@@ -1365,19 +1314,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Integer> ts = source.test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.onComplete();
-                }
-            };
+            Runnable r1 = source::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 
@@ -1392,19 +1331,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Integer> ts = source.test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.onComplete();
-                }
-            };
+            Runnable r1 = source::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 
@@ -1419,19 +1348,9 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
             final TestSubscriber<Integer> ts = source.test(0);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    source.onComplete();
-                }
-            };
+            Runnable r1 = source::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 
@@ -1705,12 +1624,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         final ReplayProcessor<byte[]> rp = ReplayProcessor.createWithSize(1);
 
         Flowable<byte[]> source = rp.take(1)
-        .concatMap(new Function<byte[], Publisher<byte[]>>() {
-            @Override
-            public Publisher<byte[]> apply(byte[] v) throws Exception {
-                return rp;
-            }
-        })
+        .concatMap((Function<byte[], Publisher<byte[]>>) v -> rp)
         .takeLast(1)
         ;
 
@@ -1730,19 +1644,16 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final AtomicLong after = new AtomicLong();
 
-        source.subscribe(new Consumer<byte[]>() {
-            @Override
-            public void accept(byte[] v) throws Exception {
-                System.out.println("Bounded Replay Leak check: Wait before GC 2");
-                Thread.sleep(1000);
+        source.subscribe(v -> {
+            System.out.println("Bounded Replay Leak check: Wait before GC 2");
+            Thread.sleep(1000);
 
-                System.out.println("Bounded Replay Leak check:  GC 2");
-                System.gc();
+            System.out.println("Bounded Replay Leak check:  GC 2");
+            System.gc();
 
-                Thread.sleep(500);
+            Thread.sleep(500);
 
-                after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
-            }
+            after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
         });
 
         for (int i = 0; i < 200; i++) {

--- a/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
@@ -424,19 +424,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             TestSubscriberEx<Integer> ts = s.to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(2);
-                }
-            };
+            Runnable r2 = () -> s.onNext(2);
 
             TestHelper.race(r1, r2);
 
@@ -460,19 +450,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onError(ex);
-                }
-            };
+            Runnable r2 = () -> s.onError(ex);
 
             TestHelper.race(r1, r2);
 
@@ -491,19 +471,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             TestSubscriber<Integer> ts = s.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r2 = s::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -524,19 +494,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             final BooleanSubscription bs = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs);
 
             TestHelper.race(r1, r2);
 
@@ -553,19 +513,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             final BooleanSubscription bs = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r1 = s::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs);
 
             TestHelper.race(r1, r2);
 
@@ -580,19 +530,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             TestSubscriber<Integer> ts = s.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r1 = s::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r2 = s::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -611,19 +551,9 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> s.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> s.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -646,19 +576,9 @@ public class SerializedProcessorTest extends RxJavaTest {
             final BooleanSubscription bs1 = new BooleanSubscription();
             final BooleanSubscription bs2 = new BooleanSubscription();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs1);
-                }
-            };
+            Runnable r1 = () -> s.onSubscribe(bs1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs2);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs2);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
@@ -110,10 +110,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
     @Test
     public void threeArgsFactory() {
-        Runnable noop = new Runnable() {
-            @Override
-            public void run() {
-            }
+        Runnable noop = () -> {
         };
         UnicastProcessor<Integer> ap = UnicastProcessor.create(16, noop, false);
         ap.onNext(1);
@@ -131,11 +128,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenOnError() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         assertFalse(didRunOnTerminate.get());
         up.onError(new RuntimeException("some error"));
@@ -146,11 +139,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenOnComplete() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         assertFalse(didRunOnTerminate.get());
         up.onComplete();
@@ -161,11 +150,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void onTerminateCalledWhenCanceled() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         final Disposable subscribe = up.subscribe();
 
@@ -193,28 +178,13 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     public void completeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final int[] calls = { 0 };
-            final UnicastProcessor<Object> up = UnicastProcessor.create(100, new Runnable() {
-                @Override
-                public void run() {
-                    calls[0]++;
-                }
-            });
+            final UnicastProcessor<Object> up = UnicastProcessor.create(100, () -> calls[0]++);
 
             final TestSubscriber<Object> ts = up.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r1 = ts::cancel;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    up.onComplete();
-                }
-            };
+            Runnable r2 = up::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -306,19 +276,9 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
             p.subscribe(ts);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onNext(1);
-                }
-            };
+            Runnable r1 = () -> p.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }
@@ -332,19 +292,9 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
             final TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
             final TestSubscriberEx<Integer> ts2 = new TestSubscriberEx<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    up.subscribe(ts1);
-                }
-            };
+            Runnable r1 = () -> up.subscribe(ts1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    up.subscribe(ts2);
-                }
-            };
+            Runnable r2 = () -> up.subscribe(ts2);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
@@ -67,12 +67,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
     private void tryOutSchedulers() throws InterruptedException {
         final CountDownLatch cdl = new CountDownLatch(4);
 
-        final Runnable countAction = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        final Runnable countAction = cdl::countDown;
 
         @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -38,12 +38,7 @@ public class SchedulerTest extends RxJavaTest {
 
         TestScheduler scheduler = new TestScheduler();
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-            }
-        }, 100, 100, TimeUnit.MILLISECONDS);
+        Disposable d = scheduler.schedulePeriodicallyDirect(() -> count[0]++, 100, 100, TimeUnit.MILLISECONDS);
 
         assertEquals(0, count[0]);
         assertFalse(d.isDisposed());
@@ -67,11 +62,8 @@ public class SchedulerTest extends RxJavaTest {
             TestScheduler scheduler = new TestScheduler();
 
             try {
-                scheduler.schedulePeriodicallyDirect(new Runnable() {
-                    @Override
-                    public void run() {
-                        throw new TestException();
-                    }
+                scheduler.schedulePeriodicallyDirect(() -> {
+                    throw new TestException();
                 }, 100, 100, TimeUnit.MILLISECONDS);
 
                 scheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
@@ -91,12 +83,7 @@ public class SchedulerTest extends RxJavaTest {
 
         TestScheduler scheduler = new TestScheduler();
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-            }
-        }, 100, 100, TimeUnit.MILLISECONDS);
+        Disposable d = scheduler.schedulePeriodicallyDirect(() -> count[0]++, 100, 100, TimeUnit.MILLISECONDS);
 
         d.dispose();
 
@@ -115,12 +102,7 @@ public class SchedulerTest extends RxJavaTest {
 
         TestScheduler scheduler = new TestScheduler();
 
-        scheduler.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-            }
-        }, 100, TimeUnit.MILLISECONDS);
+        scheduler.scheduleDirect(() -> count[0]++, 100, TimeUnit.MILLISECONDS);
 
         assertEquals(0, count[0]);
 
@@ -138,12 +120,9 @@ public class SchedulerTest extends RxJavaTest {
         @SuppressWarnings("resource")
         final SequentialDisposable sd = new SequentialDisposable();
 
-        Disposable d = scheduler.schedulePeriodicallyDirect(new Runnable() {
-            @Override
-            public void run() {
-                count[0]++;
-                sd.dispose();
-            }
+        Disposable d = scheduler.schedulePeriodicallyDirect(() -> {
+            count[0]++;
+            sd.dispose();
         }, 100, 100, TimeUnit.MILLISECONDS);
 
         sd.set(d);
@@ -169,12 +148,9 @@ public class SchedulerTest extends RxJavaTest {
             @SuppressWarnings("resource")
             final SequentialDisposable sd = new SequentialDisposable();
 
-            Disposable d = worker.schedulePeriodically(new Runnable() {
-                @Override
-                public void run() {
-                    count[0]++;
-                    sd.dispose();
-                }
+            Disposable d = worker.schedulePeriodically(() -> {
+                count[0]++;
+                sd.dispose();
             }, 100, 100, TimeUnit.MILLISECONDS);
 
             sd.set(d);
@@ -198,19 +174,9 @@ public class SchedulerTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final Disposable d = scheduler.schedulePeriodicallyDirect(Functions.EMPTY_RUNNABLE, 1, 1, TimeUnit.MILLISECONDS);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    d.dispose();
-                }
-            };
+            Runnable r1 = d::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-                }
-            };
+            Runnable r2 = () -> scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
             TestHelper.race(r1, r2);
         }
@@ -236,11 +202,8 @@ public class SchedulerTest extends RxJavaTest {
     public void scheduleDirectThrows() throws Exception {
         List<Throwable> list = TestHelper.trackPluginErrors();
         try {
-            Schedulers.cached().scheduleDirect(new Runnable() {
-                @Override
-                public void run() {
-                    throw new TestException();
-                }
+            Schedulers.cached().scheduleDirect(() -> {
+                throw new TestException();
             });
 
             Thread.sleep(250);
@@ -324,10 +287,7 @@ public class SchedulerTest extends RxJavaTest {
     public void unwrapDefaultPeriodicTask() {
         TestScheduler scheduler = new TestScheduler();
 
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-            }
+        Runnable runnable = () -> {
         };
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) scheduler.schedulePeriodicallyDirect(runnable, 100, 100, TimeUnit.MILLISECONDS);
 
@@ -338,10 +298,7 @@ public class SchedulerTest extends RxJavaTest {
     public void unwrapScheduleDirectTask() {
         TestScheduler scheduler = new TestScheduler();
 
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-            }
+        Runnable runnable = () -> {
         };
         SchedulerRunnableIntrospection wrapper = (SchedulerRunnableIntrospection) scheduler.scheduleDirect(runnable, 100, TimeUnit.MILLISECONDS);
         assertSame(runnable, wrapper.getWrappedRunnable());
@@ -349,10 +306,7 @@ public class SchedulerTest extends RxJavaTest {
 
     @Test
     public void unwrapWorkerPeriodicTask() {
-        final Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-            }
+        final Runnable runnable = () -> {
         };
 
         Scheduler scheduler = new Scheduler() {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerWorkerTest.java
@@ -78,12 +78,7 @@ public class SchedulerWorkerTest extends RxJavaTest {
         try {
             final List<Long> times = new ArrayList<>();
 
-            Disposable d = w.schedulePeriodically(new Runnable() {
-                @Override
-                public void run() {
-                    times.add(System.currentTimeMillis());
-                }
-            }, 100, 100, TimeUnit.MILLISECONDS);
+            Disposable d = w.schedulePeriodically(() -> times.add(System.currentTimeMillis()), 100, 100, TimeUnit.MILLISECONDS);
 
             Thread.sleep(150);
 
@@ -120,12 +115,7 @@ public class SchedulerWorkerTest extends RxJavaTest {
         try {
             final List<Long> times = new ArrayList<>();
 
-            Disposable d = w.schedulePeriodically(new Runnable() {
-                @Override
-                public void run() {
-                    times.add(System.currentTimeMillis());
-                }
-            }, 100, 100, TimeUnit.MILLISECONDS);
+            Disposable d = w.schedulePeriodically(() -> times.add(System.currentTimeMillis()), 100, 100, TimeUnit.MILLISECONDS);
 
             Thread.sleep(150);
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TrampolineSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TrampolineSchedulerTest.java
@@ -43,22 +43,12 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
         Flowable<Integer> f1 = Flowable.<Integer> just(1, 2, 3, 4, 5);
         Flowable<Integer> f2 = Flowable.<Integer> just(6, 7, 8, 9, 10);
-        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.trampoline()).map(new Function<Integer, String>() {
-
-            @Override
-            public String apply(Integer t) {
-                assertEquals(Thread.currentThread().getName(), currentThreadName);
-                return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
-            }
+        Flowable<String> f = Flowable.<Integer> merge(f1, f2).subscribeOn(Schedulers.trampoline()).map(t -> {
+            assertEquals(Thread.currentThread().getName(), currentThreadName);
+            return "Value_" + t + "_Thread_" + Thread.currentThread().getName();
         });
 
-        f.blockingForEach(new Consumer<String>() {
-
-            @Override
-            public void accept(String t) {
-                System.out.println("t: " + t);
-            }
-        });
+        f.blockingForEach(t -> System.out.println("t: " + t));
     }
 
     @Test
@@ -69,26 +59,14 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
         Worker worker = Schedulers.trampoline().createWorker();
         try {
             workers.add(worker);
-            worker.schedule(new Runnable() {
-
-                @Override
-                public void run() {
-                    workers.add(doWorkOnNewTrampoline("A", workDone));
-                }
-
-            });
+            worker.schedule(() -> workers.add(doWorkOnNewTrampoline("A", workDone)));
 
             final Worker worker2 = Schedulers.trampoline().createWorker();
             workers.add(worker2);
-            worker2.schedule(new Runnable() {
-
-                @Override
-                public void run() {
-                    workers.add(doWorkOnNewTrampoline("B", workDone));
-                    // we unsubscribe worker2 ... it should not affect work scheduled on a separate Trampline.Worker
-                    worker2.dispose();
-                }
-
+            worker2.schedule(() -> {
+                workers.add(doWorkOnNewTrampoline("B", workDone));
+                // we unsubscribe worker2 ... it should not affect work scheduled on a separate Trampline.Worker
+                worker2.dispose();
             });
 
             assertEquals(6, workDone.size());
@@ -112,19 +90,9 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
         // Spam the trampoline with actions.
         Flowable.range(0, 50)
-                .flatMap(new Function<Integer, Publisher<Disposable>>() {
-                    @Override
-                    public Publisher<Disposable> apply(Integer count) {
-                        return Flowable
-                                .interval(1, TimeUnit.MICROSECONDS)
-                                .map(new Function<Long, Disposable>() {
-                                    @Override
-                                    public Disposable apply(Long ount1) {
-                                        return trampolineWorker.schedule(Functions.EMPTY_RUNNABLE);
-                                    }
-                                }).take(100);
-                    }
-                })
+                .flatMap((Function<Integer, Publisher<Disposable>>) _ -> Flowable
+                        .interval(1, TimeUnit.MICROSECONDS)
+                        .map(_ -> trampolineWorker.schedule(Functions.EMPTY_RUNNABLE)).take(100))
                 .subscribeOn(Schedulers.computation())
                 .subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -133,31 +101,21 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
 
     private static Worker doWorkOnNewTrampoline(final String key, final ArrayList<String> workDone) {
         Worker worker = Schedulers.trampoline().createWorker();
-        worker.schedule(new Runnable() {
-
-            @Override
-            public void run() {
-                String msg = key + ".1";
-                workDone.add(msg);
-                System.out.println(msg);
-                Worker worker3 = Schedulers.trampoline().createWorker();
-                worker3.schedule(createPrintAction(key + ".B.1", workDone));
-                worker3.schedule(createPrintAction(key + ".B.2", workDone));
-            }
-
+        worker.schedule(() -> {
+            String msg = key + ".1";
+            workDone.add(msg);
+            System.out.println(msg);
+            Worker worker3 = Schedulers.trampoline().createWorker();
+            worker3.schedule(createPrintAction(key + ".B.1", workDone));
+            worker3.schedule(createPrintAction(key + ".B.2", workDone));
         });
         return worker;
     }
 
     private static Runnable createPrintAction(final String message, final ArrayList<String> workDone) {
-        return new Runnable() {
-
-            @Override
-            public void run() {
-                System.out.println(message);
-                workDone.add(message);
-            }
-
+        return () -> {
+            System.out.println(message);
+            workDone.add(message);
         };
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -25,7 +25,6 @@ import org.junit.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.observers.DefaultObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestObserverEx;
@@ -35,25 +34,15 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.createUnbounded();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Observable.unsafeCreate(new ObservableSource<Long>() {
-
-                    @Override
-                    public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(Disposable.empty());
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Observable.unsafeCreate((ObservableSource<Long>) o -> {
+            o.onSubscribe(Disposable.empty());
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                o.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            o.onComplete();
+        }).subscribe(replay));
         source.start();
 
         long v = replay.blockingLast();
@@ -61,76 +50,68 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
-        Thread slowThread = new Thread(new Runnable() {
+        Thread slowThread = new Thread(() -> {
+            Observer<Long> slow = new DefaultObserver<Long>() {
 
-            @Override
-            public void run() {
-                Observer<Long> slow = new DefaultObserver<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Slow Observer completed");
-                        slowLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Slow Observer STARTED");
-                        }
-                        try {
-                            if (args % 10 == 0) {
-                                Thread.sleep(1);
-                            }
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                };
-                replay.subscribe(slow);
-                try {
-                    slowLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Slow Observer completed");
+                    slowLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Slow Observer STARTED");
+                    }
+                    try {
+                        if (args % 10 == 0) {
+                            Thread.sleep(1);
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            replay.subscribe(slow);
+            try {
+                slowLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         slowThread.start();
 
-        Thread fastThread = new Thread(new Runnable() {
+        Thread fastThread = new Thread(() -> {
+            final CountDownLatch fastLatch = new CountDownLatch(1);
+            Observer<Long> fast = new DefaultObserver<Long>() {
 
-            @Override
-            public void run() {
-                final CountDownLatch fastLatch = new CountDownLatch(1);
-                Observer<Long> fast = new DefaultObserver<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Fast Observer completed");
-                        fastLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Fast Observer STARTED");
-                        }
-                    }
-                };
-                replay.subscribe(fast);
-                try {
-                    fastLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Fast Observer completed");
+                    fastLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Fast Observer STARTED");
+                    }
+                }
+            };
+            replay.subscribe(fast);
+            try {
+                fastLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         fastThread.start();
@@ -145,25 +126,15 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.createUnbounded();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Observable.unsafeCreate(new ObservableSource<Long>() {
-
-                    @Override
-                    public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(Disposable.empty());
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Observable.unsafeCreate((ObservableSource<Long>) o -> {
+            o.onSubscribe(Disposable.empty());
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                o.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            o.onComplete();
+        }).subscribe(replay));
 
         // used to collect results of each thread
         final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
@@ -180,14 +151,10 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
                 // wait for source to finish then keep adding after it's done
                 source.join();
             }
-            Thread t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    List<Long> values = replay.toList().blockingGet();
-                    listOfListsOfValues.add(values);
-                    System.out.println("Finished thread: " + count);
-                }
+            Thread t = new Thread(() -> {
+                List<Long> values = replay.toList().blockingGet();
+                listOfListsOfValues.add(values);
+                System.out.println("Finished thread: " + count);
             });
             t.start();
             System.out.println("Started thread: " + i);
@@ -235,28 +202,19 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
             final ReplaySubject<String> subject = ReplaySubject.createUnbounded();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            subject.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            subject.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    subject.onNext("value");
-                    subject.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                subject.onNext("value");
+                subject.onComplete();
             });
 
             SubjectObserverThread t2 = new SubjectObserverThread(subject);
@@ -341,17 +299,14 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
 //                int j = i;
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-//                        System.out.println("> " + j);
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+//                        System.out.println("> " + j);
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -398,12 +353,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(rs::onComplete);
                 }
             }
         } finally {
@@ -416,22 +366,19 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         final ReplaySubject<Object> rs = ReplaySubject.createUnbounded();
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {
@@ -471,22 +418,19 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         final ReplaySubject<Object> rs = ReplaySubject.createWithSize(3);
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {
@@ -515,29 +459,26 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         final ReplaySubject<Object> rs = ReplaySubject.createWithTime(1, TimeUnit.MILLISECONDS, Schedulers.computation());
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                    if (i % 10000 == 0) {
-                        try {
-                            Thread.sleep(1);
-                        } catch (InterruptedException e) {
-                            return;
-                        }
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
+            }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+                if (i % 10000 == 0) {
+                    try {
+                        Thread.sleep(1);
+                    } catch (InterruptedException e) {
+                        return;
                     }
                 }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
             }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -25,7 +25,6 @@ import org.junit.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.observers.DefaultObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestObserverEx;
@@ -35,25 +34,15 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscribersDoingReplayDontBlockEachOther() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.create();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Observable.unsafeCreate(new ObservableSource<Long>() {
-
-                    @Override
-                    public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(Disposable.empty());
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Observable.unsafeCreate((ObservableSource<Long>) o -> {
+            o.onSubscribe(Disposable.empty());
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                o.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            o.onComplete();
+        }).subscribe(replay));
         source.start();
 
         long v = replay.blockingLast();
@@ -61,76 +50,68 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
-        Thread slowThread = new Thread(new Runnable() {
+        Thread slowThread = new Thread(() -> {
+            Observer<Long> slow = new DefaultObserver<Long>() {
 
-            @Override
-            public void run() {
-                Observer<Long> slow = new DefaultObserver<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Slow Observer completed");
-                        slowLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Slow Observer STARTED");
-                        }
-                        try {
-                            if (args % 10 == 0) {
-                                Thread.sleep(1);
-                            }
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                };
-                replay.subscribe(slow);
-                try {
-                    slowLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Slow Observer completed");
+                    slowLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Slow Observer STARTED");
+                    }
+                    try {
+                        if (args % 10 == 0) {
+                            Thread.sleep(1);
+                        }
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                }
+            };
+            replay.subscribe(slow);
+            try {
+                slowLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         slowThread.start();
 
-        Thread fastThread = new Thread(new Runnable() {
+        Thread fastThread = new Thread(() -> {
+            final CountDownLatch fastLatch = new CountDownLatch(1);
+            Observer<Long> fast = new DefaultObserver<Long>() {
 
-            @Override
-            public void run() {
-                final CountDownLatch fastLatch = new CountDownLatch(1);
-                Observer<Long> fast = new DefaultObserver<Long>() {
-
-                    @Override
-                    public void onComplete() {
-                        System.out.println("*** Fast Observer completed");
-                        fastLatch.countDown();
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                    }
-
-                    @Override
-                    public void onNext(Long args) {
-                        if (args == 1) {
-                            System.out.println("*** Fast Observer STARTED");
-                        }
-                    }
-                };
-                replay.subscribe(fast);
-                try {
-                    fastLatch.await();
-                } catch (InterruptedException e1) {
-                    e1.printStackTrace();
+                @Override
+                public void onComplete() {
+                    System.out.println("*** Fast Observer completed");
+                    fastLatch.countDown();
                 }
+
+                @Override
+                public void onError(Throwable e) {
+                }
+
+                @Override
+                public void onNext(Long args) {
+                    if (args == 1) {
+                        System.out.println("*** Fast Observer STARTED");
+                    }
+                }
+            };
+            replay.subscribe(fast);
+            try {
+                fastLatch.await();
+            } catch (InterruptedException e1) {
+                e1.printStackTrace();
             }
         });
         fastThread.start();
@@ -145,25 +126,15 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
     @Test
     public void replaySubjectConcurrentSubscriptions() throws InterruptedException {
         final ReplaySubject<Long> replay = ReplaySubject.create();
-        Thread source = new Thread(new Runnable() {
-
-            @Override
-            public void run() {
-                Observable.unsafeCreate(new ObservableSource<Long>() {
-
-                    @Override
-                    public void subscribe(Observer<? super Long> o) {
-                        o.onSubscribe(Disposable.empty());
-                        System.out.println("********* Start Source Data ***********");
-                        for (long l = 1; l <= 10000; l++) {
-                            o.onNext(l);
-                        }
-                        System.out.println("********* Finished Source Data ***********");
-                        o.onComplete();
-                    }
-                }).subscribe(replay);
+        Thread source = new Thread(() -> Observable.unsafeCreate((ObservableSource<Long>) o -> {
+            o.onSubscribe(Disposable.empty());
+            System.out.println("********* Start Source Data ***********");
+            for (long l = 1; l <= 10000; l++) {
+                o.onNext(l);
             }
-        });
+            System.out.println("********* Finished Source Data ***********");
+            o.onComplete();
+        }).subscribe(replay));
 
         // used to collect results of each thread
         final List<List<Long>> listOfListsOfValues = Collections.synchronizedList(new ArrayList<>());
@@ -180,14 +151,10 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                 // wait for source to finish then keep adding after it's done
                 source.join();
             }
-            Thread t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    List<Long> values = replay.toList().blockingGet();
-                    listOfListsOfValues.add(values);
-                    System.out.println("Finished thread: " + count);
-                }
+            Thread t = new Thread(() -> {
+                List<Long> values = replay.toList().blockingGet();
+                listOfListsOfValues.add(values);
+                System.out.println("Finished thread: " + count);
             });
             t.start();
             System.out.println("Started thread: " + i);
@@ -235,28 +202,19 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
             final ReplaySubject<String> subject = ReplaySubject.create();
             final AtomicReference<String> value1 = new AtomicReference<>();
 
-            subject.subscribe(new Consumer<String>() {
-
-                @Override
-                public void accept(String t1) {
-                    try {
-                        // simulate a slow observer
-                        Thread.sleep(50);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    value1.set(t1);
+            subject.subscribe(t1 -> {
+                try {
+                    // simulate a slow observer
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
                 }
-
+                value1.set(t1);
             });
 
-            Thread t1 = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    subject.onNext("value");
-                    subject.onComplete();
-                }
+            Thread t1 = new Thread(() -> {
+                subject.onNext("value");
+                subject.onComplete();
             });
 
             SubjectObserverThread t2 = new SubjectObserverThread(subject);
@@ -339,16 +297,13 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                 final CountDownLatch finish = new CountDownLatch(1);
                 final CountDownLatch start = new CountDownLatch(1);
 
-                worker.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            start.await();
-                        } catch (Exception e1) {
-                            e1.printStackTrace();
-                        }
-                        rs.onNext(1);
+                worker.schedule(() -> {
+                    try {
+                        start.await();
+                    } catch (Exception e1) {
+                        e1.printStackTrace();
                     }
+                    rs.onNext(1);
                 });
 
                 final AtomicReference<Object> o = new AtomicReference<>();
@@ -385,12 +340,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                     break;
                 } else {
                     Assert.assertEquals(1, o.get());
-                    worker.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            rs.onComplete();
-                        }
-                    });
+                    worker.schedule(rs::onComplete);
 
                 }
             }
@@ -404,22 +354,19 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         final ReplaySubject<Object> rs = ReplaySubject.create();
         final CyclicBarrier cb = new CyclicBarrier(2);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    cb.await();
-                } catch (InterruptedException e) {
-                    return;
-                } catch (BrokenBarrierException e) {
-                    return;
-                }
-                for (int i = 0; i < 1000000; i++) {
-                    rs.onNext(i);
-                }
-                rs.onComplete();
-                System.out.println("Replay fill Thread finished!");
+        Thread t = new Thread(() -> {
+            try {
+                cb.await();
+            } catch (InterruptedException e) {
+                return;
+            } catch (BrokenBarrierException e) {
+                return;
             }
+            for (int i = 0; i < 1000000; i++) {
+                rs.onNext(i);
+            }
+            rs.onComplete();
+            System.out.println("Replay fill Thread finished!");
         });
         t.start();
         try {

--- a/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
@@ -425,19 +425,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             TestObserverEx<Integer> to = s.to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(2);
-                }
-            };
+            Runnable r2 = () -> s.onNext(2);
 
             TestHelper.race(r1, r2);
 
@@ -461,19 +451,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onError(ex);
-                }
-            };
+            Runnable r2 = () -> s.onError(ex);
 
             TestHelper.race(r1, r2);
 
@@ -492,19 +472,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             TestObserver<Integer> to = s.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r2 = s::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -525,19 +495,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             final Disposable bs = Disposable.empty();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onNext(1);
-                }
-            };
+            Runnable r1 = () -> s.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs);
 
             TestHelper.race(r1, r2);
 
@@ -554,19 +514,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             final Disposable bs = Disposable.empty();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r1 = s::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs);
 
             TestHelper.race(r1, r2);
 
@@ -581,19 +531,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             TestObserver<Integer> to = s.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r1 = s::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onComplete();
-                }
-            };
+            Runnable r2 = s::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -612,19 +552,9 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> s.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        s.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> s.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -647,19 +577,9 @@ public class SerializedSubjectTest extends RxJavaTest {
             final Disposable bs1 = Disposable.empty();
             final Disposable bs2 = Disposable.empty();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs1);
-                }
-            };
+            Runnable r1 = () -> s.onSubscribe(bs1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    s.onSubscribe(bs2);
-                }
-            };
+            Runnable r2 = () -> s.onSubscribe(bs2);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
@@ -166,11 +166,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void onTerminateCalledWhenOnError() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         assertFalse(didRunOnTerminate.get());
         us.onError(new RuntimeException("some error"));
@@ -181,11 +177,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void onTerminateCalledWhenOnComplete() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         assertFalse(didRunOnTerminate.get());
         us.onComplete();
@@ -196,11 +188,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void onTerminateCalledWhenCanceled() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
-        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), new Runnable() {
-            @Override public void run() {
-                didRunOnTerminate.set(true);
-            }
-        });
+        UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));
 
         final Disposable subscribe = us.subscribe();
 
@@ -228,28 +216,13 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void completeCancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final int[] calls = { 0 };
-            final UnicastSubject<Object> us = UnicastSubject.create(100, new Runnable() {
-                @Override
-                public void run() {
-                    calls[0]++;
-                }
-            });
+            final UnicastSubject<Object> us = UnicastSubject.create(100, () -> calls[0]++);
 
             final TestObserver<Object> to = us.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = to::dispose;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    us.onComplete();
-                }
-            };
+            Runnable r2 = us::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -341,19 +314,9 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
 
             p.subscribe(to);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    p.onNext(1);
-                }
-            };
+            Runnable r1 = () -> p.onNext(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
         }
@@ -363,12 +326,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     public void dispose() {
         final int[] calls = { 0 };
 
-        UnicastSubject<Integer> us = new UnicastSubject<>(128, new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        }, true);
+        UnicastSubject<Integer> us = new UnicastSubject<>(128, () -> calls[0]++, true);
 
         TestHelper.checkDisposed(us);
 
@@ -398,19 +356,9 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
             final TestObserverEx<Integer> to1 = new TestObserverEx<>();
             final TestObserverEx<Integer> to2 = new TestObserverEx<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    us.subscribe(to1);
-                }
-            };
+            Runnable r1 = () -> us.subscribe(to1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    us.subscribe(to2);
-                }
-            };
+            Runnable r2 = () -> us.subscribe(to2);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
@@ -445,18 +445,13 @@ public class SerializedSubscriberTest extends RxJavaTest {
     }
 
     private static Flowable<String> infinite(final AtomicInteger produced) {
-        return Flowable.unsafeCreate(new Publisher<String>() {
-
-            @Override
-            public void subscribe(Subscriber<? super String> s) {
-                BooleanSubscription bs = new BooleanSubscription();
-                s.onSubscribe(bs);
-                while (!bs.isCancelled()) {
-                    s.onNext("onNext");
-                    produced.incrementAndGet();
-                }
+        return Flowable.unsafeCreate((Publisher<String>) s -> {
+            BooleanSubscription bs = new BooleanSubscription();
+            s.onSubscribe(bs);
+            while (!bs.isCancelled()) {
+                s.onNext("onNext");
+                produced.incrementAndGet();
             }
-
         }).subscribeOn(Schedulers.newThread());
     }
 
@@ -656,22 +651,17 @@ public class SerializedSubscriberTest extends RxJavaTest {
         public void subscribe(final Subscriber<? super String> subscriber) {
             subscriber.onSubscribe(new BooleanSubscription());
             System.out.println("TestSingleThreadedObservable subscribed to ...");
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestSingleThreadedObservable thread");
-                        for (String s : values) {
-                            System.out.println("TestSingleThreadedObservable onNext: " + s);
-                            subscriber.onNext(s);
-                        }
-                        subscriber.onComplete();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestSingleThreadedObservable thread");
+                    for (String s : values) {
+                        System.out.println("TestSingleThreadedObservable onNext: " + s);
+                        subscriber.onNext(s);
                     }
+                    subscriber.onComplete();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
-
             });
             System.out.println("starting TestSingleThreadedObservable thread");
             t.start();
@@ -709,65 +699,57 @@ public class SerializedSubscriberTest extends RxJavaTest {
             subscriber.onSubscribe(new BooleanSubscription());
             final NullPointerException npe = new NullPointerException();
             System.out.println("TestMultiThreadedObservable subscribed to ...");
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        System.out.println("running TestMultiThreadedObservable thread");
-                        int j = 0;
-                        for (final String s : values) {
-                            final int fj = ++j;
-                            threadPool.execute(new Runnable() {
-
-                                @Override
-                                public void run() {
-                                    threadsRunning.incrementAndGet();
-                                    try {
-                                        // perform onNext call
-                                        System.out.println("TestMultiThreadedObservable onNext: " + s + " on thread " + Thread.currentThread().getName());
-                                        if (s == null) {
-                                            // force an error
-                                            throw npe;
-                                        } else {
-                                             // allow the exception to queue up
-                                            int sleep = (fj % 3) * 10;
-                                            if (sleep != 0) {
-                                                Thread.sleep(sleep);
-                                            }
-                                        }
-                                        subscriber.onNext(s);
-                                        // capture 'maxThreads'
-                                        int concurrentThreads = threadsRunning.get();
-                                        int maxThreads = maxConcurrentThreads.get();
-                                        if (concurrentThreads > maxThreads) {
-                                            maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
-                                        }
-                                    } catch (Throwable e) {
-                                        subscriber.onError(e);
-                                    } finally {
-                                        threadsRunning.decrementAndGet();
+            t = new Thread(() -> {
+                try {
+                    System.out.println("running TestMultiThreadedObservable thread");
+                    int j = 0;
+                    for (final String s : values) {
+                        final int fj = ++j;
+                        threadPool.execute(() -> {
+                            threadsRunning.incrementAndGet();
+                            try {
+                                // perform onNext call
+                                System.out.println("TestMultiThreadedObservable onNext: " + s + " on thread " + Thread.currentThread().getName());
+                                if (s == null) {
+                                    // force an error
+                                    throw npe;
+                                } else {
+                                     // allow the exception to queue up
+                                    int sleep = (fj % 3) * 10;
+                                    if (sleep != 0) {
+                                        Thread.sleep(sleep);
                                     }
                                 }
-                            });
-                        }
-                        // we are done spawning threads
-                        threadPool.shutdown();
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
+                                subscriber.onNext(s);
+                                // capture 'maxThreads'
+                                int concurrentThreads = threadsRunning.get();
+                                int maxThreads = maxConcurrentThreads.get();
+                                if (concurrentThreads > maxThreads) {
+                                    maxConcurrentThreads.compareAndSet(maxThreads, concurrentThreads);
+                                }
+                            } catch (Throwable e) {
+                                subscriber.onError(e);
+                            } finally {
+                                threadsRunning.decrementAndGet();
+                            }
+                        });
                     }
-
-                    // wait until all threads are done, then mark it as COMPLETED
-                    try {
-                        // wait for all the threads to finish
-                        if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
-                            System.out.println("Threadpool did not terminate in time.");
-                        }
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    subscriber.onComplete();
+                    // we are done spawning threads
+                    threadPool.shutdown();
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
                 }
+
+                // wait until all threads are done, then mark it as COMPLETED
+                try {
+                    // wait for all the threads to finish
+                    if (!threadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+                        System.out.println("Threadpool did not terminate in time.");
+                    }
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                subscriber.onComplete();
             });
             System.out.println("starting TestMultiThreadedObservable thread");
             t.start();
@@ -925,12 +907,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
             so.onSubscribe(bs);
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    so.onComplete();
-                }
-            };
+            Runnable r = so::onComplete;
 
             TestHelper.race(r, r);
 
@@ -951,19 +928,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
             so.onSubscribe(bs);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onComplete();
-                }
-            };
+            Runnable r1 = so::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -989,19 +956,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onError(ex);
-                }
-            };
+            Runnable r1 = () -> so.onError(ex);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -1027,19 +984,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onError(ex);
-                }
-            };
+            Runnable r1 = () -> so.onError(ex);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    so.onNext(1);
-                }
-            };
+            Runnable r2 = () -> so.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -1091,19 +1038,9 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
                 final Throwable ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> so.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        so.onComplete();
-                    }
-                };
+                Runnable r2 = so::onComplete;
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -29,7 +29,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.processors.PublishProcessor;
@@ -145,12 +144,7 @@ public class TestSubscriberTest extends RxJavaTest {
         final AtomicBoolean unsub = new AtomicBoolean(false);
         Flowable.just(1)
         //
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        unsub.set(true);
-                    }
-                })
+                .doOnCancel(() -> unsub.set(true))
                 //
                 .delay(1000, TimeUnit.MILLISECONDS).subscribe(ts);
         ts.awaitDone(100, TimeUnit.MILLISECONDS);
@@ -422,11 +416,8 @@ public class TestSubscriberTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
-            ts.assertError(new Predicate<Throwable>() {
-                @Override
-                public boolean test(Throwable throwable) throws Exception {
-                    throw new TestException();
-                }
+            ts.assertError(_ -> {
+                throw new TestException();
             });
         } catch (TestException ex) {
             // expected
@@ -478,12 +469,7 @@ public class TestSubscriberTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 if (ts.await(5, TimeUnit.SECONDS)) {
@@ -504,12 +490,7 @@ public class TestSubscriberTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 if (ts.await(5, TimeUnit.SECONDS)) {
@@ -531,12 +512,7 @@ public class TestSubscriberTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 ts.awaitDone(5, TimeUnit.SECONDS);
@@ -785,12 +761,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
         ts.assertError(Functions.<Throwable>alwaysTrue());
 
-        ts.assertError(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable t) {
-                return t.getMessage() != null && t.getMessage().contains("Forced");
-            }
-        });
+        ts.assertError(t -> t.getMessage() != null && t.getMessage().contains("Forced"));
 
         try {
             ts.assertError(new RuntimeException());
@@ -923,12 +894,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
         ts1.onSubscribe(new BooleanSubscription());
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                ts1.onComplete();
-            }
-        }, 200, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(ts1::onComplete, 200, TimeUnit.MILLISECONDS);
 
         ts1.await();
     }
@@ -1371,11 +1337,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.empty().subscribe(ts);
 
-            ts.assertValue(new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            ts.assertValue(_ -> false);
         });
     }
 
@@ -1385,11 +1347,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(ts);
 
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        ts.assertValue(o -> o == 1);
     }
 
     static void assertThrowsWithMessage(String message, Class<? extends Throwable> clazz, ThrowingRunnable run) {
@@ -1404,11 +1362,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.just(1).subscribe(ts);
 
-            ts.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 1;
-                }
-            });
+            ts.assertValue(o -> o != 1);
         });
     }
 
@@ -1420,11 +1374,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.just(1, 2).subscribe(ts);
 
-            ts.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertValue(o -> o == 1);
         });
     }
 
@@ -1435,11 +1385,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.empty().subscribe(ts);
 
-            ts.assertValueAt(0, new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            ts.assertValueAt(0, _ -> false);
         });
     }
 
@@ -1449,11 +1395,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
         Flowable.just(1, 2).subscribe(ts);
 
-        ts.assertValueAt(1, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 2;
-            }
-        });
+        ts.assertValueAt(1, o -> o == 2);
     }
 
     @Test
@@ -1464,11 +1406,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.just(1, 2, 3).subscribe(ts);
 
-            ts.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 3;
-                }
-            });
+            ts.assertValueAt(2, o -> o != 3);
         });
     }
 
@@ -1479,11 +1417,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.just(1, 2).subscribe(ts);
 
-            ts.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertValueAt(2, o -> o == 1);
         });
     }
 
@@ -1516,11 +1450,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
             Flowable.just(1, 2).subscribe(ts);
 
-            ts.assertValueAt(-2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertValueAt(-2, o -> o == 1);
         });
     }
 
@@ -1633,11 +1563,8 @@ public class TestSubscriberTest extends RxJavaTest {
         try {
             Flowable.just(1)
             .test()
-            .assertValueAt(0, new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t) throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            .assertValueAt(0, _ -> {
+                throw new IllegalArgumentException();
             });
             throw new RuntimeException("Should have thrown!");
         } catch (IllegalArgumentException ex) {

--- a/src/test/java/io/reactivex/rxjava4/tck/MulticastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/MulticastProcessorAsPublisherTckTest.java
@@ -31,32 +31,29 @@ public class MulticastProcessorAsPublisherTckTest extends BaseTck<Integer> {
         final MulticastProcessor<Integer> mp = MulticastProcessor.create();
         mp.start();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!mp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!mp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    while (!mp.offer(i)) {
-                        Thread.yield();
-                        if (System.currentTimeMillis() - start > 1000) {
-                            return;
-                        }
-                    }
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                mp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                while (!mp.offer(i)) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 1000) {
+                        return;
+                    }
+                }
+            }
+            mp.onComplete();
         });
         return mp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/PublishProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/PublishProcessorAsPublisherTckTest.java
@@ -30,32 +30,29 @@ public class PublishProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    while (!pp.offer(i)) {
-                        Thread.yield();
-                        if (System.currentTimeMillis() - start > 1000) {
-                            return;
-                        }
-                    }
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                while (!pp.offer(i)) {
+                    Thread.yield();
+                    if (System.currentTimeMillis() - start > 1000) {
+                        return;
+                    }
+                }
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ReduceTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReduceTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class ReduceTckTest extends BaseTck<Integer> {
@@ -25,12 +24,7 @@ public class ReduceTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(final long elements) {
         return
-                Flowable.range(1, 1000).reduce(new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                }).toFlowable()
+                Flowable.range(1, 1000).reduce(Integer::sum).toFlowable()
             ;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/tck/ReduceWithTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReduceWithTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.internal.functions.Functions;
 
 @Test
@@ -27,12 +26,7 @@ public class ReduceWithTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         return
                 Flowable.range(1, 1000).reduceWith(Functions.justSupplier(0),
-                new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                }).toFlowable()
+                        Integer::sum).toFlowable()
             ;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorSizeBoundAsPublisherTckTest.java
@@ -30,27 +30,24 @@ public class ReplayProcessorSizeBoundAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.createWithSize((int)elements + 10);
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    pp.onNext(i);
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                pp.onNext(i);
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorTimeBoundAsPublisherTckTest.java
@@ -32,27 +32,24 @@ public class ReplayProcessorTimeBoundAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.createWithTime(1, TimeUnit.MINUTES, Schedulers.computation());
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    pp.onNext(i);
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                pp.onNext(i);
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ReplayProcessorUnboundedAsPublisherTckTest.java
@@ -30,27 +30,24 @@ public class ReplayProcessorUnboundedAsPublisherTckTest extends BaseTck<Integer>
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final ReplayProcessor<Integer> pp = ReplayProcessor.create();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    pp.onNext(i);
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                pp.onNext(i);
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/ScanTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/ScanTckTest.java
@@ -17,7 +17,6 @@ import static java.util.concurrent.Flow.*;
 import org.testng.annotations.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.functions.BiFunction;
 
 @Test
 public class ScanTckTest extends BaseTck<Integer> {
@@ -25,12 +24,7 @@ public class ScanTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(long elements) {
         return
-                Flowable.range(0, (int)elements).scan(new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a + b;
-                    }
-                })
+                Flowable.range(0, (int)elements).scan(Integer::sum)
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/tck/UnicastProcessorAsPublisherTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/UnicastProcessorAsPublisherTckTest.java
@@ -30,27 +30,24 @@ public class UnicastProcessorAsPublisherTckTest extends BaseTck<Integer> {
     public Publisher<Integer> createFlowPublisher(final long elements) {
         final UnicastProcessor<Integer> pp = UnicastProcessor.create();
 
-        Schedulers.cached().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                long start = System.currentTimeMillis();
-                while (!pp.hasSubscribers()) {
-                    try {
-                        Thread.sleep(1);
-                    } catch (InterruptedException ex) {
-                        return;
-                    }
-
-                    if (System.currentTimeMillis() - start > 200) {
-                        return;
-                    }
+        Schedulers.cached().scheduleDirect(() -> {
+            long start = System.currentTimeMillis();
+            while (!pp.hasSubscribers()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {
+                    return;
                 }
 
-                for (int i = 0; i < elements; i++) {
-                    pp.onNext(i);
+                if (System.currentTimeMillis() - start > 200) {
+                    return;
                 }
-                pp.onComplete();
             }
+
+            for (int i = 0; i < elements; i++) {
+                pp.onNext(i);
+            }
+            pp.onComplete();
         });
         return pp;
     }

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -26,7 +26,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import static java.util.concurrent.Flow.*;
 
@@ -82,13 +81,10 @@ public enum TestHelper {
     public static <T> FlowableSubscriber<T> mockSubscriber() {
         FlowableSubscriber<T> w = mock(FlowableSubscriber.class);
 
-        Mockito.doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock a) throws Throwable {
-                Subscription s = a.getArgument(0);
-                s.request(Long.MAX_VALUE);
-                return null;
-            }
+        Mockito.doAnswer((Answer<Object>) a -> {
+            Subscription s = a.getArgument(0);
+            s.request(Long.MAX_VALUE);
+            return null;
         }).when(w).onSubscribe(any());
 
         return w;
@@ -159,12 +155,7 @@ public enum TestHelper {
     public static List<Throwable> trackPluginErrors() {
         final List<Throwable> list = Collections.synchronizedList(new ArrayList<>());
 
-        RxJavaPlugins.setErrorHandler(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable t) {
-                list.add(t);
-            }
-        });
+        RxJavaPlugins.setErrorHandler(list::add);
 
         return list;
     }
@@ -451,22 +442,19 @@ public enum TestHelper {
 
         final Throwable[] errors = { null, null };
 
-        s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                if (count.decrementAndGet() != 0) {
-                    while (count.get() != 0) { }
-                }
+        s.scheduleDirect(() -> {
+            if (count.decrementAndGet() != 0) {
+                while (count.get() != 0) { }
+            }
 
+            try {
                 try {
-                    try {
-                        r1.run();
-                    } catch (Throwable ex) {
-                        errors[0] = ex;
-                    }
-                } finally {
-                    cdl.countDown();
+                    r1.run();
+                } catch (Throwable ex) {
+                    errors[0] = ex;
                 }
+            } finally {
+                cdl.countDown();
             }
         });
 
@@ -3387,16 +3375,13 @@ public enum TestHelper {
     }
 
     public static <T> FlowableConverter<T, TestSubscriberEx<T>> testSubscriber(final long initialRequest, final boolean cancelled, final int fusionMode) {
-        return new FlowableConverter<T, TestSubscriberEx<T>>() {
-            @Override
-            public TestSubscriberEx<T> apply(Flowable<T> f) {
-                TestSubscriberEx<T> tse = new TestSubscriberEx<>(initialRequest);
-                if (cancelled) {
-                    tse.cancel();
-                }
-                tse.setInitialFusionMode(fusionMode);
-                return f.subscribeWith(tse);
+        return f -> {
+            TestSubscriberEx<T> tse = new TestSubscriberEx<>(initialRequest);
+            if (cancelled) {
+                tse.cancel();
             }
+            tse.setInitialFusionMode(fusionMode);
+            return f.subscribeWith(tse);
         };
     }
 
@@ -3561,12 +3546,9 @@ public enum TestHelper {
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Flowable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    disposable.dispose();
-                    throw new TestException();
-                }
+            .map((Function<Integer, Integer>) v -> {
+                disposable.dispose();
+                throw new TestException();
             })
             .to(transform);
 
@@ -3630,12 +3612,9 @@ public enum TestHelper {
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Observable.just(1)
-            .map(new Function<Integer, Integer>() {
-                @Override
-                public Integer apply(Integer v) throws Throwable {
-                    disposable.dispose();
-                    throw new TestException();
-                }
+            .map((Function<Integer, Integer>) v -> {
+                disposable.dispose();
+                throw new TestException();
             })
             .to(transform);
 
@@ -3792,12 +3771,7 @@ public enum TestHelper {
 
         final CountDownLatch cdl = new CountDownLatch(ncpu);
         final List<Scheduler.Worker> workers = new ArrayList<>();
-        final Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                cdl.countDown();
-            }
-        };
+        final Runnable task = cdl::countDown;
 
         for (int i = 0; i < ncpu; i++) {
             workers.add(Schedulers.computation().createWorker());

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
@@ -28,7 +28,6 @@ import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.operators.observable.ObservableScalarXMap.ScalarDisposable;
 import io.reactivex.rxjava4.observers.TestObserver;
@@ -110,12 +109,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             to.assertValues(1, 2);
 
-            to.assertNever(new Predicate<Integer>() {
-                @Override
-                public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertNever(o -> o == 1);
         });
     }
 
@@ -125,12 +119,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         Observable.just(2, 3).subscribe(to);
 
-        to.assertNever(new Predicate<Integer>() {
-            @Override
-            public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        to.assertNever(o -> o == 1);
     }
 
     @Test
@@ -383,12 +372,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         to.assertError(Functions.<Throwable>alwaysTrue());
 
-        to.assertError(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable t) throws Exception {
-                return t.getMessage() != null && t.getMessage().contains("Forced");
-            }
-        });
+        to.assertError(t -> t.getMessage() != null && t.getMessage().contains("Forced"));
 
         to.assertErrorMessage("Forced failure");
 
@@ -603,12 +587,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         to1.onSubscribe(Disposable.empty());
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                to1.onComplete();
-            }
-        }, 200, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(to1::onComplete, 200, TimeUnit.MILLISECONDS);
 
         to1.await();
     }
@@ -966,11 +945,8 @@ public class TestObserverExTest extends RxJavaTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
         to.onError(new RuntimeException());
         try {
-            to.assertError(new Predicate<Throwable>() {
-                @Override
-                public boolean test(Throwable throwable) throws Exception {
-                    throw new TestException();
-                }
+            to.assertError(_ -> {
+                throw new TestException();
             });
         } catch (TestException ex) {
             // expected
@@ -1097,10 +1073,7 @@ public class TestObserverExTest extends RxJavaTest {
         to.setInitialFusionMode(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(v -> { throw new TestException(); })
         .subscribe(to);
 
         to.assertSubscribed()
@@ -1117,10 +1090,7 @@ public class TestObserverExTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(v -> { throw new TestException(); })
         .subscribe(to);
 
         us.onNext(1);
@@ -1173,11 +1143,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.empty().subscribe(to);
 
-            to.assertValue(new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            to.assertValue(_ -> false);
         });
     }
 
@@ -1187,11 +1153,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         Observable.just(1).subscribe(to);
 
-        to.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        to.assertValue(o -> o == 1);
     }
 
     @Test
@@ -1201,11 +1163,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.just(1).subscribe(to);
 
-            to.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 1;
-                }
-            });
+            to.assertValue(o -> o != 1);
         });
     }
 
@@ -1216,11 +1174,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.just(1, 2).subscribe(to);
 
-            to.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertValue(o -> o == 1);
         });
     }
 
@@ -1231,11 +1185,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.empty().subscribe(to);
 
-            to.assertValueAt(0, new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            to.assertValueAt(0, _ -> false);
         });
     }
 
@@ -1245,11 +1195,7 @@ public class TestObserverExTest extends RxJavaTest {
 
         Observable.just(1, 2).subscribe(to);
 
-        to.assertValueAt(1, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 2;
-            }
-        });
+        to.assertValueAt(1, o -> o == 2);
     }
 
     @Test
@@ -1259,11 +1205,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.just(1, 2, 3).subscribe(to);
 
-            to.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 3;
-                }
-            });
+            to.assertValueAt(2, o -> o != 3);
         });
     }
 
@@ -1274,11 +1216,7 @@ public class TestObserverExTest extends RxJavaTest {
 
             Observable.just(1, 2).subscribe(to);
 
-            to.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            to.assertValueAt(2, o -> o == 1);
         });
     }
 

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
@@ -28,7 +28,6 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.operators.QueueFuseable;
@@ -109,12 +108,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             ts.assertValues(1, 2);
 
-            ts.assertNever(new Predicate<Integer>() {
-                @Override
-                public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertNever(o -> o == 1);
         });
     }
 
@@ -124,12 +118,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         Flowable.just(2, 3).subscribe(ts);
 
-        ts.assertNever(new Predicate<Integer>() {
-            @Override
-            public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        ts.assertNever(o -> o == 1);
     }
 
     @Test
@@ -189,12 +178,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         final AtomicBoolean unsub = new AtomicBoolean(false);
         Flowable.just(1)
         //
-                .doOnCancel(new Action() {
-                    @Override
-                    public void run() {
-                        unsub.set(true);
-                    }
-                })
+                .doOnCancel(() -> unsub.set(true))
                 //
                 .delay(1000, TimeUnit.MILLISECONDS).subscribe(ts);
         ts.awaitDone(100, TimeUnit.MILLISECONDS);
@@ -465,11 +449,8 @@ public class TestSubscriberExTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         ts.onError(new RuntimeException());
         try {
-            ts.assertError(new Predicate<Throwable>() {
-                @Override
-                public boolean test(Throwable throwable) throws Exception {
-                    throw new TestException();
-                }
+            ts.assertError(_ -> {
+                throw new TestException();
             });
         } catch (TestException ex) {
             // expected
@@ -521,12 +502,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 if (ts.await(5, TimeUnit.SECONDS)) {
@@ -547,12 +523,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 if (ts.await(5, TimeUnit.SECONDS)) {
@@ -574,12 +545,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         final Thread t0 = Thread.currentThread();
         Worker w = Schedulers.computation().createWorker();
         try {
-            w.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    t0.interrupt();
-                }
-            }, 200, TimeUnit.MILLISECONDS);
+            w.schedule(t0::interrupt, 200, TimeUnit.MILLISECONDS);
 
             try {
                 ts.awaitDone(5, TimeUnit.SECONDS);
@@ -849,12 +815,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         ts.assertError(Functions.<Throwable>alwaysTrue());
 
-        ts.assertError(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable t) {
-                return t.getMessage() != null && t.getMessage().contains("Forced");
-            }
-        });
+        ts.assertError(t -> t.getMessage() != null && t.getMessage().contains("Forced"));
 
         try {
             ts.assertErrorMessage("");
@@ -1064,12 +1025,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         ts1.onSubscribe(new BooleanSubscription());
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                ts1.onComplete();
-            }
-        }, 200, TimeUnit.MILLISECONDS);
+        Schedulers.single().scheduleDirect(ts1::onComplete, 200, TimeUnit.MILLISECONDS);
 
         ts1.await();
     }
@@ -1547,10 +1503,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         ts.setInitialFusionMode(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(v -> { throw new TestException(); })
         .subscribe(ts);
 
         ts.assertSubscribed()
@@ -1567,10 +1520,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(v -> { throw new TestException(); })
         .subscribe(ts);
 
         up.onNext(1);
@@ -1588,11 +1538,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.empty().subscribe(ts);
 
-            ts.assertValue(new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            ts.assertValue(_ -> false);
         });
     }
 
@@ -1602,11 +1548,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(ts);
 
-        ts.assertValue(new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 1;
-            }
-        });
+        ts.assertValue(o -> o == 1);
     }
 
     @Test
@@ -1616,11 +1558,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.just(1).subscribe(ts);
 
-            ts.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 1;
-                }
-            });
+            ts.assertValue(o -> o != 1);
         });
     }
 
@@ -1631,11 +1569,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.just(1, 2).subscribe(ts);
 
-            ts.assertValue(new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertValue(o -> o == 1);
         });
     }
 
@@ -1646,11 +1580,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.empty().subscribe(ts);
 
-            ts.assertValueAt(0, new Predicate<Object>() {
-                @Override public boolean test(final Object o) throws Exception {
-                    return false;
-                }
-            });
+            ts.assertValueAt(0, _ -> false);
         });
     }
 
@@ -1660,11 +1590,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
         Flowable.just(1, 2).subscribe(ts);
 
-        ts.assertValueAt(1, new Predicate<Integer>() {
-            @Override public boolean test(final Integer o) throws Exception {
-                return o == 2;
-            }
-        });
+        ts.assertValueAt(1, o -> o == 2);
     }
 
     @Test
@@ -1674,11 +1600,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.just(1, 2, 3).subscribe(ts);
 
-            ts.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o != 3;
-                }
-            });
+            ts.assertValueAt(2, o -> o != 3);
         });
     }
 
@@ -1689,11 +1611,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
             Flowable.just(1, 2).subscribe(ts);
 
-            ts.assertValueAt(2, new Predicate<Integer>() {
-                @Override public boolean test(final Integer o) throws Exception {
-                    return o == 1;
-                }
-            });
+            ts.assertValueAt(2, o -> o == 1);
         });
     }
 
@@ -1806,11 +1724,8 @@ public class TestSubscriberExTest extends RxJavaTest {
         try {
             Flowable.just(1)
             .test()
-            .assertValueAt(0, new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t) throws Exception {
-                    throw new IllegalArgumentException();
-                }
+            .assertValueAt(0, _ -> {
+                throw new IllegalArgumentException();
             });
             throw new RuntimeException("Should have thrown!");
         } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080