### PR TITLE
4.x: Unit test lambdaification 20 of N

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava4/core/XMapYPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/XMapYPerf.java
@@ -104,27 +104,27 @@ public class XMapYPerf {
 
         flowFlatMapFlowable1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) Flowable::just);
 
-        flowFlatMapFlowable0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.empty());
+        flowFlatMapFlowable0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) _ -> Flowable.empty());
 
         flowFlatMapSingle1 = fsource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
         flowFlatMapMaybe1 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
+        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty());
 
-        flowFlatMapCompletable0 = fsource.flatMapCompletable(v -> Completable.complete());
+        flowFlatMapCompletable0 = fsource.flatMapCompletable(_ -> Completable.complete());
 
         flowFlatMapIterable1 = fsource.flatMapIterable((Function<Integer, Iterable<Integer>>) Collections::singletonList);
 
-        flowFlatMapIterable0 = fsource.flatMapIterable((Function<Integer, Iterable<Integer>>) v -> Collections.emptyList());
+        flowFlatMapIterable0 = fsource.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Collections.emptyList());
 
         flowFlatMapSingle1 = fsource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
         flowFlatMapMaybe1 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
+        flowFlatMapMaybe0 = fsource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty());
 
-        flowFlatMapCompletable0 = fsource.flatMapCompletable(v -> Completable.complete());
+        flowFlatMapCompletable0 = fsource.flatMapCompletable(_ -> Completable.complete());
 
         // ooooooooooooooooooooooooo
 
@@ -132,13 +132,13 @@ public class XMapYPerf {
 
         flowFlatMapMaybeAsFlow1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Maybe.just(v).toFlowable());
 
-        flowFlatMapMaybeAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Maybe.<Integer>empty().toFlowable());
+        flowFlatMapMaybeAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) _ -> Maybe.<Integer>empty().toFlowable());
 
-        flowFlatMapCompletableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Completable.complete().toFlowable());
+        flowFlatMapCompletableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) _ -> Completable.complete().toFlowable());
 
         flowFlatMapIterableAsFlow1 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(Collections.singletonList(v)));
 
-        flowFlatMapIterableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) v -> Flowable.fromIterable(Collections.emptyList()));
+        flowFlatMapIterableAsFlow0 = fsource.flatMap((Function<Integer, Publisher<Integer>>) _ -> Flowable.fromIterable(Collections.emptyList()));
 
         // -------------------------------------------------------------------
 
@@ -146,19 +146,19 @@ public class XMapYPerf {
 
         obsFlatMapObservable1 = osource.flatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        obsFlatMapObservable0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.empty());
+        obsFlatMapObservable0 = osource.flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.empty());
 
         obsFlatMapSingle1 = osource.flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just);
 
         obsFlatMapMaybe1 = osource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just);
 
-        obsFlatMapMaybe0 = osource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.empty());
+        obsFlatMapMaybe0 = osource.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty());
 
-        obsFlatMapCompletable0 = osource.flatMapCompletable(v -> Completable.complete());
+        obsFlatMapCompletable0 = osource.flatMapCompletable(_ -> Completable.complete());
 
         obsFlatMapIterable1 = osource.flatMapIterable((Function<Integer, Iterable<Integer>>) Collections::singletonList);
 
-        obsFlatMapIterable0 = osource.flatMapIterable((Function<Integer, Iterable<Integer>>) v -> Collections.emptyList());
+        obsFlatMapIterable0 = osource.flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Collections.emptyList());
 
         // ooooooooooooooooooooooooo
 
@@ -166,13 +166,13 @@ public class XMapYPerf {
 
         obsFlatMapMaybeAsObs1 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Maybe.just(v).toObservable());
 
-        obsFlatMapMaybeAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Maybe.<Integer>empty().toObservable());
+        obsFlatMapMaybeAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) _ -> Maybe.<Integer>empty().toObservable());
 
-        obsFlatMapCompletableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Completable.complete().toObservable());
+        obsFlatMapCompletableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) _ -> Completable.complete().toObservable());
 
         obsFlatMapIterableAsObs1 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.fromIterable(Collections.singletonList(v)));
 
-        obsFlatMapIterableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.fromIterable(Collections.emptyList()));
+        obsFlatMapIterableAsObs0 = osource.flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.fromIterable(Collections.emptyList()));
     }
 
     @Benchmark

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/SingleFlatMapObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/SingleFlatMapObservableTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.*;
@@ -111,11 +110,8 @@ public class SingleFlatMapObservableTest extends RxJavaTest {
 
     @Test
     public void mapperCrash() {
-        Single.just(1).flatMapObservable(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        Single.just(1).flatMapObservable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleAmbTest.java
@@ -143,9 +143,9 @@ public class SingleAmbTest extends RxJavaTest {
 
                 final Single<Integer> source = Single.ambArray(ps.singleOrError(), Single.<Integer>never(), Single.<Integer>never(), null);
 
-                Runnable r1 = () -> source.test();
+                Runnable r1 = source::test;
 
-                Runnable r2 = () -> ps.onComplete();
+                Runnable r2 = ps::onComplete;
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleAmbTest.java
@@ -143,19 +143,9 @@ public class SingleAmbTest extends RxJavaTest {
 
                 final Single<Integer> source = Single.ambArray(ps.singleOrError(), Single.<Integer>never(), Single.<Integer>never(), null);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        source.test();
-                    }
-                };
+                Runnable r1 = () -> source.test();
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onComplete();
-                    }
-                };
+                Runnable r2 = () -> ps.onComplete();
 
                 TestHelper.race(r1, r2);
 
@@ -182,19 +172,9 @@ public class SingleAmbTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ps2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -221,20 +201,12 @@ public class SingleAmbTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onNext(1);
-                        ps1.onComplete();
-                    }
+                Runnable r1 = () -> {
+                    ps1.onNext(1);
+                    ps1.onComplete();
                 };
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> ps2.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -289,14 +261,11 @@ public class SingleAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Single.never()
             )
-            .subscribe(new BiConsumer<Object, Throwable>() {
-                @Override
-                public void accept(Object v, Throwable e) throws Exception {
-                    assertNotNull(v);
-                    assertNull(e);
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe((BiConsumer<Object, Throwable>) (v, e) -> {
+                assertNotNull(v);
+                assertNull(e);
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -317,14 +286,11 @@ public class SingleAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Single.never()
             )
-            .subscribe(new BiConsumer<Object, Throwable>() {
-                @Override
-                public void accept(Object v, Throwable e) throws Exception {
-                    assertNull(v);
-                    assertNotNull(e);
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe((v, e) -> {
+                assertNull(v);
+                assertNotNull(e);
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -334,12 +300,7 @@ public class SingleAmbTest extends RxJavaTest {
 
     @Test
     public void singleSourcesInIterable() {
-        SingleSource<Integer> source = new SingleSource<Integer>() {
-            @Override
-            public void subscribe(SingleObserver<? super Integer> observer) {
-                Single.just(1).subscribe(observer);
-            }
-        };
+        SingleSource<Integer> source = observer -> Single.just(1).subscribe(observer);
 
         Single.amb(Arrays.asList(source, source))
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
@@ -48,9 +48,9 @@ public class SingleCacheTest extends RxJavaTest {
 
             final TestObserver<Integer> to1 = cached.test();
 
-            Runnable r1 = () -> to1.dispose();
+            Runnable r1 = to1::dispose;
 
-            Runnable r2 = () -> cached.test();
+            Runnable r2 = cached::test;
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
@@ -48,19 +48,9 @@ public class SingleCacheTest extends RxJavaTest {
 
             final TestObserver<Integer> to1 = cached.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    to1.dispose();
-                }
-            };
+            Runnable r1 = () -> to1.dispose();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cached.test();
-                }
-            };
+            Runnable r2 = () -> cached.test();
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapCompletableTest.java
@@ -26,12 +26,7 @@ public class SingleConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete()));
     }
 
     @Test
@@ -39,17 +34,7 @@ public class SingleConcatMapCompletableTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return Completable.complete().doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        b[0] = true;
-                    }
-                });
-            }
-        })
+        .concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().doOnComplete(() -> b[0] = true))
         .test()
         .assertResult();
 
@@ -61,17 +46,7 @@ public class SingleConcatMapCompletableTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.<Integer>error(new TestException())
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return Completable.complete().doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        b[0] = true;
-                    }
-                });
-            }
-        })
+        .concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().doOnComplete(() -> b[0] = true))
         .test()
         .assertFailure(TestException.class);
 
@@ -83,11 +58,8 @@ public class SingleConcatMapCompletableTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                throw new TestException();
-            }
+        .concatMapCompletable((Function<Integer, Completable>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -100,12 +72,7 @@ public class SingleConcatMapCompletableTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return null;
-            }
-        })
+        .concatMapCompletable((Function<Integer, Completable>) _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapMaybeTest.java
@@ -23,14 +23,12 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class SingleConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void concatMapMaybeValue() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Maybe.just(2);
-                }
-
-                return Maybe.just(1);
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) integer -> {
+            if (integer == 1) {
+                return Maybe.just(2);
             }
+
+            return Maybe.just(1);
         })
             .test()
             .assertResult(2);
@@ -38,14 +36,12 @@ public class SingleConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void concatMapMaybeValueDifferentType() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<String>>() {
-            @Override public MaybeSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Maybe.just("2");
-                }
-
-                return Maybe.just("1");
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<String>>) integer -> {
+            if (integer == 1) {
+                return Maybe.just("2");
             }
+
+            return Maybe.just("1");
         })
             .test()
             .assertResult("2");
@@ -53,11 +49,7 @@ public class SingleConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void concatMapMaybeValueNull() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> null)
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
@@ -66,10 +58,8 @@ public class SingleConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void concatMapMaybeValueErrorThrown() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
@@ -81,60 +71,32 @@ public class SingleConcatMapMaybeTest extends RxJavaTest {
     public void concatMapMaybeError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Single.error(exception).concatMapMaybe(new Function<Object, MaybeSource<Object>>() {
-            @Override public MaybeSource<Object> apply(final Object integer) throws Exception {
-                return Maybe.just(new Object());
-            }
-        })
+        Single.error(exception).concatMapMaybe((Function<Object, MaybeSource<Object>>) _ -> Maybe.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1);
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Single<Integer> v) throws Exception {
-                return v.concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(1);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe((Function<Single<Integer>, MaybeSource<Integer>>) v ->
+            v.concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1)));
     }
 
     @Test
     public void mapsToError() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        })
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void mapsToEmpty() {
-        Single.just(1).concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        })
+        Single.just(1).concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapTest.java
@@ -24,14 +24,12 @@ public class SingleConcatMapTest extends RxJavaTest {
 
     @Test
     public void concatMapValue() {
-        Single.just(1).concatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just(2);
-                }
-
-                return Single.just(1);
+        Single.just(1).concatMap((Function<Integer, SingleSource<Integer>>) integer -> {
+            if (integer == 1) {
+                return Single.just(2);
             }
+
+            return Single.just(1);
         })
             .test()
             .assertResult(2);
@@ -39,14 +37,12 @@ public class SingleConcatMapTest extends RxJavaTest {
 
     @Test
     public void concatMapValueDifferentType() {
-        Single.just(1).concatMap(new Function<Integer, SingleSource<String>>() {
-            @Override public SingleSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just("2");
-                }
-
-                return Single.just("1");
+        Single.just(1).concatMap((Function<Integer, SingleSource<String>>) integer -> {
+            if (integer == 1) {
+                return Single.just("2");
             }
+
+            return Single.just("1");
         })
             .test()
             .assertResult("2");
@@ -54,11 +50,7 @@ public class SingleConcatMapTest extends RxJavaTest {
 
     @Test
     public void concatMapValueNull() {
-        Single.just(1).concatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Single.just(1).concatMap((Function<Integer, SingleSource<Integer>>) _ -> null)
         .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
@@ -67,10 +59,8 @@ public class SingleConcatMapTest extends RxJavaTest {
 
     @Test
     public void concatMapValueErrorThrown() {
-        Single.just(1).concatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Single.just(1).concatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
@@ -82,51 +72,25 @@ public class SingleConcatMapTest extends RxJavaTest {
     public void concatMapError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Single.error(exception).concatMap(new Function<Object, SingleSource<Object>>() {
-            @Override public SingleSource<Object> apply(final Object integer) throws Exception {
-                return Single.just(new Object());
-            }
-        })
+        Single.error(exception).concatMap((Function<Object, SingleSource<Object>>) _ -> Single.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).concatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).concatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2)));
     }
 
     @Test
     public void mappedSingleOnError() {
-        Single.just(1).concatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.error(new TestException());
-            }
-        })
+        Single.just(1).concatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s)
-                    throws Exception {
-                return s.concatMap(new Function<Object, SingleSource<? extends Object>>() {
-                    @Override
-                    public SingleSource<? extends Object> apply(Object v)
-                            throws Exception {
-                        return Single.just(v);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.concatMap(v -> Single.just(v)));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatMapTest.java
@@ -91,6 +91,6 @@ public class SingleConcatMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(s -> s.concatMap(v -> Single.just(v)));
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.concatMap(Single::just));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatPublisherTest.java
@@ -13,8 +13,6 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
-import java.util.concurrent.Callable;
-
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
@@ -30,12 +28,7 @@ public class SingleConcatPublisherTest extends RxJavaTest {
 
     @Test
     public void callable() {
-        Single.concat(Flowable.fromCallable(new Callable<Single<Integer>>() {
-            @Override
-            public Single<Integer> call() throws Exception {
-                return Single.just(1);
-            }
-        }))
+        Single.concat(Flowable.fromCallable(() -> Single.just(1)))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleConcatTest.java
@@ -145,12 +145,9 @@ public class SingleConcatTest extends RxJavaTest {
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
 
-        Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(SingleEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Single<Integer> source = Single.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Single.concatArray(source, source).firstElement()
@@ -164,12 +161,9 @@ public class SingleConcatTest extends RxJavaTest {
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };
 
-        Single<Integer> source = Single.create(new SingleOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(SingleEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onSuccess(1);
-            }
+        Single<Integer> source = Single.create(s -> {
+            calls[0]++;
+            s.onSuccess(1);
         });
 
         Single.concat(Arrays.asList(source, source)).firstElement()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleContainstTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleContainstTest.java
@@ -17,18 +17,14 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.BiPredicate;
 
 public class SingleContainstTest extends RxJavaTest {
 
     @Test
     public void comparerThrows() {
         Single.just(1)
-        .contains(2, new BiPredicate<Object, Object>() {
-            @Override
-            public boolean test(Object a, Object b) throws Exception {
-                throw new TestException();
-            }
+        .contains(2, (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.*;
 
@@ -34,16 +33,13 @@ public class SingleCreateTest extends RxJavaTest {
     public void basic() {
         final Disposable d = Disposable.empty();
 
-        Single.<Integer>create(new SingleOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(SingleEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+        Single.<Integer>create(e -> {
+            e.setDisposable(d);
 
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
+            e.onSuccess(1);
+            e.onError(new TestException());
+            e.onSuccess(2);
+            e.onError(new TestException());
         })
         .test()
         .assertResult(1);
@@ -57,22 +53,14 @@ public class SingleCreateTest extends RxJavaTest {
         final Disposable d1 = Disposable.empty();
         final Disposable d2 = Disposable.empty();
 
-        Single.<Integer>create(new SingleOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(SingleEmitter<Integer> e) throws Exception {
-                e.setDisposable(d1);
-                e.setCancellable(new Cancellable() {
-                    @Override
-                    public void cancel() throws Exception {
-                        d2.dispose();
-                    }
-                });
+        Single.<Integer>create(e -> {
+            e.setDisposable(d1);
+            e.setCancellable(() -> d2.dispose());
 
-                e.onSuccess(1);
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
+            e.onSuccess(1);
+            e.onError(new TestException());
+            e.onSuccess(2);
+            e.onError(new TestException());
         })
         .test()
         .assertResult(1);
@@ -86,15 +74,12 @@ public class SingleCreateTest extends RxJavaTest {
     public void basicWithError() {
         final Disposable d = Disposable.empty();
 
-        Single.<Integer>create(new SingleOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(SingleEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+        Single.<Integer>create(e -> {
+            e.setDisposable(d);
 
-                e.onError(new TestException());
-                e.onSuccess(2);
-                e.onError(new TestException());
-            }
+            e.onError(new TestException());
+            e.onSuccess(2);
+            e.onError(new TestException());
         })
         .test()
         .assertFailure(TestException.class);
@@ -109,11 +94,8 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createCallbackThrows() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                throw new TestException();
-            }
+        Single.create(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -121,22 +103,14 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                s.onSuccess(1);
-            }
-        }));
+        TestHelper.checkDisposed(Single.create(s -> s.onSuccess(1)));
     }
 
     @Test
     public void createNullSuccess() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                s.onSuccess(null);
-                s.onSuccess(null);
-            }
+        Single.create(s -> {
+            s.onSuccess(null);
+            s.onSuccess(null);
         })
         .test()
         .assertFailure(NullPointerException.class);
@@ -144,12 +118,9 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createNullError() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                s.onError(null);
-                s.onError(null);
-            }
+        Single.create(s -> {
+            s.onError(null);
+            s.onError(null);
         })
         .test()
         .assertFailure(NullPointerException.class);
@@ -157,15 +128,12 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createConsumerThrows() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                try {
-                    s.onSuccess(1);
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
+        Single.create(s -> {
+            try {
+                s.onSuccess(1);
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
         })
         .subscribe(new SingleObserver<Object>() {
@@ -188,20 +156,17 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createConsumerThrowsResource() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                Disposable d = Disposable.empty();
-                s.setDisposable(d);
-                try {
-                    s.onSuccess(1);
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(d.isDisposed());
+        Single.create(s -> {
+            Disposable d = Disposable.empty();
+            s.setDisposable(d);
+            try {
+                s.onSuccess(1);
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(d.isDisposed());
         })
         .subscribe(new SingleObserver<Object>() {
             @Override
@@ -223,15 +188,12 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createConsumerThrowsOnError() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                try {
-                    s.onError(new IOException());
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
+        Single.create(s -> {
+            try {
+                s.onError(new IOException());
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
         })
         .subscribe(new SingleObserver<Object>() {
@@ -252,20 +214,17 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void createConsumerThrowsResourceOnError() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> s) throws Exception {
-                Disposable d = Disposable.empty();
-                s.setDisposable(d);
-                try {
-                    s.onError(new IOException());
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-
-                assertTrue(d.isDisposed());
+        Single.create(s -> {
+            Disposable d = Disposable.empty();
+            s.setDisposable(d);
+            try {
+                s.onError(new IOException());
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+
+            assertTrue(d.isDisposed());
         })
         .subscribe(new SingleObserver<Object>() {
             @Override
@@ -289,12 +248,9 @@ public class SingleCreateTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final Boolean[] response = { null };
-            Single.create(new SingleOnSubscribe<Object>() {
-                @Override
-                public void subscribe(SingleEmitter<Object> e) throws Exception {
-                    e.onSuccess(1);
-                    response[0] = e.tryOnError(new TestException());
-                }
+            Single.create(e -> {
+                e.onSuccess(1);
+                response[0] = e.tryOnError(new TestException());
             })
             .test()
             .assertResult(1);
@@ -309,11 +265,6 @@ public class SingleCreateTest extends RxJavaTest {
 
     @Test
     public void emitterHasToString() {
-        Single.create(new SingleOnSubscribe<Object>() {
-            @Override
-            public void subscribe(SingleEmitter<Object> emitter) throws Exception {
-                assertTrue(emitter.toString().contains(SingleCreate.Emitter.class.getSimpleName()));
-            }
-        }).test().assertEmpty();
+        Single.create(emitter -> assertTrue(emitter.toString().contains(SingleCreate.Emitter.class.getSimpleName()))).test().assertEmpty();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
@@ -55,7 +55,7 @@ public class SingleCreateTest extends RxJavaTest {
 
         Single.<Integer>create(e -> {
             e.setDisposable(d1);
-            e.setCancellable(() -> d2.dispose());
+            e.setCancellable(d2::dispose);
 
             e.onSuccess(1);
             e.onError(new TestException());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
@@ -142,12 +142,9 @@ public class SingleDelayTest extends RxJavaTest {
 
         Single.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())
-                .doOnError(new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable throwable) throws Exception {
-                        thread.set(Thread.currentThread());
-                        latch.countDown();
-                    }
+                .doOnError(_ -> {
+                    thread.set(Thread.currentThread());
+                    latch.countDown();
                 })
                 .onErrorResumeWith(Single.just(""))
                 .subscribe();
@@ -250,24 +247,14 @@ public class SingleDelayTest extends RxJavaTest {
     @Test
     public void withCompletableDoubleOnSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeCompletableToSingle(new Function<Completable, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Completable c) throws Exception {
-                return c.andThen(Single.just(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeCompletableToSingle((Function<Completable, Single<Object>>) c -> c.andThen(Single.just(1)));
 
     }
 
     @Test
     public void withSingleDoubleOnSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Single<Object> s) throws Exception {
-                return Single.just((Object)1).delaySubscription(s);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle((Function<Single<Object>, Single<Object>>) s -> Single.just((Object)1).delaySubscription(s));
 
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDematerializeTest.java
@@ -58,7 +58,7 @@ public class SingleDematerializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(v -> v.dematerialize(w -> Notification.createOnNext(w)));
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(v -> v.dematerialize(Notification::createOnNext));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDematerializeTest.java
@@ -58,13 +58,7 @@ public class SingleDematerializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Object>, MaybeSource<Object>>() {
-            @SuppressWarnings({ "unchecked", "rawtypes" })
-            @Override
-            public MaybeSource<Object> apply(Single<Object> v) throws Exception {
-                return v.dematerialize((Function)Functions.identity());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe(v -> v.dematerialize(w -> Notification.createOnNext(w)));
     }
 
     @Test
@@ -75,11 +69,8 @@ public class SingleDematerializeTest extends RxJavaTest {
     @Test
     public void selectorCrash() {
         Single.just(Notification.createOnNext(1))
-        .dematerialize(new Function<Notification<Integer>, Notification<Integer>>() {
-            @Override
-            public Notification<Integer> apply(Notification<Integer> v) throws Exception {
-                throw new TestException();
-            }
+        .dematerialize((Function<Notification<Integer>, Notification<Integer>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -96,12 +87,7 @@ public class SingleDematerializeTest extends RxJavaTest {
     @Test
     public void selectorDifferentType() {
         Single.just(Notification.createOnNext(1))
-        .dematerialize(new Function<Notification<Integer>, Notification<String>>() {
-            @Override
-            public Notification<String> apply(Notification<Integer> v) throws Exception {
-                return Notification.createOnNext("Value-" + 1);
-            }
-        })
+        .dematerialize(_ -> Notification.createOnNext("Value-" + 1))
         .test()
         .assertResult("Value-1");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
@@ -32,7 +32,7 @@ public class SingleDetachTest extends RxJavaTest {
     @Test
     public void doubleSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeSingle(m -> m.onTerminateDetach());
+        TestHelper.checkDoubleOnSubscribeSingle(Single::onTerminateDetach);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -33,12 +32,7 @@ public class SingleDetachTest extends RxJavaTest {
     @Test
     public void doubleSubscribe() {
 
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> m) throws Exception {
-                return m.onTerminateDetach();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(m -> m.onTerminateDetach());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -32,12 +32,7 @@ public class SingleDoAfterSuccessTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<>();
 
-    final Consumer<Integer> afterSuccess = new Consumer<Integer>() {
-        @Override
-        public void accept(Integer e) throws Exception {
-            values.add(-e);
-        }
-    };
+    final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
     final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
@@ -94,11 +89,8 @@ public class SingleDoAfterSuccessTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Single.just(1)
-            .doAfterSuccess(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer e) throws Exception {
-                    throw new TestException();
-                }
+            .doAfterSuccess(_ -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1);
@@ -116,11 +108,6 @@ public class SingleDoAfterSuccessTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Single<Integer> m) throws Exception {
-                return m.doAfterSuccess(afterSuccess);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle((Function<Single<Integer>, SingleSource<Integer>>) m -> m.doAfterSuccess(afterSuccess));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterTerminateTest.java
@@ -32,12 +32,7 @@ public class SingleDoAfterTerminateTest extends RxJavaTest {
 
     private final int[] call = { 0 };
 
-    private final Action afterTerminate = new Action() {
-        @Override
-        public void run() throws Exception {
-            call[0]++;
-        }
-    };
+    private final Action afterTerminate = () -> call[0]++;
 
     private final TestObserver<Integer> to = new TestObserver<>();
 
@@ -88,11 +83,8 @@ public class SingleDoAfterTerminateTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Single.just(1)
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doAfterTerminate(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1);
@@ -110,12 +102,7 @@ public class SingleDoAfterTerminateTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Single<Integer> m) throws Exception {
-                return m.doAfterTerminate(afterTerminate);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle((Function<Single<Integer>, SingleSource<Integer>>) m -> m.doAfterTerminate(afterTerminate));
     }
 
     private void assertAfterTerminateCalledOnce() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoFinallyTest.java
@@ -57,12 +57,7 @@ public class SingleDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Single<Object> f) throws Exception {
-                return f.doFinally(SingleDoFinallyTest.this);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle((Function<Single<Object>, Single<Object>>) f -> f.doFinally(SingleDoFinallyTest.this));
     }
 
     @Test
@@ -70,11 +65,8 @@ public class SingleDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Single.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTerminateTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.testsupport.*;
 
 public class SingleDoOnTerminateTest extends RxJavaTest {
@@ -31,12 +30,7 @@ public class SingleDoOnTerminateTest extends RxJavaTest {
     public void doOnTerminateSuccess() {
         final AtomicBoolean atomicBoolean = new AtomicBoolean();
 
-        Single.just(1).doOnTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicBoolean.set(true);
-            }
-        })
+        Single.just(1).doOnTerminate(() -> atomicBoolean.set(true))
         .test()
         .assertResult(1);
 
@@ -46,12 +40,7 @@ public class SingleDoOnTerminateTest extends RxJavaTest {
     @Test
     public void doOnTerminateError() {
         final AtomicBoolean atomicBoolean = new AtomicBoolean();
-        Single.error(new TestException()).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                atomicBoolean.set(true);
-            }
-        })
+        Single.error(new TestException()).doOnTerminate(() -> atomicBoolean.set(true))
         .test()
         .assertFailure(TestException.class);
 
@@ -60,11 +49,8 @@ public class SingleDoOnTerminateTest extends RxJavaTest {
 
     @Test
     public void doOnTerminateSuccessCrash() {
-        Single.just(1).doOnTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new TestException();
-            }
+        Single.just(1).doOnTerminate(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -72,11 +58,8 @@ public class SingleDoOnTerminateTest extends RxJavaTest {
 
     @Test
     public void doOnTerminateErrorCrash() {
-        TestObserverEx<Object> to = Single.error(new TestException("Outer")).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                throw new TestException("Inner");
-            }
+        TestObserverEx<Object> to = Single.error(new TestException("Outer")).doOnTerminate(() -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.PublishSubject;
@@ -34,12 +33,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnDispose() {
         final int[] count = { 0 };
 
-        Single.never().doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                count[0]++;
-            }
-        }).test(true);
+        Single.never().doOnDispose(() -> count[0]++).test(true);
 
         assertEquals(1, count[0]);
     }
@@ -48,12 +42,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnError() {
         final Object[] event = { null };
 
-        Single.error(new TestException()).doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                event[0] = e;
-            }
-        })
+        Single.error(new TestException()).doOnError(e -> event[0] = e)
         .test();
 
         assertTrue(event[0].toString(), event[0] instanceof TestException);
@@ -63,12 +52,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnSubscribe() {
         final int[] count = { 0 };
 
-        Single.never().doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                count[0]++;
-            }
-        }).test();
+        Single.never().doOnSubscribe(_ -> count[0]++).test();
 
         assertEquals(1, count[0]);
     }
@@ -77,12 +61,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnSuccess() {
         final Object[] event = { null };
 
-        Single.just(1).doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                event[0] = e;
-            }
-        })
+        Single.just(1).doOnSuccess(e -> event[0] = e)
         .test();
 
         assertEquals(1, event[0]);
@@ -92,12 +71,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnSubscribeNormal() {
         final int[] count = { 0 };
 
-        Single.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                count[0]++;
-            }
-        })
+        Single.just(1).doOnSubscribe(_ -> count[0]++)
         .test()
         .assertResult(1);
 
@@ -108,12 +82,7 @@ public class SingleDoOnTest extends RxJavaTest {
     public void doOnSubscribeError() {
         final int[] count = { 0 };
 
-        Single.error(new TestException()).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                count[0]++;
-            }
-        })
+        Single.error(new TestException()).doOnSubscribe(_ -> count[0]++)
         .test()
         .assertFailure(TestException.class);
 
@@ -123,11 +92,8 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void doOnSubscribeJustCrash() {
 
-        Single.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) throws Exception {
-                throw new TestException();
-            }
+        Single.just(1).doOnSubscribe(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -138,11 +104,8 @@ public class SingleDoOnTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.error(new TestException("Outer")).doOnSubscribe(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                    throw new TestException("Inner");
-                }
+            Single.error(new TestException("Outer")).doOnSubscribe(_ -> {
+                throw new TestException("Inner");
             })
             .to(TestHelper.testConsumer())
             .assertFailureAndMessage(TestException.class, "Inner");
@@ -159,12 +122,7 @@ public class SingleDoOnTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Single.just(1)
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable v) throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnError(_ -> call[0]++)
         .test()
         .assertResult(1);
 
@@ -174,11 +132,8 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void onErrorCrashes() {
         TestObserverEx<Object> to = Single.error(new TestException("Outer"))
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable v) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
@@ -192,11 +147,8 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void doOnEventThrowsSuccess() {
         Single.just(1)
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                throw new TestException();
-            }
+        .doOnEvent((_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -205,11 +157,8 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void doOnEventThrowsError() {
         TestObserverEx<Integer> to = Single.<Integer>error(new TestException("Main"))
-        .doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnEvent((_, _) -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
@@ -223,12 +172,7 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void doOnDisposeDispose() {
         final int[] calls = { 0 };
-        TestHelper.checkDisposed(PublishSubject.create().singleOrError().doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        }));
+        TestHelper.checkDisposed(PublishSubject.create().singleOrError().doOnDispose(() -> calls[0]++));
 
         assertEquals(1, calls[0]);
     }
@@ -238,12 +182,7 @@ public class SingleDoOnTest extends RxJavaTest {
         final int[] calls = { 0 };
 
         Single.just(1)
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        })
+        .doOnDispose(() -> calls[0]++)
         .test()
         .assertResult(1);
 
@@ -255,12 +194,7 @@ public class SingleDoOnTest extends RxJavaTest {
         final int[] calls = { 0 };
 
         Single.error(new TestException())
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        })
+        .doOnDispose(() -> calls[0]++)
         .test()
         .assertFailure(TestException.class);
 
@@ -269,12 +203,7 @@ public class SingleDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnDisposeDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s) throws Exception {
-                return s.doOnDispose(Functions.EMPTY_ACTION);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.doOnDispose(Functions.EMPTY_ACTION));
     }
 
     @Test
@@ -283,11 +212,8 @@ public class SingleDoOnTest extends RxJavaTest {
         try {
             PublishSubject<Integer> ps = PublishSubject.create();
 
-            ps.singleOrError().doOnDispose(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            ps.singleOrError().doOnDispose(() -> {
+                throw new TestException();
             })
             .test()
             .dispose();
@@ -303,12 +229,7 @@ public class SingleDoOnTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Single.error(new TestException())
-        .doOnSuccess(new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnSuccess(_ -> call[0]++)
         .test()
         .assertFailure(TestException.class);
 
@@ -318,11 +239,8 @@ public class SingleDoOnTest extends RxJavaTest {
     @Test
     public void doOnSuccessCrash() {
         Single.just(1)
-        .doOnSuccess(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .doOnSuccess(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -342,11 +260,8 @@ public class SingleDoOnTest extends RxJavaTest {
                     observer.onSuccess(1);
                 }
             }
-            .doOnSubscribe(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                    throw new TestException("First");
-                }
+            .doOnSubscribe(_ -> {
+                throw new TestException("First");
             })
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleErrorTest.java
@@ -17,17 +17,13 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Supplier;
 
 public class SingleErrorTest extends RxJavaTest {
 
     @Test
     public void errorSupplierThrows() {
-        Single.error(new Supplier<Throwable>() {
-            @Override
-            public Throwable get() throws Exception {
-                throw new TestException();
-            }
+        Single.error(() -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapBiSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapBiSelectorTest.java
@@ -27,23 +27,13 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class SingleFlatMapBiSelectorTest extends RxJavaTest {
 
     BiFunction<Integer, Integer, String> stringCombine() {
-        return new BiFunction<Integer, Integer, String>() {
-            @Override
-            public String apply(Integer a, Integer b) throws Exception {
-                return a + ":" + b;
-            }
-        };
+        return (a, b) -> a + ":" + b;
     }
 
     @Test
     public void normal() {
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(2);
-            }
-        }, stringCombine())
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2), stringCombine())
         .test()
         .assertResult("1:2");
     }
@@ -53,12 +43,9 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Single.<Integer>error(new TestException())
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                call[0]++;
-                return Single.just(1);
-            }
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            call[0]++;
+            return Single.just(1);
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -71,12 +58,9 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                call[0]++;
-                return Single.<Integer>error(new TestException());
-            }
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            call[0]++;
+            return Single.<Integer>error(new TestException());
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -87,47 +71,20 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(SingleSubject.create()
-                .flatMap(new Function<Object, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Object v) throws Exception {
-                return Single.just(1);
-            }
-        }, new BiFunction<Object, Integer, Object>() {
-            @Override
-            public Object apply(Object a, Integer b) throws Exception {
-                return b;
-            }
-        }));
+                .flatMap((Function<Object, SingleSource<Integer>>) _ -> Single.just(1), (BiFunction<Object, Integer, Object>) (_, b) -> b));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> v) throws Exception {
-                return v.flatMap(new Function<Object, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(Object v) throws Exception {
-                        return Single.just(1);
-                    }
-                }, new BiFunction<Object, Integer, Object>() {
-                    @Override
-                    public Object apply(Object a, Integer b) throws Exception {
-                        return b;
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(v -> v.flatMap((Function<Object, SingleSource<Integer>>) _ ->
+            Single.just(1), (BiFunction<Object, Integer, Object>) (_, b) -> b));
     }
 
     @Test
     public void mapperThrows() {
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new TestException();
         }, stringCombine())
         .test()
         .assertFailure(TestException.class);
@@ -136,12 +93,7 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void mapperReturnsNull() {
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, stringCombine())
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> null, stringCombine())
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -149,16 +101,8 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void resultSelectorThrows() {
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2), (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -167,17 +111,7 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
     @Test
     public void resultSelectorReturnsNull() {
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return null;
-            }
-        })
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2), (_, _) -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -187,17 +121,11 @@ public class SingleFlatMapBiSelectorTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Single.just(1)
-        .flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                to.dispose();
-                return Single.just(2);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                throw new IllegalStateException();
-            }
+        .flatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            to.dispose();
+            return Single.just(2);
+        }, (BiFunction<Integer, Integer, Integer>) (_, _) -> {
+            throw new IllegalStateException();
         })
         .subscribeWith(to)
         .assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapCompletableTest.java
@@ -23,11 +23,6 @@ public class SingleFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -38,12 +38,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult(1, 2);
     }
@@ -51,12 +46,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void emptyIterable() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> Collections.<Integer>emptyList())
         .test()
         .assertResult();
     }
@@ -64,12 +54,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void error() {
 
-        Single.<Integer>error(new TestException()).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.<Integer>error(new TestException()).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .test()
         .assertFailure(TestException.class);
     }
@@ -77,12 +62,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void backpressure() {
 
-        TestSubscriber<Integer> ts = Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        TestSubscriber<Integer> ts = Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .test(0);
 
         ts.assertEmpty();
@@ -98,12 +78,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void take() {
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .take(1)
         .test()
         .assertResult(1);
@@ -113,12 +88,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     public void fused() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.ANY);
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -131,12 +101,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     public void fusedNoSync() {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.SYNC);
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .subscribe(ts);
 
         ts.assertFuseable()
@@ -148,12 +113,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void iteratorCrash() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(1, 100, 100);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(1, 100, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
@@ -161,12 +121,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextCrash() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 1, 100);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 1, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
@@ -174,12 +129,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextCrash() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 100, 1);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -187,12 +137,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextCrash2() {
 
-        Single.just(1).flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 2, 100);
-            }
-        })
+        Single.just(1).flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -200,14 +145,11 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async1() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .hide()
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -221,14 +163,11 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async2() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -241,14 +180,11 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async3() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .take(500 * 1000)
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -262,14 +198,11 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void async4() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .take(500 * 1000)
         .to(TestHelper.<Integer>testConsumer())
@@ -283,12 +216,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(1, 2, 3);
-                    }
-        }).subscribe(new FlowableSubscriber<Integer>() {
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() {
             QueueSubscription<Integer> qs;
             @SuppressWarnings("unchecked")
             @Override
@@ -322,12 +250,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextThrowsUnbounded() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 2, 100);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -335,12 +258,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextThrowsUnbounded() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 100, 1);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -348,12 +266,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void hasNextThrows() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 2, 100);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testSubscriber(2L))
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
@@ -361,12 +274,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void nextThrows() {
         Single.just(1)
-        .flattenAsFlowable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return new CrashingIterable(100, 100, 1);
-                    }
-                })
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testSubscriber(2L))
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -377,12 +285,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(1, 2, 3);
-                }
-            })
+                            (Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
             .test(5L)
             .assertEmpty();
         }
@@ -399,30 +302,19 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
             ps.onNext(1);
 
             final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(a);
-                }
-            })
+                            (Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(a))
             .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                    for (int i = 0; i < 500; i++) {
-                        ts.request(1);
-                    }
+            Runnable r1 = () -> {
+                ps.onComplete();
+                for (int i1 = 0; i1 < 500; i1++) {
+                    ts.request(1);
                 }
             };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int i = 0; i < 500; i++) {
-                        ts.request(1);
-                    }
+            Runnable r2 = () -> {
+                for (int i2 = 0; i2 < 500; i2++) {
+                    ts.request(1);
                 }
             };
 
@@ -438,27 +330,12 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
             ps.onNext(1);
 
             final TestSubscriber<Integer> ts = ps.singleElement().flattenAsFlowable(
-            new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(1, 2, 3);
-                }
-            })
+                            (Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
             .test(0L);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r1 = () -> ps.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.cancel();
-                }
-            };
+            Runnable r2 = () -> ts.cancel();
 
             TestHelper.race(r1, r2);
         }
@@ -472,34 +349,24 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+            int count;
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            int count;
-                            @Override
-                            public boolean hasNext() {
-                                if (count++ == 2) {
-                                    ts.cancel();
-                                }
-                                return true;
-                            }
+            public boolean hasNext() {
+                if (count++ == 2) {
+                    ts.cancel();
+                }
+                return true;
+            }
 
-                            @Override
-                            public Integer next() {
-                                return 1;
-                            }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -516,34 +383,24 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+            int count;
             @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            int count;
-                            @Override
-                            public boolean hasNext() {
-                                if (count++ == 2) {
-                                    ts.cancel();
-                                }
-                                return true;
-                            }
+            public boolean hasNext() {
+                if (count++ == 2) {
+                    ts.cancel();
+                }
+                return true;
+            }
 
-                            @Override
-                            public Integer next() {
-                                return 1;
-                            }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(ts);
@@ -560,28 +417,17 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            final TestSubscriber<Integer> ts = ps.singleOrError().flattenAsFlowable(new Function<Integer, Iterable<Integer>>() {
-                @Override
-                public Iterable<Integer> apply(Integer v) throws Exception {
-                    return Arrays.asList(a);
-                }
-            }).test();
+            final TestSubscriber<Integer> ts = ps.singleOrError().flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(a)).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int i = 0; i < 1000; i++) {
-                        ts.request(1);
-                    }
+            Runnable r1 = () -> {
+                for (int i1 = 0; i1 < 1000; i1++) {
+                    ts.request(1);
                 }
             };
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onNext(1);
-                    ps.onComplete();
-                }
+            Runnable r2 = () -> {
+                ps.onNext(1);
+                ps.onComplete();
             };
 
             TestHelper.race(r1, r2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -333,9 +333,9 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
                             (Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
             .test(0L);
 
-            Runnable r1 = () -> ps.onComplete();
+            Runnable r1 = ps::onComplete;
 
-            Runnable r2 = () -> ts.cancel();
+            Runnable r2 = ts::cancel;
 
             TestHelper.race(r1, r2);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -36,12 +36,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .test()
         .assertResult(1, 2);
     }
@@ -49,12 +44,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void emptyIterable() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Collections.<Integer>emptyList();
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) _ -> Collections.<Integer>emptyList())
         .test()
         .assertResult();
     }
@@ -62,24 +52,14 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void error() {
 
-        Single.<Integer>error(new TestException()).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.<Integer>error(new TestException()).flattenAsObservable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void take() {
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .take(1)
         .test()
         .assertResult(1);
@@ -89,12 +69,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     public void fused() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .subscribe(to);
 
         to.assertFuseable()
@@ -107,12 +82,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     public void fusedNoSync() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(v, v + 1);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) v -> Arrays.asList(v, v + 1))
         .subscribe(to);
 
         to.assertFuseable()
@@ -124,12 +94,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void iteratorCrash() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(1, 100, 100);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(1, 100, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
@@ -137,12 +102,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void hasNextCrash() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 1, 100);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 1, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
@@ -150,12 +110,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void nextCrash() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 100, 1);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 100, 1))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
@@ -163,52 +118,29 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void hasNextCrash2() {
 
-        Single.just(1).flattenAsObservable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return new CrashingIterable(100, 2, 100);
-            }
-        })
+        Single.just(1).flattenAsObservable((Function<Integer, Iterable<Integer>>) _ -> new CrashingIterable(100, 2, 100))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()", 0);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToObservable(new Function<Single<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Single<Object> o) throws Exception {
-                return o.flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Collections.singleton(1);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToObservable(o -> o.flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Collections.singleton(1)));
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Collections.singleton(1);
-                    }
-                }));
+        TestHelper.checkDisposed(Single.just(1).flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Collections.singleton(1)));
     }
 
     @Test
     public void async1() {
         Single.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .hide()
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -222,14 +154,11 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async2() {
         Single.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -242,14 +171,11 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async3() {
         Single.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .take(500 * 1000)
         .observeOn(Schedulers.single())
         .to(TestHelper.<Integer>testConsumer())
@@ -263,14 +189,11 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void async4() {
         Single.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        Integer[] array = new Integer[1000 * 1000];
-                        Arrays.fill(array, 1);
-                        return Arrays.asList(array);
-                    }
-                })
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> {
+            Integer[] array = new Integer[1000 * 1000];
+            Arrays.fill(array, 1);
+            return Arrays.asList(array);
+        })
         .observeOn(Schedulers.single())
         .take(500 * 1000)
         .to(TestHelper.<Integer>testConsumer())
@@ -284,12 +207,7 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Single.just(1)
-        .flattenAsObservable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(1, 2, 3);
-                    }
-        }).subscribe(new Observer<Integer>() {
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3)).subscribe(new Observer<Integer>() {
             QueueDisposable<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybeTest.java
@@ -23,14 +23,12 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class SingleFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void flatMapMaybeValue() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Maybe.just(2);
-                }
-
-                return Maybe.just(1);
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) integer -> {
+            if (integer == 1) {
+                return Maybe.just(2);
             }
+
+            return Maybe.just(1);
         })
             .test()
             .assertResult(2);
@@ -38,14 +36,12 @@ public class SingleFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void flatMapMaybeValueDifferentType() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<String>>() {
-            @Override public MaybeSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Maybe.just("2");
-                }
-
-                return Maybe.just("1");
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<String>>) integer -> {
+            if (integer == 1) {
+                return Maybe.just("2");
             }
+
+            return Maybe.just("1");
         })
             .test()
             .assertResult("2");
@@ -53,11 +49,7 @@ public class SingleFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void flatMapMaybeValueNull() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> null)
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
@@ -66,10 +58,8 @@ public class SingleFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void flatMapMaybeValueErrorThrown() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override public MaybeSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
@@ -81,60 +71,32 @@ public class SingleFlatMapMaybeTest extends RxJavaTest {
     public void flatMapMaybeError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Single.error(exception).flatMapMaybe(new Function<Object, MaybeSource<Object>>() {
-            @Override public MaybeSource<Object> apply(final Object integer) throws Exception {
-                return Maybe.just(new Object());
-            }
-        })
+        Single.error(exception).flatMapMaybe((Function<Object, MaybeSource<Object>>) _ -> Maybe.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1);
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1)));
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Integer>, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Single<Integer> v) throws Exception {
-                return v.flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(Integer v) throws Exception {
-                        return Maybe.just(1);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe((Function<Single<Integer>, MaybeSource<Integer>>) v ->
+            v.flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1)));
     }
 
     @Test
     public void mapsToError() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        })
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void mapsToEmpty() {
-        Single.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        })
+        Single.just(1).flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
@@ -37,14 +37,9 @@ public class SingleFlatMapNotificationTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Integer>, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Single<Integer> m) throws Exception {
-                return m
-                        .flatMap(Functions.justFunction(Single.just(1)),
-                                Functions.justFunction(Single.just(1)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle((Function<Single<Integer>, SingleSource<Integer>>) m -> m
+                .flatMap(Functions.justFunction(Single.just(1)),
+                        Functions.justFunction(Single.just(1))));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapTest.java
@@ -32,17 +32,7 @@ public class SingleFlatMapTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return Completable.complete().doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        b[0] = true;
-                    }
-                });
-            }
-        })
+        .flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().doOnComplete(() -> b[0] = true))
         .test()
         .assertResult();
 
@@ -54,17 +44,7 @@ public class SingleFlatMapTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.<Integer>error(new TestException())
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return Completable.complete().doOnComplete(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        b[0] = true;
-                    }
-                });
-            }
-        })
+        .flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().doOnComplete(() -> b[0] = true))
         .test()
         .assertFailure(TestException.class);
 
@@ -76,11 +56,8 @@ public class SingleFlatMapTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable((Function<Integer, Completable>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -93,12 +70,7 @@ public class SingleFlatMapTest extends RxJavaTest {
         final boolean[] b = { false };
 
         Single.just(1)
-        .flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer t) throws Exception {
-                return null;
-            }
-        })
+        .flatMapCompletable((Function<Integer, Completable>) _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
 
@@ -107,24 +79,14 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapObservable() {
-        Single.just(1).flatMapObservable(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 5);
-            }
-        })
+        Single.just(1).flatMapObservable((Function<Integer, Observable<Integer>>) v -> Observable.range(v, 5))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
 
     @Test
     public void flatMapPublisher() {
-        Single.just(1).flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(v, 5);
-            }
-        })
+        Single.just(1).flatMapPublisher((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v, 5))
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -133,11 +95,8 @@ public class SingleFlatMapTest extends RxJavaTest {
     public void flatMapPublisherMapperThrows() {
         final TestException ex = new TestException();
         Single.just(1)
-        .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                throw ex;
-            }
+        .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
+            throw ex;
         })
         .test()
         .assertNoValues()
@@ -148,12 +107,7 @@ public class SingleFlatMapTest extends RxJavaTest {
     public void flatMapPublisherSingleError() {
         final TestException ex = new TestException();
         Single.<Integer>error(ex)
-        .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.just(1);
-            }
-        })
+        .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.just(1))
         .test()
         .assertNoValues()
         .assertError(ex);
@@ -163,18 +117,8 @@ public class SingleFlatMapTest extends RxJavaTest {
     public void flatMapPublisherCancelDuringSingle() {
         final AtomicBoolean disposed = new AtomicBoolean();
         TestSubscriberEx<Integer> ts = Single.<Integer>never()
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                disposed.set(true);
-            }
-        })
-        .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.range(v, 5);
-            }
-        })
+        .doOnDispose(() -> disposed.set(true))
+        .flatMapPublisher((Function<Integer, Publisher<Integer>>) v -> Flowable.range(v, 5))
         .to(TestHelper.<Integer>testConsumer())
         .assertNoValues()
         .assertNotTerminated();
@@ -189,18 +133,8 @@ public class SingleFlatMapTest extends RxJavaTest {
         final AtomicBoolean disposed = new AtomicBoolean();
         TestSubscriberEx<Integer> ts =
         Single.just(1)
-        .flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-            @Override
-            public Publisher<Integer> apply(Integer v) throws Exception {
-                return Flowable.<Integer>never()
-                        .doOnCancel(new Action() {
-                            @Override
-                            public void run() throws Exception {
-                                disposed.set(true);
-                            }
-                        });
-            }
-        })
+        .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.<Integer>never()
+                .doOnCancel(() -> disposed.set(true)))
         .to(TestHelper.<Integer>testConsumer())
         .assertNoValues()
         .assertNotTerminated();
@@ -212,14 +146,12 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapValue() {
-        Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just(2);
-                }
-
-                return Single.just(1);
+        Single.just(1).flatMap((Function<Integer, SingleSource<Integer>>) integer -> {
+            if (integer == 1) {
+                return Single.just(2);
             }
+
+            return Single.just(1);
         })
             .test()
             .assertResult(2);
@@ -227,14 +159,12 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapValueDifferentType() {
-        Single.just(1).flatMap(new Function<Integer, SingleSource<String>>() {
-            @Override public SingleSource<String> apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return Single.just("2");
-                }
-
-                return Single.just("1");
+        Single.just(1).flatMap((Function<Integer, SingleSource<String>>) integer -> {
+            if (integer == 1) {
+                return Single.just("2");
             }
+
+            return Single.just("1");
         })
             .test()
             .assertResult("2");
@@ -242,11 +172,7 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapValueNull() {
-        Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Single.just(1).flatMap((Function<Integer, SingleSource<Integer>>) _ -> null)
         .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
             .assertError(NullPointerException.class)
@@ -255,10 +181,8 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void flatMapValueErrorThrown() {
-        Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Single.just(1).flatMap((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
             .to(TestHelper.<Integer>testConsumer())
             .assertNoValues()
@@ -270,51 +194,25 @@ public class SingleFlatMapTest extends RxJavaTest {
     public void flatMapError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Single.error(exception).flatMap(new Function<Object, SingleSource<Object>>() {
-            @Override public SingleSource<Object> apply(final Object integer) throws Exception {
-                return Single.just(new Object());
-            }
-        })
+        Single.error(exception).flatMap((Function<Object, SingleSource<Object>>) _ -> Single.just(new Object()))
             .test()
             .assertError(exception);
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(2);
-            }
-        }));
+        TestHelper.checkDisposed(Single.just(1).flatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.just(2)));
     }
 
     @Test
     public void mappedSingleOnError() {
-        Single.just(1).flatMap(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.error(new TestException());
-            }
-        })
+        Single.just(1).flatMap((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s)
-                    throws Exception {
-                return s.flatMap(new Function<Object, SingleSource<? extends Object>>() {
-                    @Override
-                    public SingleSource<? extends Object> apply(Object v)
-                            throws Exception {
-                        return Single.just(v);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.flatMap(v -> Single.just(v)));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapTest.java
@@ -213,6 +213,6 @@ public class SingleFlatMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(s -> s.flatMap(v -> Single.just(v)));
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.flatMap(Single::just));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromCallableTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -36,21 +35,15 @@ public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void fromCallableValue() {
-        Single.fromCallable(new Callable<Integer>() {
-            @Override public Integer call() throws Exception {
-                return 5;
-            }
-        })
+        Single.fromCallable(() -> 5)
         .test()
         .assertResult(5);
     }
 
     @Test
     public void fromCallableError() {
-        Single.fromCallable(new Callable<Integer>() {
-            @Override public Integer call() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Single.fromCallable((Callable<Integer>) () -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -58,11 +51,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void fromCallableNull() {
-        Single.fromCallable(new Callable<Integer>() {
-            @Override public Integer call() throws Exception {
-                return null;
-            }
-        })
+        Single.fromCallable((Callable<Integer>) () -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The callable returned a null value");
     }
@@ -71,12 +60,7 @@ public class SingleFromCallableTest extends RxJavaTest {
     public void fromCallableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Callable<Integer> callable = new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return atomicInteger.incrementAndGet();
-            }
-        };
+        Callable<Integer> callable = () -> atomicInteger.incrementAndGet();
 
         Single.fromCallable(callable)
                 .test()
@@ -114,13 +98,10 @@ public class SingleFromCallableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Integer> to = Single.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                    return 1;
-                }
+            TestObserver<Integer> to = Single.fromCallable(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
+                return 1;
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -147,22 +128,19 @@ public class SingleFromCallableTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.call()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.call()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Single<String> fromCallableObservable = Single.fromCallable(func);
@@ -196,11 +174,8 @@ public class SingleFromCallableTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Single<Object> fromCallableObservable = Single.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw checkedException;
-            }
+        Single<Object> fromCallableObservable = Single.fromCallable(() -> {
+            throw checkedException;
         });
 
         SingleObserver<Object> observer = TestHelper.mockSingleObserver();
@@ -215,12 +190,9 @@ public class SingleFromCallableTest extends RxJavaTest {
     @Test
     public void disposedOnArrival() {
         final int[] count = { 0 };
-        Single.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                count[0]++;
-                return 1;
-            }
+        Single.fromCallable((Callable<Object>) () -> {
+            count[0]++;
+            return 1;
         })
                 .test(true)
                 .assertEmpty();
@@ -232,12 +204,9 @@ public class SingleFromCallableTest extends RxJavaTest {
     public void disposedOnCall() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Single.fromCallable(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                to.dispose();
-                return 1;
-            }
+        Single.fromCallable(() -> {
+            to.dispose();
+            return 1;
         })
                 .subscribe(to);
 
@@ -246,12 +215,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void toObservableTake() {
-        Single.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return 1;
-            }
-        })
+        Single.fromCallable((Callable<Object>) () -> 1)
                 .toObservable()
                 .take(1)
                 .test()
@@ -260,12 +224,7 @@ public class SingleFromCallableTest extends RxJavaTest {
 
     @Test
     public void toObservableAndBack() {
-        Single.fromCallable(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return 1;
-            }
-        })
+        Single.fromCallable(() -> 1)
                 .toObservable()
                 .singleOrError()
                 .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromCallableTest.java
@@ -60,7 +60,7 @@ public class SingleFromCallableTest extends RxJavaTest {
     public void fromCallableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Callable<Integer> callable = () -> atomicInteger.incrementAndGet();
+        Callable<Integer> callable = atomicInteger::incrementAndGet;
 
         Single.fromCallable(callable)
                 .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromSupplierTest.java
@@ -61,7 +61,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
     public void fromSupplierTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Supplier<Integer> supplier = () -> atomicInteger.incrementAndGet();
+        Supplier<Integer> supplier = atomicInteger::incrementAndGet;
 
         Single.fromSupplier(supplier)
                 .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromSupplierTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -37,21 +36,15 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fromSupplierValue() {
-        Single.fromSupplier(new Supplier<Integer>() {
-            @Override public Integer get() throws Exception {
-                return 5;
-            }
-        })
+        Single.fromSupplier(() -> 5)
         .test()
         .assertResult(5);
     }
 
     @Test
     public void fromSupplierError() {
-        Single.fromSupplier(new Supplier<Integer>() {
-            @Override public Integer get() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Single.fromSupplier((Supplier<Integer>) () -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -59,11 +52,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fromSupplierNull() {
-        Single.fromSupplier(new Supplier<Integer>() {
-            @Override public Integer get() throws Exception {
-                return null;
-            }
-        })
+        Single.fromSupplier((Supplier<Integer>) () -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The supplier returned a null value");
     }
@@ -72,12 +61,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
     public void fromSupplierTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Supplier<Integer> supplier = new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                return atomicInteger.incrementAndGet();
-            }
-        };
+        Supplier<Integer> supplier = () -> atomicInteger.incrementAndGet();
 
         Single.fromSupplier(supplier)
                 .test()
@@ -115,13 +99,10 @@ public class SingleFromSupplierTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Integer> to = Single.fromSupplier(new Supplier<Integer>() {
-                @Override
-                public Integer get() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                    return 1;
-                }
+            TestObserver<Integer> to = Single.fromSupplier(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
+                return 1;
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -148,22 +129,19 @@ public class SingleFromSupplierTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.get()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.get()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Single<String> fromSupplierObservable = Single.fromSupplier(func);
@@ -197,11 +175,8 @@ public class SingleFromSupplierTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Single<Object> fromSupplierObservable = Single.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw checkedException;
-            }
+        Single<Object> fromSupplierObservable = Single.fromSupplier(() -> {
+            throw checkedException;
         });
 
         SingleObserver<Object> observer = TestHelper.mockSingleObserver();
@@ -216,12 +191,9 @@ public class SingleFromSupplierTest extends RxJavaTest {
     @Test
     public void disposedOnArrival() {
         final int[] count = { 0 };
-        Single.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                count[0]++;
-                return 1;
-            }
+        Single.fromSupplier((Supplier<Object>) () -> {
+            count[0]++;
+            return 1;
         })
                 .test(true)
                 .assertEmpty();
@@ -233,12 +205,9 @@ public class SingleFromSupplierTest extends RxJavaTest {
     public void disposedOnCall() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Single.fromSupplier(new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                to.dispose();
-                return 1;
-            }
+        Single.fromSupplier(() -> {
+            to.dispose();
+            return 1;
         })
                 .subscribe(to);
 
@@ -247,12 +216,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void toObservableTake() {
-        Single.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        })
+        Single.fromSupplier((Supplier<Object>) () -> 1)
         .toObservable()
         .take(1)
         .test()
@@ -261,12 +225,7 @@ public class SingleFromSupplierTest extends RxJavaTest {
 
     @Test
     public void toObservableAndBack() {
-        Single.fromSupplier(new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                return 1;
-            }
-        })
+        Single.fromSupplier(() -> 1)
         .toObservable()
         .singleOrError()
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleHideTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleHideTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -38,11 +37,6 @@ public class SingleHideTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s) throws Exception {
-                return s.hide();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.hide());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleHideTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleHideTest.java
@@ -37,6 +37,6 @@ public class SingleHideTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(s -> s.hide());
+        TestHelper.checkDoubleOnSubscribeSingle(Single::hide);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
@@ -23,26 +23,21 @@ public class SingleLiftTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single.just(1).lift(new SingleOperator<Integer, Integer>() {
+        Single.just(1).lift((SingleOperator<Integer, Integer>) observer -> new SingleObserver<Integer>() {
+
             @Override
-            public SingleObserver<Integer> apply(final SingleObserver<? super Integer> observer) throws Exception {
-                return new SingleObserver<Integer>() {
+            public void onSubscribe(Disposable d) {
+                observer.onSubscribe(d);
+            }
 
-                    @Override
-                    public void onSubscribe(Disposable d) {
-                        observer.onSubscribe(d);
-                    }
+            @Override
+            public void onSuccess(Integer value) {
+                observer.onSuccess(value + 1);
+            }
 
-                    @Override
-                    public void onSuccess(Integer value) {
-                        observer.onSuccess(value + 1);
-                    }
-
-                    @Override
-                    public void onError(Throwable e) {
-                        observer.onError(e);
-                    }
-                };
+            @Override
+            public void onError(Throwable e) {
+                observer.onError(e);
             }
         })
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMapTest.java
@@ -23,15 +23,12 @@ public class SingleMapTest extends RxJavaTest {
 
     @Test
     public void mapValue() {
-        Single.just(1).map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(final Integer integer) throws Exception {
-                if (integer == 1) {
-                    return 2;
-                }
-
-                return 1;
+        Single.just(1).map(integer -> {
+            if (integer == 1) {
+                return 2;
             }
+
+            return 1;
         })
         .test()
         .assertResult(2);
@@ -39,12 +36,7 @@ public class SingleMapTest extends RxJavaTest {
 
     @Test
     public void mapValueNull() {
-        Single.just(1).map(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                return null;
-            }
-        })
+        Single.just(1).map((Function<Integer, SingleSource<Integer>>) _ -> null)
         .to(TestHelper.<SingleSource<Integer>>testConsumer())
         .assertNoValues()
         .assertError(NullPointerException.class)
@@ -53,11 +45,8 @@ public class SingleMapTest extends RxJavaTest {
 
     @Test
     public void mapValueErrorThrown() {
-        Single.just(1).map(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final Integer integer) throws Exception {
-                throw new RuntimeException("something went terribly wrong!");
-            }
+        Single.just(1).map((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new RuntimeException("something went terribly wrong!");
         })
         .to(TestHelper.<SingleSource<Integer>>testConsumer())
         .assertNoValues()
@@ -69,12 +58,7 @@ public class SingleMapTest extends RxJavaTest {
     public void mapError() {
         RuntimeException exception = new RuntimeException("test");
 
-        Single.error(exception).map(new Function<Object, Object>() {
-            @Override
-            public Object apply(final Object integer) throws Exception {
-                return new Object();
-            }
-        })
+        Single.error(exception).map(_ -> new Object())
         .test()
         .assertError(exception);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMaterializeTest.java
@@ -17,7 +17,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.subjects.SingleSubject;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -42,12 +41,7 @@ public class SingleMaterializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Notification<Object>>>() {
-            @Override
-            public SingleSource<Notification<Object>> apply(Single<Object> v) throws Exception {
-                return v.materialize();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(v -> v.materialize());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMaterializeTest.java
@@ -41,7 +41,7 @@ public class SingleMaterializeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(v -> v.materialize());
+        TestHelper.checkDoubleOnSubscribeSingle(Single::materialize);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -130,7 +130,7 @@ public class SingleMiscTest extends RxJavaTest {
 
             }
         })
-        .repeatUntil(() -> flag.get())
+        .repeatUntil(flag::get)
         .test()
         .assertResult(1, 1, 1, 1, 1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -48,12 +48,9 @@ public class SingleMiscTest extends RxJavaTest {
     public void wrap() {
         assertSame(Single.never(), Single.wrap(Single.never()));
 
-        Single.wrap(new SingleSource<Object>() {
-            @Override
-            public void subscribe(SingleObserver<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onSuccess(1);
-            }
+        Single.wrap(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onSuccess(1);
         })
         .test()
         .assertResult(1);
@@ -78,17 +75,7 @@ public class SingleMiscTest extends RxJavaTest {
     public void compose() {
 
         Single.just(1)
-        .compose(new SingleTransformer<Integer, Object>() {
-            @Override
-            public SingleSource<Object> apply(Single<Integer> f) {
-                return f.map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer v) throws Exception {
-                        return v + 1;
-                    }
-                });
-            }
-        })
+        .compose(f -> f.map((Function<Integer, Object>) v -> v + 1))
         .test()
         .assertResult(2);
     }
@@ -143,12 +130,7 @@ public class SingleMiscTest extends RxJavaTest {
 
             }
         })
-        .repeatUntil(new BooleanSupplier() {
-            @Override
-            public boolean getAsBoolean() throws Exception {
-                return flag.get();
-            }
-        })
+        .repeatUntil(() -> flag.get())
         .test()
         .assertResult(1, 1, 1, 1, 1);
     }
@@ -182,12 +164,7 @@ public class SingleMiscTest extends RxJavaTest {
                 return 1;
             }
         })
-        .retry(new BiPredicate<Integer, Throwable>() {
-            @Override
-            public boolean test(Integer i, Throwable e) throws Exception {
-                return true;
-            }
-        })
+        .retry((_, _) -> true)
         .test()
         .assertResult(1);
     }
@@ -196,15 +173,11 @@ public class SingleMiscTest extends RxJavaTest {
     public void retryTimes() {
         final AtomicInteger calls = new AtomicInteger();
 
-        Single.fromCallable(new Callable<Object>() {
-
-            @Override
-            public Object call() throws Exception {
-                if (calls.incrementAndGet() != 6) {
-                    throw new TestException();
-                }
-                return 1;
+        Single.fromCallable((Callable<Object>) () -> {
+            if (calls.incrementAndGet() != 6) {
+                throw new TestException();
             }
+            return 1;
         })
         .retry(5)
         .test()
@@ -225,12 +198,7 @@ public class SingleMiscTest extends RxJavaTest {
                 return 1;
             }
         })
-        .retry(new Predicate<Throwable>() {
-            @Override
-            public boolean test(Throwable e) throws Exception {
-                return true;
-            }
-        })
+        .retry(_ -> true)
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleObserveOnTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -32,12 +31,7 @@ public class SingleObserveOnTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s) throws Exception {
-                return s.observeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.observeOn(Schedulers.single()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOfTypeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOfTypeTest.java
@@ -69,12 +69,7 @@ public class SingleOfTypeTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposedSingleToMaybe(new Function<Single<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Single<Object> m) throws Exception {
-                return m.ofType(Object.class);
-            }
-        });
+        TestHelper.checkDisposedSingleToMaybe((Function<Single<Object>, Maybe<Object>>) m -> m.ofType(Object.class));
     }
 
     @Test
@@ -86,11 +81,6 @@ public class SingleOfTypeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingleToMaybe(new Function<Single<Object>, Maybe<Object>>() {
-            @Override
-            public Maybe<Object> apply(Single<Object> f) throws Exception {
-                return f.ofType(Object.class);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingleToMaybe((Function<Single<Object>, Maybe<Object>>) f -> f.ofType(Object.class));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorXTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.testsupport.*;
 
 public class SingleOnErrorXTest extends RxJavaTest {
@@ -35,11 +34,8 @@ public class SingleOnErrorXTest extends RxJavaTest {
     @Test
     public void resumeThrows() {
         TestObserverEx<Integer> to = Single.<Integer>error(new TestException("Outer"))
-        .onErrorReturn(new Function<Throwable, Integer>() {
-            @Override
-            public Integer apply(Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .onErrorReturn(_ -> {
+            throw new TestException("Inner");
         })
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
@@ -66,12 +62,7 @@ public class SingleOnErrorXTest extends RxJavaTest {
 
     @Test
     public void resumeDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> s) throws Exception {
-                return s.onErrorResumeWith(Single.just(1));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(s -> s.onErrorResumeWith(Single.just(1)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntilTest.java
@@ -237,19 +237,9 @@ public class SingleTakeUntilTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp1.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp2.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp2.onError(ex);
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeoutTest.java
@@ -25,7 +25,6 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.*;
@@ -123,12 +122,7 @@ public class SingleTimeoutTest extends RxJavaTest {
         final int[] calls = { 0 };
 
         Single.just(1)
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                calls[0]++;
-            }
-        })
+        .doOnDispose(() -> calls[0]++)
         .timeout(1, TimeUnit.DAYS)
         .test()
         .assertResult(1);
@@ -146,19 +140,9 @@ public class SingleTimeoutTest extends RxJavaTest {
 
             TestObserver<Integer> to = subj.timeout(1, TimeUnit.MILLISECONDS, sch, fallback).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    subj.onSuccess(1);
-                }
-            };
+            Runnable r1 = () -> subj.onSuccess(1);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
-                }
-            };
+            Runnable r2 = () -> sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
             TestHelper.race(r1, r2);
 
@@ -184,19 +168,9 @@ public class SingleTimeoutTest extends RxJavaTest {
 
                 TestObserver<Integer> to = subj.timeout(1, TimeUnit.MILLISECONDS, sch, fallback).test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        subj.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> subj.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
-                    }
-                };
+                Runnable r2 = () -> sch.advanceTimeBy(1, TimeUnit.MILLISECONDS);
 
                 TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -40,16 +39,13 @@ public class SingleTimerTest extends RxJavaTest {
             for (Scheduler s : new Scheduler[] { Schedulers.single(), Schedulers.computation(), Schedulers.newThread(), Schedulers.cached(), Schedulers.from(exec, true) }) {
                 final AtomicBoolean interrupted = new AtomicBoolean();
                 TestObserver<Long> to = Single.timer(1, TimeUnit.MILLISECONDS, s)
-                .map(new Function<Long, Long>() {
-                    @Override
-                    public Long apply(Long v) throws Exception {
-                        try {
-                        Thread.sleep(3000);
-                        } catch (InterruptedException ex) {
-                            interrupted.set(true);
-                        }
-                        return v;
+                .map(v -> {
+                    try {
+                    Thread.sleep(3000);
+                    } catch (InterruptedException ex) {
+                        interrupted.set(true);
                     }
+                    return v;
                 })
                 .test();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -37,12 +36,9 @@ public class SingleUnsubscribeOnTest extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(1);
 
-        pp.doOnCancel(new Action() {
-            @Override
-            public void run() throws Exception {
-                name[0] = Thread.currentThread().getName();
-                cdl.countDown();
-            }
+        pp.doOnCancel(() -> {
+            name[0] = Thread.currentThread().getName();
+            cdl.countDown();
         })
         .single(-99)
         .unsubscribeOn(Schedulers.single())
@@ -86,12 +82,7 @@ public class SingleUnsubscribeOnTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeSingle(new Function<Single<Object>, SingleSource<Object>>() {
-            @Override
-            public SingleSource<Object> apply(Single<Object> v) throws Exception {
-                return v.unsubscribeOn(Schedulers.single());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeSingle(v -> v.unsubscribeOn(Schedulers.single()));
     }
 
     @Test
@@ -118,12 +109,7 @@ public class SingleUnsubscribeOnTest extends RxJavaTest {
                 }
             });
 
-            Runnable r = new Runnable() {
-                @Override
-                public void run() {
-                    ds[0].dispose();
-                }
-            };
+            Runnable r = () -> ds[0].dispose();
 
             TestHelper.race(r, r);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
@@ -37,7 +37,7 @@ public class SingleUsingTest extends RxJavaTest {
         throw new TestException("Mapper");
     };
 
-    Consumer<Disposable> disposer = d -> d.dispose();
+    Consumer<Disposable> disposer = Disposable::dispose;
 
     Consumer<Disposable> disposerThrows = _ -> {
         throw new TestException("Disposer");
@@ -200,8 +200,8 @@ public class SingleUsingTest extends RxJavaTest {
 
             pp.onNext(1);
 
-            Runnable r1 = () -> pp.onComplete();
-            Runnable r2 = () -> to.dispose();
+            Runnable r1 = pp::onComplete;
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -257,7 +257,7 @@ public class SingleUsingTest extends RxJavaTest {
             final TestException ex = new TestException();
 
             Runnable r1 = () -> pp.onError(ex);
-            Runnable r2 = () -> to.dispose();
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
@@ -31,41 +31,22 @@ import io.reactivex.rxjava4.testsupport.*;
 
 public class SingleUsingTest extends RxJavaTest {
 
-    Function<Disposable, Single<Integer>> mapper = new Function<Disposable, Single<Integer>>() {
-        @Override
-        public Single<Integer> apply(Disposable d) throws Exception {
-            return Single.just(1);
-        }
+    Function<Disposable, Single<Integer>> mapper = _ -> Single.just(1);
+
+    Function<Disposable, Single<Integer>> mapperThrows = _ -> {
+        throw new TestException("Mapper");
     };
 
-    Function<Disposable, Single<Integer>> mapperThrows = new Function<Disposable, Single<Integer>>() {
-        @Override
-        public Single<Integer> apply(Disposable d) throws Exception {
-            throw new TestException("Mapper");
-        }
-    };
+    Consumer<Disposable> disposer = d -> d.dispose();
 
-    Consumer<Disposable> disposer = new Consumer<Disposable>() {
-        @Override
-        public void accept(Disposable d) throws Exception {
-            d.dispose();
-        }
-    };
-
-    Consumer<Disposable> disposerThrows = new Consumer<Disposable>() {
-        @Override
-        public void accept(Disposable d) throws Exception {
-            throw new TestException("Disposer");
-        }
+    Consumer<Disposable> disposerThrows = _ -> {
+        throw new TestException("Disposer");
     };
 
     @Test
     public void resourceSupplierThrows() {
-        Single.using(new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                throw new TestException();
-            }
+        Single.using((Supplier<Integer>) () -> {
+            throw new TestException();
         }, Functions.justFunction(Single.just(1)), Functions.emptyConsumer())
         .test()
         .assertFailure(TestException.class);
@@ -183,12 +164,7 @@ public class SingleUsingTest extends RxJavaTest {
     @Test
     public void errorAndDisposerThrowsEager() {
         TestObserverEx<Integer> to = Single.using(Functions.justSupplier(Disposable.empty()),
-        new Function<Disposable, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Disposable v) throws Exception {
-                return Single.<Integer>error(new TestException("Mapper-run"));
-            }
-        }, disposerThrows)
+                        (Function<Disposable, SingleSource<Integer>>) _ -> Single.<Integer>error(new TestException("Mapper-run")), disposerThrows)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -203,12 +179,7 @@ public class SingleUsingTest extends RxJavaTest {
 
         try {
             Single.using(Functions.justSupplier(Disposable.empty()),
-            new Function<Disposable, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Disposable v) throws Exception {
-                    return Single.<Integer>error(new TestException("Mapper-run"));
-                }
-            }, disposerThrows, false)
+                            (Function<Disposable, SingleSource<Integer>>) _ -> Single.<Integer>error(new TestException("Mapper-run")), disposerThrows, false)
             .test()
             .assertFailure(TestException.class);
             TestHelper.assertUndeliverable(errors, 0, TestException.class, "Disposer");
@@ -224,28 +195,13 @@ public class SingleUsingTest extends RxJavaTest {
 
             Disposable d = Disposable.empty();
 
-            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), new Function<Disposable, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Disposable v) throws Exception {
-                    return pp.single(-99);
-                }
-            }, disposer)
+            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), (Function<Disposable, SingleSource<Integer>>) _ -> pp.single(-99), disposer)
             .test();
 
             pp.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> pp.onComplete();
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
 
@@ -258,28 +214,23 @@ public class SingleUsingTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justSupplier(1), new Function<Integer, SingleSource<Integer>>() {
+            Single.using(Functions.justSupplier(1), (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
                 @Override
-                public SingleSource<Integer> apply(Integer v) throws Exception {
-                    return new Single<Integer>() {
-                        @Override
-                        protected void subscribeActual(SingleObserver<? super Integer> observer) {
-                            observer.onSubscribe(Disposable.empty());
+                protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
 
-                            assertFalse(((Disposable)observer).isDisposed());
+                    assertFalse(((Disposable)observer).isDisposed());
 
-                            Disposable d = Disposable.empty();
-                            observer.onSubscribe(d);
+                    Disposable d = Disposable.empty();
+                    observer.onSubscribe(d);
 
-                            assertTrue(d.isDisposed());
+                    assertTrue(d.isDisposed());
 
-                            assertFalse(((Disposable)observer).isDisposed());
+                    assertFalse(((Disposable)observer).isDisposed());
 
-                            observer.onSuccess(1);
+                    observer.onSuccess(1);
 
-                            assertTrue(((Disposable)observer).isDisposed());
-                        }
-                    };
+                    assertTrue(((Disposable)observer).isDisposed());
                 }
             }, Functions.emptyConsumer())
             .test()
@@ -300,28 +251,13 @@ public class SingleUsingTest extends RxJavaTest {
 
             Disposable d = Disposable.empty();
 
-            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), new Function<Disposable, SingleSource<Integer>>() {
-                @Override
-                public SingleSource<Integer> apply(Disposable v) throws Exception {
-                    return pp.single(-99);
-                }
-            }, disposer)
+            final TestObserver<Integer> to = Single.using(Functions.justSupplier(d), (Function<Disposable, SingleSource<Integer>>) _ -> pp.single(-99), disposer)
             .test();
 
             final TestException ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    pp.onError(ex);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> pp.onError(ex);
+            Runnable r2 = () -> to.dispose();
 
             TestHelper.race(r1, r2);
 
@@ -334,24 +270,8 @@ public class SingleUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Integer> to = Single.using(Functions.justSupplier(1),
-            new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer t) throws Throwable {
-                    return Single.<Integer>never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, true)
+                        (Function<Integer, Single<Integer>>) _ -> Single.<Integer>never()
+                                .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), true)
         .test()
         ;
         to.assertEmpty();
@@ -366,24 +286,8 @@ public class SingleUsingTest extends RxJavaTest {
         final StringBuilder sb = new StringBuilder();
 
         TestObserver<Integer> to = Single.using(Functions.justSupplier(1),
-            new Function<Integer, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Integer t) throws Throwable {
-                    return Single.<Integer>never()
-                            .doOnDispose(new Action() {
-                                @Override
-                                public void run() throws Throwable {
-                                    sb.append("Dispose");
-                                }
-                            })
-                            ;
-                }
-            }, new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Throwable {
-                    sb.append("Resource");
-                }
-            }, false)
+                        (Function<Integer, Single<Integer>>) _ -> Single.<Integer>never()
+                                .doOnDispose(() -> sb.append("Dispose")), _ -> sb.append("Resource"), false)
         .test()
         ;
         to.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArrayTest.java
@@ -33,19 +33,9 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class SingleZipArrayTest extends RxJavaTest {
 
-    final BiFunction<Object, Object, Object> addString = new BiFunction<Object, Object, Object>() {
-        @Override
-        public Object apply(Object a, Object b) throws Exception {
-            return "" + a + b;
-        }
-    };
+    final BiFunction<Object, Object, Object> addString = (a, b) -> "" + a + b;
 
-    final Function3<Object, Object, Object, Object> addString3 = new Function3<Object, Object, Object, Object>() {
-        @Override
-        public Object apply(Object a, Object b, Object c) throws Exception {
-            return "" + a + b + c;
-        }
-    };
+    final Function3<Object, Object, Object, Object> addString3 = (a, b, c) -> "" + a + b + c;
 
     @Test
     public void firstError() {
@@ -77,11 +67,8 @@ public class SingleZipArrayTest extends RxJavaTest {
 
     @Test
     public void zipperThrows() {
-        Single.zip(Single.just(1), Single.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                throw new TestException();
-            }
+        Single.zip(Single.just(1), Single.just(2), (_, _) -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -89,12 +76,7 @@ public class SingleZipArrayTest extends RxJavaTest {
 
     @Test
     public void zipperReturnsNull() {
-        Single.zip(Single.just(1), Single.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return null;
-            }
-        })
+        Single.zip(Single.just(1), Single.just(2), (_, _) -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -127,19 +109,9 @@ public class SingleZipArrayTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp0.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp0.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp1.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -156,36 +128,21 @@ public class SingleZipArrayTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
-        Single.zipArray(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, Single.just(1), null)
+        Single.zipArray((Function<Object[], Object>) _ -> 1, Single.just(1), null)
         .blockingGet();
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void emptyArray() {
-        Single.zipArray(new Function<Object[], Object[]>() {
-            @Override
-            public Object[] apply(Object[] a) throws Exception {
-                return a;
-            }
-        }, new SingleSource[0])
+        Single.zipArray(a -> a, new SingleSource[0])
         .test()
         .assertFailure(NoSuchElementException.class);
     }
 
     @Test
     public void oneArray() {
-        Single.zipArray(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return (Integer)a[0] + 1;
-            }
-        }, Single.just(1))
+        Single.zipArray((Function<Object[], Object>) a -> (Integer)a[0] + 1, Single.just(1))
         .test()
         .assertResult(2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
@@ -31,7 +31,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class SingleZipIterableTest extends RxJavaTest {
 
-    final Function<Object[], Object> addString = a -> Arrays.toString(a);
+    final Function<Object[], Object> addString = Arrays::toString;
 
     @Test
     public void firstError() {
@@ -126,21 +126,21 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Single.zip(new CrashingMappedIterable<>(1, 100, 100, v -> Single.just(v)), addString)
+        Single.zip(new CrashingMappedIterable<>(1, 100, 100, Single::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
 
     @Test
     public void hasNextThrows() {
-        Single.zip(new CrashingMappedIterable<>(100, 20, 100, v -> Single.just(v)), addString)
+        Single.zip(new CrashingMappedIterable<>(100, 20, 100, Single::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
 
     @Test
     public void nextThrows() {
-        Single.zip(new CrashingMappedIterable<>(100, 100, 5, v -> Single.just(v)), addString)
+        Single.zip(new CrashingMappedIterable<>(100, 100, 5, Single::just), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipIterableTest.java
@@ -31,12 +31,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class SingleZipIterableTest extends RxJavaTest {
 
-    final Function<Object[], Object> addString = new Function<Object[], Object>() {
-        @Override
-        public Object apply(Object[] a) throws Exception {
-            return Arrays.toString(a);
-        }
-    };
+    final Function<Object[], Object> addString = a -> Arrays.toString(a);
 
     @Test
     public void firstError() {
@@ -68,11 +63,8 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void zipperThrows() {
-        Single.zip(Arrays.asList(Single.just(1), Single.just(2)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] b) throws Exception {
-                throw new TestException();
-            }
+        Single.zip(Arrays.asList(Single.just(1), Single.just(2)), _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -80,12 +72,7 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void zipperReturnsNull() {
-        Single.zip(Arrays.asList(Single.just(1), Single.just(2)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return null;
-            }
-        })
+        Single.zip(Arrays.asList(Single.just(1), Single.just(2)), _ -> null)
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -120,19 +107,9 @@ public class SingleZipIterableTest extends RxJavaTest {
 
                 final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp0.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> pp0.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        pp1.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> pp1.onError(ex);
 
                 TestHelper.race(r1, r2);
 
@@ -149,82 +126,47 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void iteratorThrows() {
-        Single.zip(new CrashingMappedIterable<>(1, 100, 100, new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }), addString)
+        Single.zip(new CrashingMappedIterable<>(1, 100, 100, v -> Single.just(v)), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "iterator()");
     }
 
     @Test
     public void hasNextThrows() {
-        Single.zip(new CrashingMappedIterable<>(100, 20, 100, new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }), addString)
+        Single.zip(new CrashingMappedIterable<>(100, 20, 100, v -> Single.just(v)), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "hasNext()");
     }
 
     @Test
     public void nextThrows() {
-        Single.zip(new CrashingMappedIterable<>(100, 100, 5, new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }), addString)
+        Single.zip(new CrashingMappedIterable<>(100, 100, 5, v -> Single.just(v)), addString)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(TestException.class, "next()");
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
-        Single.zip(Arrays.asList(null, Single.just(1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        })
+        Single.zip(Arrays.asList(null, Single.just(1)), (Function<Object[], Object>) _ -> 1)
         .blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
-        Single.zip(Arrays.asList(Single.just(1), null), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        })
+        Single.zip(Arrays.asList(Single.just(1), null), (Function<Object[], Object>) _ -> 1)
         .blockingGet();
     }
 
     @Test
     public void emptyIterable() {
-        Single.zip(Collections.<SingleSource<Integer>>emptyList(), new Function<Object[], Object[]>() {
-            @Override
-            public Object[] apply(Object[] a) throws Exception {
-                return a;
-            }
-        })
+        Single.zip(Collections.<SingleSource<Integer>>emptyList(), a -> a)
         .test()
         .assertFailure(NoSuchElementException.class);
     }
 
     @Test
     public void oneIterable() {
-        Single.zip(Collections.singleton(Single.just(1)), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return (Integer)a[0] + 1;
-            }
-        })
+        Single.zip(Collections.singleton(Single.just(1)), (Function<Object[], Object>) a -> (Integer)a[0] + 1)
         .test()
         .assertResult(2);
     }
@@ -238,19 +180,9 @@ public class SingleZipIterableTest extends RxJavaTest {
 
     @Test
     public void singleSourcesInIterable() {
-        SingleSource<Integer> source = new SingleSource<Integer>() {
-            @Override
-            public void subscribe(SingleObserver<? super Integer> observer) {
-                Single.just(1).subscribe(observer);
-            }
-        };
+        SingleSource<Integer> source = observer -> Single.just(1).subscribe(observer);
 
-        Single.zip(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Single.zip(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipTest.java
@@ -102,9 +102,9 @@ public class SingleZipTest extends RxJavaTest {
     public void noDisposeOnAllSuccess() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Single<Integer> source = Single.just(1).doOnDispose(() -> counter.getAndIncrement());
+        Single<Integer> source = Single.just(1).doOnDispose(counter::getAndIncrement);
 
-        Single.zip(source, source, (BiFunction<Integer, Integer, Object>) (a, b) -> a + b)
+        Single.zip(source, source, (BiFunction<Integer, Integer, Object>) Integer::sum)
         .test()
         .assertResult(2);
 
@@ -115,7 +115,7 @@ public class SingleZipTest extends RxJavaTest {
     public void noDisposeOnAllSuccess2() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Single<Integer> source = Single.just(1).doOnDispose(() -> counter.getAndIncrement());
+        Single<Integer> source = Single.just(1).doOnDispose(counter::getAndIncrement);
 
         Single.zip(Arrays.asList(source, source), (Function<Object[], Object>) o -> (Integer)o[0] + (Integer)o[1])
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleZipTest.java
@@ -27,24 +27,14 @@ public class SingleZipTest extends RxJavaTest {
 
     @Test
     public void zip2() {
-        Single.zip(Single.just(1), Single.just(2), new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) throws Exception {
-                return a + "" + b;
-            }
-        })
+        Single.zip(Single.just(1), Single.just(2), (BiFunction<Integer, Integer, Object>) (a, b) -> a + "" + b)
         .test()
         .assertResult("12");
     }
 
     @Test
     public void zip3() {
-        Single.zip(Single.just(1), Single.just(2), Single.just(3), new Function3<Integer, Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b, Integer c) throws Exception {
-                return a + "" + b + c;
-            }
-        })
+        Single.zip(Single.just(1), Single.just(2), Single.just(3), (Function3<Integer, Integer, Integer, Object>) (a, b, c) -> a + "" + b + c)
         .test()
         .assertResult("123");
     }
@@ -53,12 +43,7 @@ public class SingleZipTest extends RxJavaTest {
     public void zip4() {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4),
-                new Function4<Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d) throws Exception {
-                        return a + "" + b + c + d;
-                    }
-                })
+                        (Function4<Integer, Integer, Integer, Integer, Object>) (a, b, c, d) -> a + "" + b + c + d)
         .test()
         .assertResult("1234");
     }
@@ -67,12 +52,7 @@ public class SingleZipTest extends RxJavaTest {
     public void zip5() {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4), Single.just(5),
-                new Function5<Integer, Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e) throws Exception {
-                        return a + "" + b + c + d + e;
-                    }
-                })
+                        (Function5<Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e) -> a + "" + b + c + d + e)
         .test()
         .assertResult("12345");
     }
@@ -81,13 +61,7 @@ public class SingleZipTest extends RxJavaTest {
     public void zip6() {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4), Single.just(5), Single.just(6),
-                new Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f)
-                            throws Exception {
-                        return a + "" + b + c + d + e + f;
-                    }
-                })
+                        (Function6<Integer, Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e, f) -> a + "" + b + c + d + e + f)
         .test()
         .assertResult("123456");
     }
@@ -97,13 +71,7 @@ public class SingleZipTest extends RxJavaTest {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4), Single.just(5), Single.just(6),
                 Single.just(7),
-                new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g)
-                            throws Exception {
-                        return a + "" + b + c + d + e + f + g;
-                    }
-                })
+                        (Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>) (a, b, c, d, e, f, g) -> a + "" + b + c + d + e + f + g)
         .test()
         .assertResult("1234567");
     }
@@ -113,13 +81,8 @@ public class SingleZipTest extends RxJavaTest {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4), Single.just(5), Single.just(6),
                 Single.just(7), Single.just(8),
-                new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
-                            Integer h) throws Exception {
-                        return a + "" + b + c + d + e + f + g + h;
-                    }
-                })
+                        (Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>)
+                        (a, b, c, d, e, f, g, h) -> a + "" + b + c + d + e + f + g + h)
         .test()
         .assertResult("12345678");
     }
@@ -129,13 +92,8 @@ public class SingleZipTest extends RxJavaTest {
         Single.zip(Single.just(1), Single.just(2), Single.just(3),
                 Single.just(4), Single.just(5), Single.just(6),
                 Single.just(7), Single.just(8), Single.just(9),
-                new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>() {
-                    @Override
-                    public Object apply(Integer a, Integer b, Integer c, Integer d, Integer e, Integer f, Integer g,
-                            Integer h, Integer i) throws Exception {
-                        return a + "" + b + c + d + e + f + g + h + i;
-                    }
-                })
+                        (Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Object>)
+                        (a, b, c, d, e, f, g, h, i) -> a + "" + b + c + d + e + f + g + h + i)
         .test()
         .assertResult("123456789");
     }
@@ -144,19 +102,9 @@ public class SingleZipTest extends RxJavaTest {
     public void noDisposeOnAllSuccess() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Single<Integer> source = Single.just(1).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Single<Integer> source = Single.just(1).doOnDispose(() -> counter.getAndIncrement());
 
-        Single.zip(source, source, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        })
+        Single.zip(source, source, (BiFunction<Integer, Integer, Object>) (a, b) -> a + b)
         .test()
         .assertResult(2);
 
@@ -167,19 +115,9 @@ public class SingleZipTest extends RxJavaTest {
     public void noDisposeOnAllSuccess2() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Single<Integer> source = Single.just(1).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Single<Integer> source = Single.just(1).doOnDispose(() -> counter.getAndIncrement());
 
-        Single.zip(Arrays.asList(source, source), new Function<Object[], Object>() {
-            @Override
-            public Integer apply(Object[] o) throws Exception {
-                return (Integer)o[0] + (Integer)o[1];
-            }
-        })
+        Single.zip(Arrays.asList(source, source), (Function<Object[], Object>) o -> (Integer)o[0] + (Integer)o[1])
         .test()
         .assertResult(2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactoryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerPoolFactoryTest.java
@@ -53,9 +53,9 @@ public class SchedulerPoolFactoryTest extends RxJavaTest {
         assertFalse(SchedulerPoolFactory.getBooleanProperty(true, "false", false, true, Functions.<String>identity()));
     }
 
-    static final Function<String, String> failingPropertiesAccessor = v -> {
+    static final Function<String, String> failingPropertiesAccessor = _ -> {
         throw new SecurityException();
     };
 
-    static final Function<String, String> missingPropertiesAccessor = v -> null;
+    static final Function<String, String> missingPropertiesAccessor = _ -> null;
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
@@ -47,7 +47,7 @@ public class SharedSchedulerTest implements Runnable {
 
             for (int i = 0; i < 100; i++) {
                 Flowable.just(1).subscribeOn(scheduler)
-                .map((Function<Integer, Object>) v -> threads.add(Thread.currentThread().getName()))
+                .map((Function<Integer, Object>) _ -> threads.add(Thread.currentThread().getName()))
                 .blockingLast();
             }
 
@@ -65,7 +65,7 @@ public class SharedSchedulerTest implements Runnable {
 
             for (int i = 0; i < 100; i++) {
                 Flowable.just(1).delay(1, TimeUnit.MILLISECONDS, scheduler)
-                .map((Function<Integer, Object>) v -> threads.add(Thread.currentThread().getName()))
+                .map((Function<Integer, Object>) _ -> threads.add(Thread.currentThread().getName()))
                 .blockingLast();
             }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
@@ -69,7 +69,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             s.shutdown();
 
-            Runnable r1 = () -> s.start();
+            Runnable r1 = s::start;
 
             TestHelper.race(r1, r1);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
@@ -36,12 +36,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
     public void shutdownRejects() {
         final int[] calls = { 0 };
 
-        Runnable r = new Runnable() {
-            @Override
-            public void run() {
-                calls[0]++;
-            }
-        };
+        Runnable r = () -> calls[0]++;
 
         Scheduler s = new SingleScheduler();
         s.shutdown();
@@ -74,12 +69,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             s.shutdown();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    s.start();
-                }
-            };
+            Runnable r1 = () -> s.start();
 
             TestHelper.race(r1, r1);
         }
@@ -99,11 +89,8 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
     public void runnableDisposedAsyncCrash() throws Exception {
         final Scheduler s = Schedulers.single();
 
-        Disposable d = s.scheduleDirect(new Runnable() {
-            @Override
-            public void run() {
-                throw new IllegalStateException();
-            }
+        Disposable d = s.scheduleDirect(() -> {
+            throw new IllegalStateException();
         });
 
         while (!d.isDisposed()) {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -46,19 +46,9 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
 
             spc.onSubscribe(new BooleanSubscription());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    spc.onComplete();
-                }
-            };
+            Runnable r1 = () -> spc.onComplete();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ts.request(1);
-                }
-            };
+            Runnable r2 = () -> ts.request(1);
 
             TestHelper.race(r1, r2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -46,7 +46,7 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
 
             spc.onSubscribe(new BooleanSubscription());
 
-            Runnable r1 = () -> spc.onComplete();
+            Runnable r1 = spc::onComplete;
 
             Runnable r2 = () -> ts.request(1);
 

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
@@ -130,7 +130,7 @@ public class ParallelMapTest extends RxJavaTest {
     public void mapCrashConditional() {
         Flowable.just(1)
         .parallel()
-        .map(v -> {
+        .map(_ -> {
             throw new TestException();
         })
         .filter(Functions.alwaysTrue())
@@ -144,7 +144,7 @@ public class ParallelMapTest extends RxJavaTest {
         Flowable.just(1)
         .parallel()
         .runOn(Schedulers.computation())
-        .map(v -> {
+        .map(_ -> {
             throw new TestException();
         })
         .filter(Functions.alwaysTrue())

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -429,7 +429,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         assertNotSame(ImmediateThinScheduler.INSTANCE, Schedulers.newThread());
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void observableCreate() {
         try {
@@ -451,7 +450,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         .assertComplete();
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void flowableCreate() {
         try {
@@ -617,7 +615,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         .assertComplete();
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void singleCreate() {
         try {
@@ -639,7 +636,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         .assertComplete();
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void singleStart() {
         try {
@@ -1214,7 +1210,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         .assertResult(1);
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void assemblyHookCrashes() {
         try {
@@ -1257,7 +1252,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void subscribeHookCrashes() {
         try {
@@ -1496,7 +1490,6 @@ public class RxJavaPluginsTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void onParallelAssembly() {
         try {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
@@ -1624,7 +1624,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         final ReplayProcessor<byte[]> rp = ReplayProcessor.createWithSize(1);
 
         Flowable<byte[]> source = rp.take(1)
-        .concatMap((Function<byte[], Publisher<byte[]>>) v -> rp)
+        .concatMap((Function<byte[], Publisher<byte[]>>) _ -> rp)
         .takeLast(1)
         ;
 
@@ -1644,7 +1644,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final AtomicLong after = new AtomicLong();
 
-        source.subscribe(v -> {
+        source.subscribe(_ -> {
             System.out.println("Bounded Replay Leak check: Wait before GC 2");
             Thread.sleep(1000);
 

--- a/src/test/java/io/reactivex/rxjava4/single/SingleNullTests.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleNullTests.java
@@ -35,12 +35,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test
     public void ambIterableIteratorNull() {
-        Single.amb(new Iterable<Single<Object>>() {
-            @Override
-            public Iterator<Single<Object>> iterator() {
-                return null;
-            }
-        }).test().assertError(NullPointerException.class);
+        Single.amb((Iterable<Single<Object>>) () -> null).test().assertError(NullPointerException.class);
     }
 
     @Test
@@ -59,12 +54,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void concatIterableIteratorNull() {
-        Single.concat(new Iterable<Single<Object>>() {
-            @Override
-            public Iterator<Single<Object>> iterator() {
-                return null;
-            }
-        }).blockingSubscribe();
+        Single.concat((Iterable<Single<Object>>) () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -113,12 +103,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void fromCallableReturnsNull() {
-        Single.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return null;
-            }
-        }).blockingGet();
+        Single.fromCallable(() -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
@@ -137,12 +122,7 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeIterableIteratorNull() {
-        Single.merge(new Iterable<Single<Object>>() {
-            @Override
-            public Iterator<Single<Object>> iterator() {
-                return null;
-            }
-        }).blockingSubscribe();
+        Single.merge((Iterable<Single<Object>>) () -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
@@ -181,52 +161,22 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void usingSingleSupplierReturnsNull() {
-        Single.using(new Supplier<Object>() {
-            @Override
-            public Object get() {
-                return 1;
-            }
-        }, new Function<Object, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Object d) {
-                return null;
-            }
-        }, Functions.emptyConsumer()).blockingGet();
+        Single.using((Supplier<Object>) () -> 1, (Function<Object, Single<Object>>) _ -> null, Functions.emptyConsumer()).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableIteratorNull() {
-        Single.zip(new Iterable<Single<Object>>() {
-            @Override
-            public Iterator<Single<Object>> iterator() {
-                return null;
-            }
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }).blockingGet();
+        Single.zip((Iterable<Single<Object>>) () -> null, (Function<Object[], Object>) _ -> 1).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableOneIsNull() {
-        Single.zip(Arrays.asList(null, just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }).blockingGet();
+        Single.zip(Arrays.asList(null, just1), (Function<Object[], Object>) _ -> 1).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipIterableOneFunctionReturnsNull() {
-        Single.zip(Arrays.asList(just1, just1), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }).blockingGet();
+        Single.zip(Arrays.asList(just1, just1), _ -> null).blockingGet();
     }
 
     @SuppressWarnings("unchecked")
@@ -244,12 +194,7 @@ public class SingleNullTests extends RxJavaTest {
                 Object[] values = new Object[argCount + 1];
                 Arrays.fill(values, just1);
                 values[argNull - 1] = null;
-                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, new InvocationHandler() {
-                    @Override
-                    public Object invoke(Object o, Method m, Object[] a) throws Throwable {
-                        return 1;
-                    }
-                });
+                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, (_, _, _) -> 1);
 
                 Method m = clazz.getMethod("zip", params);
 
@@ -262,12 +207,7 @@ public class SingleNullTests extends RxJavaTest {
                     }
                 }
 
-                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, new InvocationHandler() {
-                    @Override
-                    public Object invoke(Object o, Method m1, Object[] a) throws Throwable {
-                        return null;
-                    }
-                });
+                values[argCount] = Proxy.newProxyInstance(getClass().getClassLoader(), new Class[] { fniClass }, (_, _, _) -> null);
                 try {
                     ((Single<Object>)m.invoke(null, values)).blockingGet();
                     Assert.fail("No exception for argCount " + argCount + " / argNull " + argNull);
@@ -303,34 +243,19 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void zipIterableTwoIsNull() {
-        Single.zip(Arrays.asList(just1, null), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        })
+        Single.zip(Arrays.asList(just1, null), (Function<Object[], Object>) _ -> 1)
         .blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipArrayOneIsNull() {
-        Single.zipArray(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return 1;
-            }
-        }, just1, null)
+        Single.zipArray((Function<Object[], Object>) _ -> 1, just1, null)
         .blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void zipArrayFunctionReturnsNull() {
-        Single.zipArray(new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] v) {
-                return null;
-            }
-        }, just1, just1).blockingGet();
+        Single.zipArray(_ -> null, just1, just1).blockingGet();
     }
 
     //**************************************************
@@ -339,53 +264,28 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void flatMapFunctionReturnsNull() {
-        just1.flatMap(new Function<Integer, Single<Object>>() {
-            @Override
-            public Single<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingGet();
+        just1.flatMap((Function<Integer, Single<Object>>) _ -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void flatMapPublisherFunctionReturnsNull() {
-        just1.flatMapPublisher(new Function<Integer, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Integer v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        just1.flatMapPublisher((Function<Integer, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void liftFunctionReturnsNull() {
-        just1.lift(new SingleOperator<Object, Integer>() {
-            @Override
-            public SingleObserver<? super Integer> apply(SingleObserver<? super Object> observer) {
-                return null;
-            }
-        }).blockingGet();
+        just1.lift(_ -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void onErrorReturnsSupplierReturnsNull() {
-        error.onErrorReturn(new Function<Throwable, Integer>() {
-            @Override
-            public Integer apply(Throwable t) throws Exception {
-                return null;
-            }
-        }).blockingGet();
+        error.onErrorReturn(_ -> null).blockingGet();
     }
 
     @Test
     public void onErrorResumeNextFunctionReturnsNull() {
         try {
-            error.onErrorResumeNext(new Function<Throwable, Single<Integer>>() {
-                @Override
-                public Single<Integer> apply(Throwable e) {
-                    return null;
-                }
-            }).blockingGet();
+            error.onErrorResumeNext((Function<Throwable, Single<Integer>>) _ -> null).blockingGet();
         } catch (CompositeException ex) {
             assertTrue(ex.toString(), ex.getExceptions().get(1) instanceof NullPointerException);
         }
@@ -393,39 +293,21 @@ public class SingleNullTests extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void repeatWhenFunctionReturnsNull() {
-        error.repeatWhen(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> v) {
-                return null;
-            }
-        }).blockingSubscribe();
+        error.repeatWhen((Function<Flowable<Object>, Publisher<Object>>) _ -> null).blockingSubscribe();
     }
 
     @Test(expected = NullPointerException.class)
     public void retryWhenFunctionReturnsNull() {
-        error.retryWhen(new Function<Flowable<? extends Throwable>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<? extends Throwable> e) {
-                return null;
-            }
-        }).blockingGet();
+        error.retryWhen((Function<Flowable<? extends Throwable>, Publisher<Object>>) _ -> null).blockingGet();
     }
 
     @Test(expected = NullPointerException.class)
     public void subscribeOnSuccessNull() {
-        just1.subscribe(null, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) { }
-        });
+        just1.subscribe(null, _ -> { });
     }
 
     @Test(expected = NullPointerException.class)
     public void zipWithFunctionReturnsNull() {
-        just1.zipWith(just1, new BiFunction<Integer, Integer, Object>() {
-            @Override
-            public Object apply(Integer a, Integer b) {
-                return null;
-            }
-        }).blockingGet();
+        just1.zipWith(just1, (_, _) -> null).blockingGet();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
@@ -35,12 +35,7 @@ public class SingleSubscribeTest extends RxJavaTest {
     public void consumer() {
         final Integer[] value = { null };
 
-        Single.just(1).subscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                value[0] = v;
-            }
-        });
+        Single.just(1).subscribe(v -> value[0] = v);
 
         assertEquals((Integer)1, value[0]);
     }
@@ -49,12 +44,9 @@ public class SingleSubscribeTest extends RxJavaTest {
     public void biconsumer() {
         final Object[] value = { null, null };
 
-        Single.just(1).subscribe(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer v, Throwable e) throws Exception {
-                value[0] = v;
-                value[1] = e;
-            }
+        Single.just(1).subscribe((v, e) -> {
+            value[0] = v;
+            value[1] = e;
         });
 
         assertEquals(1, value[0]);
@@ -67,12 +59,9 @@ public class SingleSubscribeTest extends RxJavaTest {
 
         TestException ex = new TestException();
 
-        Single.error(ex).subscribe(new BiConsumer<Object, Throwable>() {
-            @Override
-            public void accept(Object v, Throwable e) throws Exception {
-                value[0] = v;
-                value[1] = e;
-            }
+        Single.error(ex).subscribe((v, e) -> {
+            value[0] = v;
+            value[1] = e;
         });
 
         assertNull(value[0]);
@@ -99,11 +88,8 @@ public class SingleSubscribeTest extends RxJavaTest {
     public void biConsumerDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        Disposable d = ps.single(-99).subscribe(new BiConsumer<Object, Object>() {
-            @Override
-            public void accept(Object t1, Object t2) throws Exception {
+        Disposable d = ps.single(-99).subscribe((BiConsumer<Object, Object>) (_, _) -> {
 
-            }
         });
 
         assertFalse(d.isDisposed());
@@ -135,11 +121,8 @@ public class SingleSubscribeTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            Single.just(1).subscribe(new Consumer<Integer>() {
-                @Override
-                public void accept(Integer t) throws Exception {
-                    throw new TestException();
-                }
+            Single.just(1).subscribe(_ -> {
+                throw new TestException();
             });
 
             TestHelper.assertUndeliverable(list, 0, TestException.class);
@@ -155,12 +138,9 @@ public class SingleSubscribeTest extends RxJavaTest {
         try {
             Single.<Integer>error(new TestException("Outer failure")).subscribe(
             Functions.<Integer>emptyConsumer(),
-            new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable t) throws Exception {
-                    throw new TestException("Inner failure");
-                }
-            });
+                    _ -> {
+                        throw new TestException("Inner failure");
+                    });
 
             TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
@@ -176,11 +156,8 @@ public class SingleSubscribeTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            Single.just(1).subscribe(new BiConsumer<Integer, Throwable>() {
-                @Override
-                public void accept(Integer t, Throwable e) throws Exception {
-                    throw new TestException();
-                }
+            Single.just(1).subscribe((_, _) -> {
+                throw new TestException();
             });
 
             TestHelper.assertUndeliverable(list, 0, TestException.class);
@@ -195,12 +172,9 @@ public class SingleSubscribeTest extends RxJavaTest {
 
         try {
             Single.<Integer>error(new TestException("Outer failure")).subscribe(
-            new BiConsumer<Integer, Throwable>() {
-                @Override
-                public void accept(Integer a, Throwable t) throws Exception {
-                    throw new TestException("Inner failure");
-                }
-            });
+                    (_, _) -> {
+                        throw new TestException("Inner failure");
+                    });
 
             TestHelper.assertError(list, 0, CompositeException.class);
             List<Throwable> cel = TestHelper.compositeList(list.get(0));
@@ -235,12 +209,9 @@ public class SingleSubscribeTest extends RxJavaTest {
         final Object[] result = { null, null };
 
         Disposable d = Single.just(1)
-        .subscribe(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer t1, Throwable t2) throws Exception {
-                result[0] = t1;
-                result[1] = t2;
-            }
+        .subscribe((t1, t2) -> {
+            result[0] = t1;
+            result[1] = t2;
         });
 
         assertTrue("Not disposed?!", d.isDisposed());
@@ -253,12 +224,9 @@ public class SingleSubscribeTest extends RxJavaTest {
         final Object[] result = { null, null };
 
         Disposable d = Single.<Integer>error(new IOException())
-        .subscribe(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(Integer t1, Throwable t2) throws Exception {
-                result[0] = t1;
-                result[1] = t2;
-            }
+        .subscribe((t1, t2) -> {
+            result[0] = t1;
+            result[1] = t2;
         });
 
         assertTrue("Not disposed?!", d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -452,7 +452,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void to() {
-        Single.just(1).to(v -> v.toFlowable())
+        Single.just(1).to(Single::toFlowable)
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -68,12 +68,7 @@ public class SingleTest extends RxJavaTest {
     public void map() {
         TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("A")
-                .map(new Function<String, String>() {
-                    @Override
-                    public String apply(String s) {
-                        return s + "B";
-                    }
-                })
+                .map(s -> s + "B")
                 .toFlowable().subscribe(ts);
         ts.assertValueSequence(List.of("AB"));
     }
@@ -84,12 +79,7 @@ public class SingleTest extends RxJavaTest {
         Single<String> a = Single.just("A");
         Single<String> b = Single.just("B");
 
-        Single.zip(a, b, new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String a1, String b1) {
-                return a1 + b1;
-            }
-        })
+        Single.zip(a, b, (a1, b1) -> a1 + b1)
         .toFlowable().subscribe(ts);
         ts.assertValueSequence(List.of("AB"));
     }
@@ -98,12 +88,7 @@ public class SingleTest extends RxJavaTest {
     public void zipWith() {
         TestSubscriber<String> ts = new TestSubscriber<>();
 
-        Single.just("A").zipWith(Single.just("B"), new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String a1, String b1) {
-                return a1 + b1;
-            }
-        })
+        Single.just("A").zipWith(Single.just("B"), (a1, b1) -> a1 + b1)
         .toFlowable().subscribe(ts);
         ts.assertValueSequence(List.of("AB"));
     }
@@ -130,12 +115,9 @@ public class SingleTest extends RxJavaTest {
     public void createSuccess() {
         TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Single.unsafeCreate(new SingleSource<Object>() {
-            @Override
-            public void subscribe(SingleObserver<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onSuccess("Hello");
-            }
+        Single.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onSuccess("Hello");
         }).toFlowable().subscribe(ts);
 
         ts.assertValueSequence(List.of("Hello"));
@@ -144,12 +126,9 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void createError() {
         TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
-        Single.unsafeCreate(new SingleSource<Object>() {
-            @Override
-            public void subscribe(SingleObserver<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onError(new RuntimeException("fail"));
-            }
+        Single.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onError(new RuntimeException("fail"));
         }).toFlowable().subscribe(ts);
 
         ts.assertError(RuntimeException.class);
@@ -161,20 +140,14 @@ public class SingleTest extends RxJavaTest {
         TestSubscriber<String> ts = new TestSubscriber<>();
         Single.just("Hello")
                 .subscribeOn(Schedulers.cached())
-                .map(new Function<String, String>() {
-                    @Override
-                    public String apply(String v) {
-                        System.out.println("SubscribeOn Thread: " + Thread.currentThread());
-                        return v;
-                    }
+                .map(v -> {
+                    System.out.println("SubscribeOn Thread: " + Thread.currentThread());
+                    return v;
                 })
                 .observeOn(Schedulers.computation())
-                .map(new Function<String, String>() {
-                    @Override
-                    public String apply(String v) {
-                        System.out.println("ObserveOn Thread: " + Thread.currentThread());
-                        return v;
-                    }
+                .map(v -> {
+                    System.out.println("ObserveOn Thread: " + Thread.currentThread());
+                    return v;
                 })
                 .toFlowable().subscribe(ts);
         ts.awaitDone(5, TimeUnit.SECONDS);
@@ -184,12 +157,7 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void flatMap() throws InterruptedException {
         TestSubscriberEx<String> ts = new TestSubscriberEx<>();
-        Single.just("Hello").flatMap(new Function<String, Single<String>>() {
-            @Override
-            public Single<String> apply(String s) {
-                return Single.just(s + " World!").subscribeOn(Schedulers.computation());
-            }
-        }
+        Single.just("Hello").flatMap((Function<String, Single<String>>) s -> Single.just(s + " World!").subscribeOn(Schedulers.computation())
         ).toFlowable().subscribe(ts);
         if (!ts.await(5, TimeUnit.SECONDS)) {
             ts.cancel();
@@ -201,17 +169,14 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void timeout() {
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(SingleObserver<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                try {
-                    Thread.sleep(5000);
-                } catch (InterruptedException e) {
-                    // ignore as we expect this for the test
-                }
-                observer.onSuccess("success");
+        Single<String> s1 = Single.<String>unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                // ignore as we expect this for the test
             }
+            observer.onSuccess("success");
         }).subscribeOn(Schedulers.cached());
 
         s1.timeout(100, TimeUnit.MILLISECONDS).toFlowable().subscribe(ts);
@@ -223,17 +188,14 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void timeoutWithFallback() {
         TestSubscriber<String> ts = new TestSubscriber<>();
-        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(SingleObserver<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                    try {
-                        Thread.sleep(5000);
-                    } catch (InterruptedException e) {
-                        // ignore as we expect this for the test
-                    }
-                    observer.onSuccess("success");
-            }
+        Single<String> s1 = Single.<String>unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    // ignore as we expect this for the test
+                }
+                observer.onSuccess("success");
         }).subscribeOn(Schedulers.cached());
 
         s1.timeout(100, TimeUnit.MILLISECONDS, Single.just("hello")).toFlowable().subscribe(ts);
@@ -250,35 +212,24 @@ public class SingleTest extends RxJavaTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.<String>unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(final SingleObserver<? super String> observer) {
-                SerialDisposable sd = new SerialDisposable();
-                observer.onSubscribe(sd);
-                final Thread t = new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(5000);
-                            observer.onSuccess("success");
-                        } catch (InterruptedException e) {
-                            interrupted.set(true);
-                            latch.countDown();
-                        }
-                    }
-
-                });
-                sd.replace(Disposable.fromRunnable(new Runnable() {
-                    @Override
-                    public void run() {
-                        unsubscribed.set(true);
-                        t.interrupt();
-                        latch.countDown();
-                    }
-                }));
-                t.start();
-            }
+        Single<String> s1 = Single.<String>unsafeCreate(observer -> {
+            SerialDisposable sd = new SerialDisposable();
+            observer.onSubscribe(sd);
+            final Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(5000);
+                    observer.onSuccess("success");
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                    latch.countDown();
+                }
+            });
+            sd.replace(Disposable.fromRunnable(() -> {
+                unsubscribed.set(true);
+                t.interrupt();
+                latch.countDown();
+            }));
+            t.start();
         });
 
         s1.toFlowable().subscribe(ts);
@@ -325,36 +276,25 @@ public class SingleTest extends RxJavaTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(final SingleObserver<? super String> observer) {
-                SerialDisposable sd = new SerialDisposable();
-                observer.onSubscribe(sd);
-                final Thread t = new Thread(new Runnable() {
+        Single<String> s1 = Single.unsafeCreate(observer -> {
+            SerialDisposable sd1 = new SerialDisposable();
+            observer.onSubscribe(sd1);
+            final Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(5000);
+                    observer.onSuccess("success");
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                    latch.countDown();
+                }
+            });
+            sd1.replace(Disposable.fromRunnable(() -> {
+                unsubscribed.set(true);
+                t.interrupt();
+                latch.countDown();
+            }));
+            t.start();
 
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(5000);
-                            observer.onSuccess("success");
-                        } catch (InterruptedException e) {
-                            interrupted.set(true);
-                            latch.countDown();
-                        }
-                    }
-
-                });
-                sd.replace(Disposable.fromRunnable(new Runnable() {
-                    @Override
-                    public void run() {
-                        unsubscribed.set(true);
-                        t.interrupt();
-                        latch.countDown();
-                    }
-                }));
-                t.start();
-
-            }
         });
 
         s1.subscribe(ts);
@@ -381,36 +321,25 @@ public class SingleTest extends RxJavaTest {
         final AtomicBoolean interrupted = new AtomicBoolean();
         final CountDownLatch latch = new CountDownLatch(2);
 
-        Single<String> s1 = Single.unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(final SingleObserver<? super String> observer) {
-                SerialDisposable sd = new SerialDisposable();
-                observer.onSubscribe(sd);
-                final Thread t = new Thread(new Runnable() {
+        Single<String> s1 = Single.unsafeCreate(observer -> {
+            SerialDisposable sd = new SerialDisposable();
+            observer.onSubscribe(sd);
+            final Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(5000);
+                    observer.onSuccess("success");
+                } catch (InterruptedException e) {
+                    interrupted.set(true);
+                    latch.countDown();
+                }
+            });
+            sd.replace(Disposable.fromRunnable(() -> {
+                unsubscribed.set(true);
+                t.interrupt();
+                latch.countDown();
+            }));
+            t.start();
 
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(5000);
-                            observer.onSuccess("success");
-                        } catch (InterruptedException e) {
-                            interrupted.set(true);
-                            latch.countDown();
-                        }
-                    }
-
-                });
-                sd.replace(Disposable.fromRunnable(new Runnable() {
-                    @Override
-                    public void run() {
-                        unsubscribed.set(true);
-                        t.interrupt();
-                        latch.countDown();
-                    }
-                }));
-                t.start();
-
-            }
         });
 
         Disposable subscription = s1.subscribe();
@@ -429,12 +358,9 @@ public class SingleTest extends RxJavaTest {
 
     @Test
     public void backpressureAsObservable() {
-        Single<String> s = Single.unsafeCreate(new SingleSource<String>() {
-            @Override
-            public void subscribe(SingleObserver<? super String> t) {
-                t.onSubscribe(Disposable.empty());
-                t.onSuccess("hello");
-            }
+        Single<String> s = Single.unsafeCreate(t -> {
+            t.onSubscribe(Disposable.empty());
+            t.onSuccess("hello");
         });
 
         TestSubscriber<String> ts = new TestSubscriber<>(0L);
@@ -467,12 +393,9 @@ public class SingleTest extends RxJavaTest {
     public void doOnEventComplete() {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
 
-        Single.just(1).doOnEvent(new BiConsumer<Integer, Throwable>() {
-            @Override
-            public void accept(final Integer integer, final Throwable throwable) throws Exception {
-                if (integer != null) {
-                    atomicInteger.incrementAndGet();
-                }
+        Single.just(1).doOnEvent((integer, _) -> {
+            if (integer != null) {
+                atomicInteger.incrementAndGet();
             }
         }).subscribe();
 
@@ -483,12 +406,9 @@ public class SingleTest extends RxJavaTest {
     public void doOnEventError() {
         final AtomicInteger atomicInteger = new AtomicInteger(0);
 
-        Single.error(new RuntimeException()).doOnEvent(new BiConsumer<Object, Throwable>() {
-            @Override
-            public void accept(final Object o, final Throwable throwable) throws Exception {
-                if (throwable != null) {
-                    atomicInteger.incrementAndGet();
-                }
+        Single.error(new RuntimeException()).doOnEvent((_, throwable) -> {
+            if (throwable != null) {
+                atomicInteger.incrementAndGet();
             }
         }).subscribe();
 
@@ -521,26 +441,18 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void zipIterableObject() {
         final List<Single<Integer>> singles = Arrays.asList(Single.just(1), Single.just(4));
-        Single.zip(singles, new Function<Object[], Object>() {
-            @Override
-            public Object apply(final Object[] o) throws Exception {
-                int sum = 0;
-                for (Object i : o) {
-                    sum += (Integer) i;
-                }
-                return sum;
+        Single.zip(singles, (Function<Object[], Object>) o -> {
+            int sum = 0;
+            for (Object i : o) {
+                sum += (Integer) i;
             }
+            return sum;
         }).test().assertResult(5);
     }
 
     @Test
     public void to() {
-        Single.just(1).to(new SingleConverter<Integer, Flowable<Integer>>() {
-            @Override
-            public Flowable<Integer> apply(Single<Integer> v) {
-                return v.toFlowable();
-            }
-        })
+        Single.just(1).to(v -> v.toFlowable())
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTimerTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.schedulers.TestScheduler;
 
 public class SingleTimerTest extends RxJavaTest {
@@ -30,12 +29,7 @@ public class SingleTimerTest extends RxJavaTest {
         final TestScheduler testScheduler = new TestScheduler();
 
         final AtomicLong atomicLong = new AtomicLong();
-        Single.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(new Consumer<Long>() {
-            @Override
-            public void accept(final Long value) throws Exception {
-                atomicLong.incrementAndGet();
-            }
-        });
+        Single.timer(2, TimeUnit.SECONDS, testScheduler).subscribe(_ -> atomicLong.incrementAndGet());
 
         assertEquals(0, atomicLong.get());
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
@@ -1220,7 +1220,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         final ReplaySubject<byte[]> rs = ReplaySubject.createWithSize(1);
 
         Observable<byte[]> source = rs.take(1)
-        .concatMap((Function<byte[], Observable<byte[]>>) v -> rs)
+        .concatMap((Function<byte[], Observable<byte[]>>) _ -> rs)
         .takeLast(1)
         ;
 
@@ -1240,7 +1240,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final AtomicLong after = new AtomicLong();
 
-        source.subscribe(v -> {
+        source.subscribe(_ -> {
             System.out.println("Bounded Replay Leak check: Wait before GC 2");
             Thread.sleep(1000);
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
@@ -231,9 +231,9 @@ public class SingleSubjectTest extends RxJavaTest {
 
             final TestObserver<Integer> to = ss.test();
 
-            Runnable r1 = () -> ss.test();
+            Runnable r1 = ss::test;
 
-            Runnable r2 = () -> to.dispose();
+            Runnable r2 = to::dispose;
             TestHelper.race(r1, r2);
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
@@ -231,19 +231,9 @@ public class SingleSubjectTest extends RxJavaTest {
 
             final TestObserver<Integer> to = ss.test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ss.test();
-                }
-            };
+            Runnable r1 = () -> ss.test();
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = () -> to.dispose();
             TestHelper.race(r1, r2);
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/tck/SingleFlatMapFlowableTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/SingleFlatMapFlowableTckTest.java
@@ -25,13 +25,7 @@ public class SingleFlatMapFlowableTckTest extends BaseTck<Integer> {
     @Override
     public Publisher<Integer> createFlowPublisher(final long elements) {
         return
-                Single.just(1).hide().flatMapPublisher(new Function<Integer, Publisher<Integer>>() {
-                    @Override
-                    public Publisher<Integer> apply(Integer v)
-                            throws Exception {
-                        return Flowable.range(0, (int)elements);
-                    }
-                })
+                Single.just(1).hide().flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> Flowable.range(0, (int)elements))
         ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -3546,7 +3546,7 @@ public enum TestHelper {
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Flowable.just(1)
-            .map((Function<Integer, Integer>) v -> {
+            .map((Function<Integer, Integer>) _ -> {
                 disposable.dispose();
                 throw new TestException();
             })
@@ -3612,7 +3612,7 @@ public enum TestHelper {
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Observable.just(1)
-            .map((Function<Integer, Integer>) v -> {
+            .map((Function<Integer, Integer>) _ -> {
                 disposable.dispose();
                 throw new TestException();
             })

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
@@ -1073,7 +1073,7 @@ public class TestObserverExTest extends RxJavaTest {
         to.setInitialFusionMode(QueueFuseable.SYNC);
 
         Observable.range(1, 5)
-        .map(v -> { throw new TestException(); })
+        .map(_ -> { throw new TestException(); })
         .subscribe(to);
 
         to.assertSubscribed()
@@ -1090,7 +1090,7 @@ public class TestObserverExTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .map(v -> { throw new TestException(); })
+        .map(_ -> { throw new TestException(); })
         .subscribe(to);
 
         us.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
@@ -1503,7 +1503,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         ts.setInitialFusionMode(QueueFuseable.SYNC);
 
         Flowable.range(1, 5)
-        .map(v -> { throw new TestException(); })
+        .map(_ -> { throw new TestException(); })
         .subscribe(ts);
 
         ts.assertSubscribed()
@@ -1520,7 +1520,7 @@ public class TestSubscriberExTest extends RxJavaTest {
         UnicastProcessor<Integer> up = UnicastProcessor.create();
 
         up
-        .map(v -> { throw new TestException(); })
+        .map(_ -> { throw new TestException(); })
         .subscribe(ts);
 
         up.onNext(1);


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080