### PR TITLE
4.x: Unit test lambdaification 21 of N

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapCompletablePerf.java
@@ -45,26 +45,11 @@ public class ObservableConcatMapCompletablePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.empty();
-            }
-        });
+        observablePlain = source.concatMap((Function<Integer, Observable<Integer>>) _ -> Observable.empty());
 
-        observableConvert = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Completable.complete().toObservable();
-            }
-        });
+        observableConvert = source.concatMap((Function<Integer, Observable<Integer>>) _ -> Completable.complete().toObservable());
 
-        observableDedicated = source.concatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        observableDedicated = source.concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapMaybePerf.java
@@ -45,26 +45,11 @@ public class ObservableConcatMapMaybePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        observablePlain = source.concatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        observableConvert = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.just(v).toObservable();
-            }
-        });
+        observableConvert = source.concatMap((Function<Integer, Observable<Integer>>) v -> Maybe.just(v).toObservable());
 
-        observableDedicated = source.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        observableDedicated = source.concatMapMaybe((Function<Integer, Maybe<Integer>>) Maybe::just);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableConcatMapSinglePerf.java
@@ -45,26 +45,11 @@ public class ObservableConcatMapSinglePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        observablePlain = source.concatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        observableConvert = source.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Single.just(v).toObservable();
-            }
-        });
+        observableConvert = source.concatMap((Function<Integer, Observable<Integer>>) v -> Single.just(v).toObservable());
 
-        observableDedicated = source.concatMapSingle(new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        observableDedicated = source.concatMapSingle((Function<Integer, Single<Integer>>) Single::just);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapCompletablePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapCompletablePerf.java
@@ -45,26 +45,11 @@ public class ObservableFlatMapCompletablePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.empty();
-            }
-        });
+        observablePlain = source.flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.empty());
 
-        observableConvert = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Completable.complete().toObservable();
-            }
-        });
+        observableConvert = source.flatMap((Function<Integer, Observable<Integer>>) _ -> Completable.complete().toObservable());
 
-        observableDedicated = source.flatMapCompletable(new Function<Integer, Completable>() {
-            @Override
-            public Completable apply(Integer v) {
-                return Completable.complete();
-            }
-        });
+        observableDedicated = source.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete());
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapMaybePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapMaybePerf.java
@@ -45,26 +45,11 @@ public class ObservableFlatMapMaybePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        observablePlain = source.flatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        observableConvert = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Maybe.just(v).toObservable();
-            }
-        });
+        observableConvert = source.flatMap((Function<Integer, Observable<Integer>>) v -> Maybe.just(v).toObservable());
 
-        observableDedicated = source.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-            @Override
-            public Maybe<Integer> apply(Integer v) {
-                return Maybe.just(v);
-            }
-        });
+        observableDedicated = source.flatMapMaybe((Function<Integer, Maybe<Integer>>) Maybe::just);
     }
 
     @Benchmark

--- a/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapSinglePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/xmapz/ObservableFlatMapSinglePerf.java
@@ -45,26 +45,11 @@ public class ObservableFlatMapSinglePerf {
 
         Observable<Integer> source = Observable.fromArray(sourceArray);
 
-        observablePlain = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        observablePlain = source.flatMap((Function<Integer, Observable<Integer>>) Observable::just);
 
-        observableConvert = source.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Single.just(v).toObservable();
-            }
-        });
+        observableConvert = source.flatMap((Function<Integer, Observable<Integer>>) v -> Single.just(v).toObservable());
 
-        observableDedicated = source.flatMapSingle(new Function<Integer, Single<Integer>>() {
-            @Override
-            public Single<Integer> apply(Integer v) {
-                return Single.just(v);
-            }
-        });
+        observableDedicated = source.flatMapSingle((Function<Integer, Single<Integer>>) Single::just);
     }
 
     @Benchmark

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
@@ -44,12 +44,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     public void simple2() {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
-        .concatMapCompletable(Functions.justFunction(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.incrementAndGet();
-            }
-        })))
+        .concatMapCompletable(Functions.justFunction(Completable.fromAction(counter::incrementAndGet)))
         .test()
         .assertResult();
 
@@ -84,12 +79,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     public void innerErrorDelayed() {
         TestObserverEx<Void> to = Observable.range(1, 5)
         .concatMapCompletableDelayError(
-                new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.error(new TestException());
-                    }
-                }
+                _ -> Completable.error(new TestException())
         )
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class)
@@ -101,11 +91,8 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void mapperCrash() {
         Observable.just(1)
-        .concatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMapCompletable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -114,11 +101,8 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void mapperCrashHidden() {
         Observable.just(1).hide()
-        .concatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMapCompletable(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -207,15 +191,12 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         final CompletableSubject cs2 = CompletableSubject.create();
 
         TestObserver<Void> to = ps.concatMapCompletableDelayError(
-                new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        if (v == 1) {
-                            return cs;
-                        }
-                        return cs2;
-                    }
-                }, true, 32
+                        v -> {
+                            if (v == 1) {
+                                return cs;
+                            }
+                            return cs2;
+                        }, true, 32
         )
         .test();
 
@@ -250,14 +231,8 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservableToCompletable(
-                new Function<Observable<Object>, Completable>() {
-                    @Override
-                    public Completable apply(Observable<Object> f)
-                            throws Exception {
-                        return f.concatMapCompletable(
-                                Functions.justFunction(Completable.complete()));
-                    }
-                }
+                (Function<Observable<Object>, Completable>) f -> f.concatMapCompletable(
+                        Functions.justFunction(Completable.complete()))
         );
     }
 
@@ -286,28 +261,13 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
 
                 ps.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onError(ex);
-                    }
-                };
+                Runnable r1 = () -> ps.onError(ex);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        cs.onError(ex);
-                    }
-                };
+                Runnable r2 = () -> cs.onError(ex);
 
                 TestHelper.race(r1, r2);
 
-                to.assertError(new Predicate<Throwable>() {
-                    @Override
-                    public boolean test(Throwable e) throws Exception {
-                        return e instanceof TestException || e instanceof CompositeException;
-                    }
-                })
+                to.assertError(e -> e instanceof TestException || e instanceof CompositeException)
                 .assertNotComplete();
 
                 if (!errors.isEmpty()) {
@@ -332,19 +292,11 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
 
             ps.onNext(1);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onNext(2);
-                }
-            };
+            Runnable r1 = () -> ps.onNext(2);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    cs.onComplete();
-                    to.dispose();
-                }
+            Runnable r2 = () -> {
+                cs.onComplete();
+                to.dispose();
             };
 
             TestHelper.race(r1, r2);
@@ -432,47 +384,20 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Observable<Integer> upstream) {
-                return upstream.concatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Observable<Integer> upstream) {
-                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Observable<Integer> upstream) {
-                return upstream.concatMapCompletableDelayError(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
+            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -39,13 +39,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void simple() {
         Observable.range(1, 5)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -53,13 +47,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void simpleLong() {
         Observable.range(1, 1024)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        }, 32)
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, 32)
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -69,13 +57,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void empty() {
         Observable.range(1, 10)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.empty();
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }
@@ -83,15 +65,11 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void mixed() {
         Observable.range(1, 10)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v);
-                }
-                return Maybe.empty();
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v);
             }
+            return Maybe.empty();
         })
         .test()
         .assertResult(2, 4, 6, 8, 10);
@@ -100,15 +78,11 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void mixedLong() {
         TestObserverEx<Integer> to = Observable.range(1, 1024)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                if (v % 2 == 0) {
-                    return Maybe.just(v).subscribeOn(Schedulers.computation());
-                }
-                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v % 2 == 0) {
+                return Maybe.just(v).subscribeOn(Schedulers.computation());
             }
+            return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
         })
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -189,27 +163,15 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(
-                new Function<Observable<Object>, Observable<Object>>() {
-                    @Override
-                    public Observable<Object> apply(Observable<Object> f)
-                            throws Exception {
-                        return f.concatMapMaybeDelayError(
-                                Functions.justFunction(Maybe.empty()));
-                    }
-                }
+                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapMaybeDelayError(
+                        Functions.justFunction(Maybe.empty()))
         );
     }
 
     @Test
     public void take() {
         Observable.range(1, 5)
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -218,13 +180,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void cancel() {
         Observable.range(1, 5).concatWith(Observable.<Integer>never())
-        .concatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .test()
         .assertValues(1, 2, 3, 4, 5)
         .assertNoErrors()
@@ -265,19 +221,13 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapMaybe(
-                    new Function<Integer, MaybeSource<Integer>>() {
-                        @Override
-                        public MaybeSource<Integer> apply(Integer v)
-                                throws Exception {
-                            return new Maybe<Integer>() {
-                                    @Override
-                                    protected void subscribeActual(
-                                            MaybeObserver<? super Integer> observer) {
-                                        observer.onSubscribe(Disposable.empty());
-                                        obs.set(observer);
-                                    }
-                            };
-                        }
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+                            @Override
+                            protected void subscribeActual(
+                                    MaybeObserver<? super Integer> observer) {
+                                observer.onSubscribe(Disposable.empty());
+                                obs.set(observer);
+                            }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 
@@ -297,13 +247,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestObserverEx<Object> to = Observable.range(1, 5)
-        .concatMapMaybeDelayError(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Maybe.error(new TestException());
-            }
-        })
+        .concatMapMaybeDelayError(_ -> Maybe.error(new TestException()))
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -317,13 +261,9 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Object> to = ps
-        .concatMapMaybe(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapMaybe(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         to.assertEmpty();
@@ -340,13 +280,9 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void scalarMapperCrash() {
         TestObserver<Object> to = Observable.just(1)
-        .concatMapMaybe(new Function<Integer, MaybeSource<? extends Object>>() {
-            @Override
-            public MaybeSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapMaybe(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         to.assertFailure(TestException.class);
@@ -423,18 +359,8 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
                     .concatMapMaybe(Functions.justFunction(ms))
                     .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ms.onSuccess(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> ms.onSuccess(1);
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -444,47 +370,20 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapMaybeDelayError(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -37,13 +37,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void simple() {
         Observable.range(1, 5)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .test()
         .assertResult(1, 2, 3, 4, 5);
     }
@@ -51,13 +45,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void simpleLong() {
         Observable.range(1, 1024)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        }, 32)
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, 32)
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -107,27 +95,15 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(
-                new Function<Observable<Object>, Observable<Object>>() {
-                    @Override
-                    public Observable<Object> apply(Observable<Object> f)
-                            throws Exception {
-                        return f.concatMapSingleDelayError(
-                                Functions.justFunction(Single.never()));
-                    }
-                }
+                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapSingleDelayError(
+                        Functions.justFunction(Single.never()))
         );
     }
 
     @Test
     public void take() {
         Observable.range(1, 5)
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .take(3)
         .test()
         .assertResult(1, 2, 3);
@@ -136,13 +112,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void cancel() {
         Observable.range(1, 5).concatWith(Observable.<Integer>never())
-        .concatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Single.just(v);
-            }
-        })
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .test()
         .assertValues(1, 2, 3, 4, 5)
         .assertNoErrors()
@@ -183,19 +153,13 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapSingle(
-                    new Function<Integer, SingleSource<Integer>>() {
-                        @Override
-                        public SingleSource<Integer> apply(Integer v)
-                                throws Exception {
-                            return new Single<Integer>() {
-                                    @Override
-                                    protected void subscribeActual(
-                                            SingleObserver<? super Integer> observer) {
-                                        observer.onSubscribe(Disposable.empty());
-                                        obs.set(observer);
-                                    }
-                            };
-                        }
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+                            @Override
+                            protected void subscribeActual(
+                                    SingleObserver<? super Integer> observer) {
+                                observer.onSubscribe(Disposable.empty());
+                                obs.set(observer);
+                            }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 
@@ -215,13 +179,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestObserverEx<Object> to = Observable.range(1, 5)
-        .concatMapSingleDelayError(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Single.error(new TestException());
-            }
-        })
+        .concatMapSingleDelayError(_ -> Single.error(new TestException()))
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -235,13 +193,9 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Object> to = ps
-        .concatMapSingle(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapSingle(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         to.assertEmpty();
@@ -258,13 +212,9 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void mapperCrashScalar() {
         TestObserver<Object> to = Observable.just(1)
-        .concatMapSingle(new Function<Integer, SingleSource<? extends Object>>() {
-            @Override
-            public SingleSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                        throw new TestException();
-                    }
-        })
+        .concatMapSingle(_ -> {
+                    throw new TestException();
+                })
         .test();
 
         to.assertFailure(TestException.class);
@@ -363,18 +313,8 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
                     .concatMapSingle(Functions.justFunction(ss))
                     .test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ss.onSuccess(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> ss.onSuccess(1);
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -384,47 +324,20 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapSingleDelayError(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
@@ -38,12 +38,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         Observer <Boolean> observer = TestHelper.mockObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        }).toObservable()
+        obs.all(s -> s.length() == 3).toObservable()
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -58,12 +53,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         Observer <Boolean> observer = TestHelper.mockObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        }).toObservable()
+        obs.all(s -> s.length() == 3).toObservable()
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -78,12 +68,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         Observer <Boolean> observer = TestHelper.mockObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        }).toObservable()
+        obs.all(s -> s.length() == 3).toObservable()
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -99,12 +84,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         Observer <Boolean> observer = TestHelper.mockObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        }).toObservable()
+        obs.all(s -> s.length() == 3).toObservable()
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -115,12 +95,7 @@ public class ObservableAllTest extends RxJavaTest {
     @Test
     public void followingFirstObservable() {
         Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
-        Observable<Boolean> allOdd = o.all(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 1;
-            }
-        }).toObservable();
+        Observable<Boolean> allOdd = o.all(i -> i % 2 == 1).toObservable();
 
         assertFalse(allOdd.blockingFirst());
     }
@@ -128,18 +103,8 @@ public class ObservableAllTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstreamObservable() {
         Observable<Integer> source = Observable.just(1)
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t1) {
-                    return false;
-                }
-            }).toObservable()
-            .flatMap(new Function<Boolean, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Boolean t1) {
-                    return Observable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .all(_ -> false).toObservable()
+            .flatMap((Function<Boolean, Observable<Integer>>) _ -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -150,11 +115,8 @@ public class ObservableAllTest extends RxJavaTest {
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Observable.just("Boo!").all(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Observable.just("Boo!").all(_ -> {
+            throw ex;
         })
         .subscribe(to);
 
@@ -172,12 +134,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -191,12 +148,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         SingleObserver <Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -210,12 +162,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         SingleObserver <Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -230,12 +177,7 @@ public class ObservableAllTest extends RxJavaTest {
 
         SingleObserver <Boolean> observer = TestHelper.mockSingleObserver();
 
-        obs.all(new Predicate<String>() {
-            @Override
-            public boolean test(String s) {
-                return s.length() == 3;
-            }
-        })
+        obs.all(s -> s.length() == 3)
         .subscribe(observer);
 
         verify(observer).onSubscribe(any());
@@ -246,12 +188,7 @@ public class ObservableAllTest extends RxJavaTest {
     @Test
     public void followingFirst() {
         Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
-        Single<Boolean> allOdd = o.all(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 1;
-            }
-        });
+        Single<Boolean> allOdd = o.all(i -> i % 2 == 1);
 
         assertFalse(allOdd.blockingGet());
     }
@@ -259,18 +196,8 @@ public class ObservableAllTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstream() {
         Observable<Integer> source = Observable.just(1)
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer t1) {
-                    return false;
-                }
-            })
-            .flatMapObservable(new Function<Boolean, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Boolean t1) {
-                    return Observable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .all(_ -> false)
+            .flatMapObservable((Function<Boolean, Observable<Integer>>) _ -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -281,11 +208,8 @@ public class ObservableAllTest extends RxJavaTest {
 
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Observable.just("Boo!").all(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Observable.just("Boo!").all(_ -> {
+            throw ex;
         })
         .subscribe(to);
 
@@ -319,11 +243,8 @@ public class ObservableAllTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .all(_ -> {
+                throw new TestException();
             })
             .toObservable()
             .test()
@@ -350,11 +271,8 @@ public class ObservableAllTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .all(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .all(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmbTest.java
@@ -50,36 +50,24 @@ public class ObservableAmbTest extends RxJavaTest {
 
     private Observable<String> createObservable(final String[] values,
             final long interval, final Throwable e) {
-        return Observable.unsafeCreate(new ObservableSource<String>() {
+        return Observable.unsafeCreate(observer -> {
+            CompositeDisposable parentSubscription = new CompositeDisposable();
 
-            @Override
-            public void subscribe(final Observer<? super String> observer) {
-                CompositeDisposable parentSubscription = new CompositeDisposable();
+            observer.onSubscribe(parentSubscription);
 
-                observer.onSubscribe(parentSubscription);
-
-                long delay = interval;
-                for (final String value : values) {
-                    parentSubscription.add(innerScheduler.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            observer.onNext(value);
-                        }
-                    }
-                    , delay, TimeUnit.MILLISECONDS));
-                    delay += interval;
-                }
-                parentSubscription.add(innerScheduler.schedule(new Runnable() {
-                    @Override
-                    public void run() {
-                            if (e == null) {
-                                observer.onComplete();
-                            } else {
-                                observer.onError(e);
-                            }
-                    }
-                }, delay, TimeUnit.MILLISECONDS));
+            long delay = interval;
+            for (final String value : values) {
+                parentSubscription.add(innerScheduler.schedule(() -> observer.onNext(value)
+                        , delay, TimeUnit.MILLISECONDS));
+                delay += interval;
             }
+            parentSubscription.add(innerScheduler.schedule(() -> {
+                    if (e == null) {
+                        observer.onComplete();
+                    } else {
+                        observer.onError(e);
+                    }
+            }, delay, TimeUnit.MILLISECONDS));
         });
     }
 
@@ -161,12 +149,7 @@ public class ObservableAmbTest extends RxJavaTest {
     @Test
     public void subscriptionOnlyHappensOnce() throws InterruptedException {
         final AtomicLong count = new AtomicLong();
-        Consumer<Disposable> incrementer = new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                count.incrementAndGet();
-            }
-        };
+        Consumer<Disposable> incrementer = _ -> count.incrementAndGet();
 
         //this aync stream should emit first
         Observable<Integer> o1 = Observable.just(1).doOnSubscribe(incrementer)
@@ -188,15 +171,12 @@ public class ObservableAmbTest extends RxJavaTest {
         // then second Observable does not get subscribed to before first
         // subscription completes hence first Observable emits result through
         // amb
-        int result = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        //
-                    }
-            }
+        int result = Observable.just(1).doOnNext(_ -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    //
+                }
         }).ambWith(Observable.just(2)).blockingSingle();
         assertEquals(1, result);
     }
@@ -272,18 +252,8 @@ public class ObservableAmbTest extends RxJavaTest {
 
             TestObserverEx<Integer> to = Observable.ambArray(ps1, ps2).to(TestHelper.<Integer>testConsumer());
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps1.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps2.onNext(1);
-                }
-            };
+            Runnable r1 = () -> ps1.onNext(1);
+            Runnable r2 = () -> ps2.onNext(1);
 
             TestHelper.race(r1, r2);
 
@@ -302,18 +272,8 @@ public class ObservableAmbTest extends RxJavaTest {
 
             TestObserver<Integer> to = Observable.ambArray(ps1, ps2).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps1.onComplete();
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps2.onComplete();
-                }
-            };
+            Runnable r1 = ps1::onComplete;
+            Runnable r2 = ps2::onComplete;
 
             TestHelper.race(r1, r2);
 
@@ -331,18 +291,8 @@ public class ObservableAmbTest extends RxJavaTest {
 
             final Throwable ex = new TestException();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps1.onError(ex);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    ps2.onError(ex);
-                }
-            };
+            Runnable r1 = () -> ps1.onError(ex);
+            Runnable r2 = () -> ps2.onError(ex);
 
             List<Throwable> errors = TestHelper.trackPluginErrors();
             try {
@@ -388,12 +338,9 @@ public class ObservableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Observable.never()
             )
-            .subscribe(new Consumer<Object>() {
-                @Override
-                public void accept(Object v) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe((Consumer<Object>) _ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -414,12 +361,9 @@ public class ObservableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Observable.never()
             )
-            .subscribe(Functions.emptyConsumer(), new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable e) throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), _ -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -439,12 +383,9 @@ public class ObservableAmbTest extends RxJavaTest {
                     .observeOn(Schedulers.computation()),
                 Observable.never()
             )
-            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), new Action() {
-                @Override
-                public void run() throws Exception {
-                    interrupted.set(Thread.currentThread().isInterrupted());
-                    cdl.countDown();
-                }
+            .subscribe(Functions.emptyConsumer(), Functions.emptyConsumer(), () -> {
+                interrupted.set(Thread.currentThread().isInterrupted());
+                cdl.countDown();
             });
 
             assertTrue(cdl.await(500, TimeUnit.SECONDS));
@@ -454,12 +395,7 @@ public class ObservableAmbTest extends RxJavaTest {
 
     @Test
     public void observableSourcesInIterable() {
-        ObservableSource<Integer> source = new ObservableSource<Integer>() {
-            @Override
-            public void subscribe(Observer<? super Integer> observer) {
-                Observable.just(1).subscribe(observer);
-            }
-        };
+        ObservableSource<Integer> source = observer -> Observable.just(1).subscribe(observer);
 
         Observable.amb(Arrays.asList(source, source))
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAnyTest.java
@@ -36,12 +36,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithTwoItemsObservable() {
         Observable<Integer> w = Observable.just(1, 2);
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(_ -> true).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -71,12 +66,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithOneItemObservable() {
         Observable<Integer> w = Observable.just(1);
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(_ -> true).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -106,12 +96,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithEmptyObservable() {
         Observable<Integer> w = Observable.empty();
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(_ -> true).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -141,12 +126,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate1Observable() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(t1 -> t1 < 2).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -161,12 +141,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void exists1Observable() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(t1 -> t1 < 2).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -181,12 +156,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate2Observable() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 1;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(t1 -> t1 < 1).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -202,12 +172,7 @@ public class ObservableAnyTest extends RxJavaTest {
     public void anyWithEmptyAndPredicateObservable() {
         // If the source is empty, always output false.
         Observable<Integer> w = Observable.empty();
-        Observable<Boolean> observable = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        }).toObservable();
+        Observable<Boolean> observable = w.any(_ -> true).toObservable();
 
         Observer<Boolean> observer = TestHelper.mockObserver();
 
@@ -222,12 +187,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void withFollowingFirstObservable() {
         Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
-        Observable<Boolean> anyEven = o.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 0;
-            }
-        }).toObservable();
+        Observable<Boolean> anyEven = o.any(i -> i % 2 == 0).toObservable();
 
         assertTrue(anyEven.blockingFirst());
     }
@@ -235,12 +195,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstreamObservable() {
         Observable<Integer> source = Observable.just(1).isEmpty().toObservable()
-            .flatMap(new Function<Boolean, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Boolean t1) {
-                    return Observable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .flatMap((Function<Boolean, Observable<Integer>>) _ -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -250,11 +205,8 @@ public class ObservableAnyTest extends RxJavaTest {
         TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Observable.just("Boo!").any(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Observable.just("Boo!").any(_ -> {
+            throw ex;
         }).subscribe(to);
 
         to.assertTerminated();
@@ -268,12 +220,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithTwoItems() {
         Observable<Integer> w = Observable.just(1, 2);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -301,12 +248,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithOneItem() {
         Observable<Integer> w = Observable.just(1);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -334,12 +276,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithEmpty() {
         Observable<Integer> w = Observable.empty();
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -367,12 +304,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 2);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -386,12 +318,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void exists1() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 2;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 2);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -405,12 +332,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void anyWithPredicate2() {
         Observable<Integer> w = Observable.just(1, 2, 3);
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t1) {
-                return t1 < 1;
-            }
-        });
+        Single<Boolean> single = w.any(t1 -> t1 < 1);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -425,12 +347,7 @@ public class ObservableAnyTest extends RxJavaTest {
     public void anyWithEmptyAndPredicate() {
         // If the source is empty, always output false.
         Observable<Integer> w = Observable.empty();
-        Single<Boolean> single = w.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer t) {
-                return true;
-            }
-        });
+        Single<Boolean> single = w.any(_ -> true);
 
         SingleObserver<Boolean> observer = TestHelper.mockSingleObserver();
 
@@ -444,12 +361,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void withFollowingFirst() {
         Observable<Integer> o = Observable.fromArray(1, 3, 5, 6);
-        Single<Boolean> anyEven = o.any(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer i) {
-                return i % 2 == 0;
-            }
-        });
+        Single<Boolean> anyEven = o.any(i -> i % 2 == 0);
 
         assertTrue(anyEven.blockingGet());
     }
@@ -457,12 +369,7 @@ public class ObservableAnyTest extends RxJavaTest {
     @Test
     public void issue1935NoUnsubscribeDownstream() {
         Observable<Integer> source = Observable.just(1).isEmpty()
-            .flatMapObservable(new Function<Boolean, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Boolean t1) {
-                    return Observable.just(2).delay(500, TimeUnit.MILLISECONDS);
-                }
-            });
+            .flatMapObservable((Function<Boolean, Observable<Integer>>) _ -> Observable.just(2).delay(500, TimeUnit.MILLISECONDS));
 
         assertEquals((Object)2, source.blockingFirst());
     }
@@ -472,11 +379,8 @@ public class ObservableAnyTest extends RxJavaTest {
         TestObserverEx<Boolean> to = new TestObserverEx<>();
         final IllegalArgumentException ex = new IllegalArgumentException();
 
-        Observable.just("Boo!").any(new Predicate<String>() {
-            @Override
-            public boolean test(String v) {
-                throw ex;
-            }
+        Observable.just("Boo!").any(_ -> {
+            throw ex;
         }).subscribe(to);
 
         to.assertTerminated();
@@ -496,18 +400,8 @@ public class ObservableAnyTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Boolean>>() {
-            @Override
-            public ObservableSource<Boolean> apply(Observable<Object> o) throws Exception {
-                return o.any(Functions.alwaysTrue()).toObservable();
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Object>, SingleSource<Boolean>>() {
-            @Override
-            public SingleSource<Boolean> apply(Observable<Object> o) throws Exception {
-                return o.any(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.any(Functions.alwaysTrue()).toObservable());
+        TestHelper.checkDoubleOnSubscribeObservableToSingle(o -> o.any(Functions.alwaysTrue()));
     }
 
     @Test
@@ -525,11 +419,8 @@ public class ObservableAnyTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .any(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            .any(_ -> {
+                throw new TestException();
             })
             .toObservable()
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
@@ -215,18 +215,18 @@ public class ObservableBlockingTest extends RxJavaTest {
     @Test
     public void delayed() throws Exception {
         final TestObserver<Object> to = new TestObserver<>();
-        final AtomicReference<Observer<? super Integer>> s = new AtomicReference<>();
+        final AtomicReference<Observer<? super Integer>> obsRef = new AtomicReference<>();
 
         Schedulers.single().scheduleDirect(() -> {
             to.dispose();
-            s.get().onNext(1);
+            obsRef.get().onNext(1);
         }, 200, TimeUnit.MILLISECONDS);
 
         new Observable<Integer>() {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
-                s.set(observer);
+                obsRef.set(observer);
             }
         }.blockingSubscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
@@ -17,15 +17,16 @@ import static org.junit.Assert.*;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.core.RxJavaTest;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.observers.BlockingFirstObserver;
 import io.reactivex.rxjava4.observers.TestObserver;
@@ -52,12 +53,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        });
+        .blockingSubscribe(list::add);
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -68,12 +64,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        }, Functions.emptyConsumer());
+        .blockingSubscribe(list::add, Functions.emptyConsumer());
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
@@ -84,12 +75,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
         TestException ex = new TestException();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = list::add;
 
         Observable.range(1, 5).concatWith(Observable.<Integer>error(ex))
         .subscribeOn(Schedulers.computation())
@@ -102,21 +88,11 @@ public class ObservableBlockingTest extends RxJavaTest {
     public void blockingSubscribeConsumerConsumerAction() {
         final List<Object> list = new ArrayList<>();
 
-        Consumer<Object> cons = new Consumer<Object>() {
-            @Override
-            public void accept(Object v) throws Exception {
-                list.add(v);
-            }
-        };
+        Consumer<Object> cons = list::add;
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(cons, cons, new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add(100);
-            }
-        });
+        .blockingSubscribe(cons, cons, () -> list.add(100));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
     }
@@ -192,11 +168,8 @@ public class ObservableBlockingTest extends RxJavaTest {
     @Test(expected = TestException.class)
     public void blockingForEachThrows() {
         Observable.just(1)
-        .blockingForEach(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .blockingForEach(_ -> {
+            throw new TestException();
         });
     }
 
@@ -239,26 +212,21 @@ public class ObservableBlockingTest extends RxJavaTest {
         to.assertEmpty();
     }
 
-    @SuppressWarnings("rawtypes")
     @Test
     public void delayed() throws Exception {
         final TestObserver<Object> to = new TestObserver<>();
-        final Observer[] s = { null };
+        final AtomicReference<Observer<? super Integer>> s = new AtomicReference<>();
 
-        Schedulers.single().scheduleDirect(new Runnable() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void run() {
-                to.dispose();
-                s[0].onNext(1);
-            }
+        Schedulers.single().scheduleDirect(() -> {
+            to.dispose();
+            s.get().onNext(1);
         }, 200, TimeUnit.MILLISECONDS);
 
         new Observable<Integer>() {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
-                s[0] = observer;
+                s.set(observer);
             }
         }.blockingSubscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -67,16 +67,13 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void skipAndCountOverlappingBuffers() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext("one");
-                observer.onNext("two");
-                observer.onNext("three");
-                observer.onNext("four");
-                observer.onNext("five");
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext("one");
+            observer.onNext("two");
+            observer.onNext("three");
+            observer.onNext("four");
+            observer.onNext("five");
         });
 
         Observable<List<String>> buffered = source.buffer(3, 1);
@@ -123,17 +120,14 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void timedAndCount() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                push(observer, "one", 10);
-                push(observer, "two", 90);
-                push(observer, "three", 110);
-                push(observer, "four", 190);
-                push(observer, "five", 210);
-                complete(observer, 250);
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            push(observer, "one", 10);
+            push(observer, "two", 90);
+            push(observer, "three", 110);
+            push(observer, "four", 190);
+            push(observer, "five", 210);
+            complete(observer, 250);
         });
 
         Observable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler, 2);
@@ -155,22 +149,19 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void timed() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                push(observer, "one", 97);
-                push(observer, "two", 98);
-                /**
-                 * Changed from 100. Because scheduling the cut to 100ms happens before this
-                 * Observable even runs due how lift works, pushing at 100ms would execute after the
-                 * buffer cut.
-                 */
-                push(observer, "three", 99);
-                push(observer, "four", 101);
-                push(observer, "five", 102);
-                complete(observer, 150);
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            push(observer, "one", 97);
+            push(observer, "two", 98);
+            /**
+             * Changed from 100. Because scheduling the cut to 100ms happens before this
+             * Observable even runs due how lift works, pushing at 100ms would execute after the
+             * buffer cut.
+             */
+            push(observer, "three", 99);
+            push(observer, "four", 101);
+            push(observer, "five", 102);
+            complete(observer, 150);
         });
 
         Observable<List<String>> buffered = source.buffer(100, TimeUnit.MILLISECONDS, scheduler);
@@ -189,42 +180,28 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void observableBasedOpenerAndCloser() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                push(observer, "one", 10);
-                push(observer, "two", 60);
-                push(observer, "three", 110);
-                push(observer, "four", 160);
-                push(observer, "five", 210);
-                complete(observer, 500);
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            push(observer, "one", 10);
+            push(observer, "two", 60);
+            push(observer, "three", 110);
+            push(observer, "four", 160);
+            push(observer, "five", 210);
+            complete(observer, 500);
         });
 
-        Observable<Object> openings = Observable.unsafeCreate(new ObservableSource<Object>() {
-            @Override
-            public void subscribe(Observer<Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                push(observer, new Object(), 50);
-                push(observer, new Object(), 200);
-                complete(observer, 250);
-            }
+        Observable<Object> openings = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            push(observer, new Object(), 50);
+            push(observer, new Object(), 200);
+            complete(observer, 250);
         });
 
-        Function<Object, Observable<Object>> closer = new Function<Object, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Object opening) {
-                return Observable.unsafeCreate(new ObservableSource<Object>() {
-                    @Override
-                    public void subscribe(Observer<? super Object> observer) {
-                        observer.onSubscribe(Disposable.empty());
-                        push(observer, new Object(), 100);
-                        complete(observer, 101);
-                    }
-                });
-            }
-        };
+        Function<Object, Observable<Object>> closer = _ -> Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            push(observer, new Object(), 100);
+            complete(observer, 101);
+        });
 
         Observable<List<String>> buffered = source.buffer(openings, closer);
         buffered.subscribe(observer);
@@ -281,21 +258,11 @@ public class ObservableBufferTest extends RxJavaTest {
     }
 
     private <T> void push(final Observer<T> observer, final T value, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                observer.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> observer.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     private void complete(final Observer<?> observer, int delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                observer.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(observer::onComplete, delay, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -306,12 +273,7 @@ public class ObservableBufferTest extends RxJavaTest {
         TestObserver<List<Integer>> to = new TestObserver<>(o);
 
         source.buffer(100, 200, TimeUnit.MILLISECONDS, scheduler)
-        .doOnNext(new Consumer<List<Integer>>() {
-            @Override
-            public void accept(List<Integer> pv) {
-                System.out.println(pv);
-            }
-        })
+        .doOnNext(System.out::println)
         .subscribe(to);
 
         InOrder inOrder = Mockito.inOrder(o);
@@ -543,12 +505,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferWithStartEndBoundaryTake2() {
         Observable<Long> start = Observable.interval(61, 61, TimeUnit.MILLISECONDS, scheduler);
-        Function<Long, Observable<Long>> end = new Function<Long, Observable<Long>>() {
-            @Override
-            public Observable<Long> apply(Long t1) {
-                return Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
-            }
-        };
+        Function<Long, Observable<Long>> end = _ -> Observable.interval(100, 100, TimeUnit.MILLISECONDS, scheduler);
 
         Observable<Long> source = Observable.interval(40, 40, TimeUnit.MILLISECONDS, scheduler);
 
@@ -558,12 +515,7 @@ public class ObservableBufferTest extends RxJavaTest {
         InOrder inOrder = inOrder(o);
 
         result
-        .doOnNext(new Consumer<List<Long>>() {
-            @Override
-            public void accept(List<Long> pv) {
-                System.out.println(pv);
-            }
-        })
+        .doOnNext(System.out::println)
         .subscribe(o);
 
         scheduler.advanceTimeBy(5, TimeUnit.SECONDS);
@@ -648,12 +600,7 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferWithStartEndStartThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> end = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return Observable.never();
-            }
-        };
+        Function<Integer, Observable<Integer>> end = _ -> Observable.never();
 
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -677,11 +624,8 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferWithStartEndEndFunctionThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> end = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Observable<Integer>> end = _ -> {
+            throw new TestException();
         };
 
         PublishSubject<Integer> source = PublishSubject.create();
@@ -705,12 +649,7 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferWithStartEndEndThrows() {
         PublishSubject<Integer> start = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> end = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return Observable.error(new TestException());
-            }
-        };
+        Function<Integer, Observable<Integer>> end = _ -> Observable.error(new TestException());
 
         PublishSubject<Integer> source = PublishSubject.create();
 
@@ -785,12 +724,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return new HashSet<>();
-            }
-        })
+        .buffer(3, (Supplier<Collection<Integer>>) HashSet::new)
         .test()
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
@@ -798,12 +732,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferSkipIntoCustomCollection() {
         Observable.just(1, 1, 2, 2, 3, 3, 4, 4)
-        .buffer(3, 3, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                return new HashSet<>();
-            }
-        })
+        .buffer(3, 3, (Supplier<Collection<Integer>>) HashSet::new)
         .test()
         .assertResult(set(1, 2), set(2, 3), set(4));
     }
@@ -811,11 +740,8 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows() {
         Observable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), Integer.MAX_VALUE, (Supplier<Collection<Integer>>) () -> {
+            throw new TestException();
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -824,11 +750,8 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows2() {
         Observable.just(1)
-        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(1, TimeUnit.SECONDS, Schedulers.single(), 10, (Supplier<Collection<Integer>>) () -> {
+            throw new TestException();
         }, false)
         .test()
         .assertFailure(TestException.class);
@@ -837,11 +760,8 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows3() {
         Observable.just(1)
-        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
-            @Override
-            public Collection<Integer> get() throws Exception {
-                throw new TestException();
-            }
+        .buffer(2, 1, TimeUnit.SECONDS, Schedulers.single(), (Supplier<Collection<Integer>>) () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -1154,19 +1074,9 @@ public class ObservableBufferTest extends RxJavaTest {
             ps.onNext(3);
             ps.onNext(4);
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onNext(5);
-                }
-            };
+            Runnable r1 = () -> ps.onNext(5);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
-                }
-            };
+            Runnable r2 = () -> scheduler.advanceTimeBy(1, TimeUnit.SECONDS);
 
             TestHelper.race(r1, r2);
 
@@ -1186,12 +1096,7 @@ public class ObservableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.<Integer>empty()
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnDispose(counter::getAndIncrement)
         .buffer(5, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1205,12 +1110,7 @@ public class ObservableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.<Integer>empty()
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnDispose(counter::getAndIncrement)
         .buffer(5, 10, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1224,12 +1124,7 @@ public class ObservableBufferTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.<Integer>empty()
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        })
+        .doOnDispose(counter::getAndIncrement)
         .buffer(10, 5, TimeUnit.SECONDS)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1271,19 +1166,9 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesDropping() {
         Observable.range(1, 50)
                 .zipWith(Observable.interval(5, TimeUnit.MILLISECONDS),
-                        new BiFunction<Integer, Long, Integer>() {
-                            @Override
-                            public Integer apply(Integer integer, Long aLong) {
-                                return integer;
-                            }
-                        })
+                        (integer, _) -> integer)
                 .buffer(Observable.interval(0, 200, TimeUnit.MILLISECONDS),
-                        new Function<Long, Observable<Long>>() {
-                            @Override
-                            public Observable<Long> apply(Long a) {
-                                return Observable.just(a).delay(100, TimeUnit.MILLISECONDS);
-                            }
-                        })
+                        (Function<Long, Observable<Long>>) a -> Observable.just(a).delay(100, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
                 .assertSubscribed()
                 .awaitDone(3, TimeUnit.SECONDS)
@@ -1294,19 +1179,9 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferedCanCompleteIfOpenNeverCompletesOverlapping() {
         Observable.range(1, 50)
                 .zipWith(Observable.interval(5, TimeUnit.MILLISECONDS),
-                        new BiFunction<Integer, Long, Integer>() {
-                            @Override
-                            public Integer apply(Integer integer, Long aLong) {
-                                return integer;
-                            }
-                        })
+                        (integer, _) -> integer)
                 .buffer(Observable.interval(0, 100, TimeUnit.MILLISECONDS),
-                        new Function<Long, Observable<Long>>() {
-                            @Override
-                            public Observable<Long> apply(Long a) {
-                                return Observable.just(a).delay(200, TimeUnit.MILLISECONDS);
-                            }
-                        })
+                        (Function<Long, Observable<Long>>) a -> Observable.just(a).delay(200, TimeUnit.MILLISECONDS))
                 .to(TestHelper.<List<Integer>>testConsumer())
                 .assertSubscribed()
                 .awaitDone(3, TimeUnit.SECONDS)
@@ -1527,13 +1402,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferExactBoundaryDoubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(
-                new Function<Observable<Object>, ObservableSource<List<Object>>>() {
-                    @Override
-                    public ObservableSource<List<Object>> apply(Observable<Object> f)
-                            throws Exception {
-                        return f.buffer(Observable.never());
-                    }
-                }
+                f -> f.buffer(Observable.never())
         );
     }
 
@@ -1588,13 +1457,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void timedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<List<Object>>>() {
-            @Override
-            public Observable<List<Object>> apply(Observable<Object> f)
-                    throws Exception {
-                return f.buffer(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<List<Object>>>) f -> f.buffer(1, TimeUnit.SECONDS));
     }
 
     @Test
@@ -1641,24 +1504,12 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void timedSkipDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<List<Object>>>() {
-            @Override
-            public Observable<List<Object>> apply(Observable<Object> f)
-                    throws Exception {
-                return f.buffer(2, 1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<List<Object>>>) f -> f.buffer(2, 1, TimeUnit.SECONDS));
     }
 
     @Test
     public void timedSizedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<List<Object>>>() {
-            @Override
-            public Observable<List<Object>> apply(Observable<Object> f)
-                    throws Exception {
-                return f.buffer(2, TimeUnit.SECONDS, 10);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<List<Object>>>) f -> f.buffer(2, TimeUnit.SECONDS, 10));
     }
 
     @Test
@@ -1745,13 +1596,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<List<Object>>>() {
-            @Override
-            public ObservableSource<List<Object>> apply(Observable<Object> o)
-                    throws Exception {
-                return o.buffer(1);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.buffer(1));
     }
 
     @Test
@@ -1770,23 +1615,14 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferSkipDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<List<Object>>>() {
-            @Override
-            public ObservableSource<List<Object>> apply(Observable<Object> o)
-                    throws Exception {
-                return o.buffer(1, 2);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.buffer(1, 2));
     }
 
     @Test
     public void bufferExactFailingSupplier() {
         Observable.empty()
-                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, new Supplier<List<Object>>() {
-                    @Override
-                    public List<Object> get() throws Exception {
-                        throw new TestException();
-                    }
+                .buffer(1, TimeUnit.SECONDS, Schedulers.computation(), 10, (Supplier<List<Object>>) () -> {
+                    throw new TestException();
                 }, false)
                 .test()
                 .awaitDone(1, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferUntilSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferUntilSubscriberTest.java
@@ -13,7 +13,6 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
-import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -42,32 +41,21 @@ public class ObservableBufferUntilSubscriberTest extends RxJavaTest {
             Observable.fromArray(numbers)
                     .takeUntil(s)
                     .window(50)
-                    .flatMap(new Function<Observable<Integer>, Observable<Object>>() {
-                        @Override
-                        public Observable<Object> apply(Observable<Integer> integerObservable) {
-                                return integerObservable
-                                        .subscribeOn(Schedulers.computation())
-                                        .map(new Function<Integer, Object>() {
-                                            @Override
-                                            public Object apply(Integer integer) {
-                                                    if (integer >= 5 && completed.compareAndSet(false, true)) {
-                                                        s.onComplete();
-                                                    }
-                                                    // do some work
-                                                    Math.pow(Math.random(), Math.random());
-                                                    return integer * 2;
-                                            }
-                                        });
-                        }
-                    })
+                    .flatMap((Function<Observable<Integer>, Observable<Object>>) integerObservable -> integerObservable
+                            .subscribeOn(Schedulers.computation())
+                            .map((Function<Integer, Object>) integer -> {
+                                    if (integer >= 5 && completed.compareAndSet(false, true)) {
+                                        s.onComplete();
+                                    }
+                                    // do some work
+                                    Math.pow(Math.random(), Math.random());
+                                    return integer * 2;
+                            }))
                     .toList()
-                    .doOnSuccess(new Consumer<List<Object>>() {
-                        @Override
-                        public void accept(List<Object> integers) {
-                                counter.incrementAndGet();
-                                latch.countDown();
-                                innerLatch.countDown();
-                        }
+                    .doOnSuccess(_ -> {
+                            counter.incrementAndGet();
+                            latch.countDown();
+                            innerLatch.countDown();
                     })
                     .subscribe();
             if (!innerLatch.await(30, TimeUnit.SECONDS)) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
@@ -25,11 +25,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.observables.ConnectableObservable;
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
@@ -65,45 +65,31 @@ public class ObservableCacheTest extends RxJavaTest {
     @Test
     public void cache() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
-
-            @Override
-            public void subscribe(final Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        counter.incrementAndGet();
-                        System.out.println("published Observable being executed");
-                        observer.onNext("one");
-                        observer.onComplete();
-                    }
-                }).start();
-            }
+        Observable<String> o = Observable.unsafeCreate((ObservableSource<String>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            new Thread(() -> {
+                counter.incrementAndGet();
+                System.out.println("published Observable being executed");
+                observer.onNext("one");
+                observer.onComplete();
+            }).start();
         }).cache();
 
         // we then expect the following 2 subscriptions to get that same value
         final CountDownLatch latch = new CountDownLatch(2);
 
         // subscribe once
-        o.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                    assertEquals("one", v);
-                    System.out.println("v: " + v);
-                    latch.countDown();
-            }
+        o.subscribe(v -> {
+                Assert.assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
         });
 
         // subscribe again
-        o.subscribe(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                    assertEquals("one", v);
-                    System.out.println("v: " + v);
-                    latch.countDown();
-            }
+        o.subscribe(v -> {
+                Assert.assertEquals("one", v);
+                System.out.println("v: " + v);
+                latch.countDown();
         });
 
         if (!latch.await(1000, TimeUnit.MILLISECONDS)) {
@@ -200,15 +186,12 @@ public class ObservableCacheTest extends RxJavaTest {
     @Test
     public void noMissingBackpressureException() {
         final int m = 4 * 1000 * 1000;
-        Observable<Integer> firehose = Observable.unsafeCreate(new ObservableSource<Integer>() {
-            @Override
-            public void subscribe(Observer<? super Integer> t) {
-                t.onSubscribe(Disposable.empty());
-                for (int i = 0; i < m; i++) {
-                    t.onNext(i);
-                }
-                t.onComplete();
+        Observable<Integer> firehose = Observable.unsafeCreate(t -> {
+            t.onSubscribe(Disposable.empty());
+            for (int i = 0; i < m; i++) {
+                t.onNext(i);
             }
+            t.onComplete();
         });
 
         TestObserver<Integer> to = new TestObserver<>();
@@ -303,21 +286,13 @@ public class ObservableCacheTest extends RxJavaTest {
 
             final TestObserverEx<Integer> to = new TestObserverEx<>();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    cache.subscribe(to);
-                }
-            };
+            Runnable r1 = () -> cache.subscribe(to);
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    for (int j = 0; j < 500; j++) {
-                        ps.onNext(j);
-                    }
-                    ps.onComplete();
+            Runnable r2 = () -> {
+                for (int j = 0; j < 500; j++) {
+                    ps.onNext(j);
                 }
+                ps.onComplete();
             };
 
             TestHelper.race(r1, r2);
@@ -331,12 +306,7 @@ public class ObservableCacheTest extends RxJavaTest {
     @Test
     public void cancelledUpFront() {
         final AtomicInteger call = new AtomicInteger();
-        Observable<Object> f = Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return call.incrementAndGet();
-            }
-        }).concatWith(Observable.never())
+        Observable<Object> f = Observable.fromCallable((Callable<Object>) call::incrementAndGet).concatWith(Observable.never())
         .cache();
 
         f.test().assertValuesOnly(1);
@@ -384,19 +354,16 @@ public class ObservableCacheTest extends RxJavaTest {
 
         final AtomicLong after = new AtomicLong();
 
-        source.cache().lastElement().subscribe(new Consumer<byte[]>() {
-            @Override
-            public void accept(byte[] v) throws Exception {
-                System.out.println("Bounded Replay Leak check: Wait before GC 2");
-                Thread.sleep(1000);
+        source.cache().lastElement().subscribe(_ -> {
+            System.out.println("Bounded Replay Leak check: Wait before GC 2");
+            Thread.sleep(1000);
 
-                System.out.println("Bounded Replay Leak check:  GC 2");
-                System.gc();
+            System.out.println("Bounded Replay Leak check:  GC 2");
+            System.gc();
 
-                Thread.sleep(500);
+            Thread.sleep(500);
 
-                after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
-            }
+            after.set(memoryMXBean.getHeapMemoryUsage().getUsed());
         });
 
         source.connect();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -33,17 +33,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectToListObservable() {
         Observable<List<Integer>> o = Observable.just(1, 2, 3)
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        }).toObservable();
+        .collect((Supplier<List<Integer>>) ArrayList::new, List::add).toObservable();
 
         List<Integer> list =  o.blockingLast();
 
@@ -63,19 +53,11 @@ public final class ObservableCollectTest extends RxJavaTest {
 
     @Test
     public void collectToStringObservable() {
-        String value = Observable.just(1, 2, 3).collect(new Supplier<StringBuilder>() {
-            @Override
-            public StringBuilder get() {
-                return new StringBuilder();
+        String value = Observable.just(1, 2, 3).collect(StringBuilder::new, (sb, v) -> {
+            if (sb.length() > 0) {
+                sb.append("-");
             }
-        }, new BiConsumer<StringBuilder, Integer>() {
-            @Override
-            public void accept(StringBuilder sb, Integer v) {
-                if (sb.length() > 0) {
-                    sb.append("-");
-                }
-                sb.append(v);
-            }
+            sb.append(v);
         }).toObservable().blockingLast().toString();
 
         assertEquals("1-2-3", value);
@@ -144,12 +126,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectIntoObservable() {
         Observable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
-            @Override
-            public void accept(HashSet<Integer> s, Integer v) throws Exception {
-                s.add(v);
-            }
-        }).toObservable()
+        .collectInto(new HashSet<>(), (BiConsumer<HashSet<Integer>, Integer>) HashSet::add).toObservable()
         .test()
         .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
@@ -157,17 +134,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectToList() {
         Single<List<Integer>> o = Observable.just(1, 2, 3)
-        .collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> list, Integer v) {
-                list.add(v);
-            }
-        });
+        .collect(ArrayList::new, List::add);
 
         List<Integer> list =  o.blockingGet();
 
@@ -187,19 +154,11 @@ public final class ObservableCollectTest extends RxJavaTest {
 
     @Test
     public void collectToString() {
-        String value = Observable.just(1, 2, 3).collect(new Supplier<StringBuilder>() {
-            @Override
-            public StringBuilder get() {
-                return new StringBuilder();
+        String value = Observable.just(1, 2, 3).collect(StringBuilder::new, (sb, v) -> {
+            if (sb.length() > 0) {
+                sb.append("-");
             }
-        }, new BiConsumer<StringBuilder, Integer>() {
-            @Override
-            public void accept(StringBuilder sb, Integer v) {
-                if (sb.length() > 0) {
-                    sb.append("-");
-                }
-                sb.append(v);
-            }
+            sb.append(v);
         }).blockingGet().toString();
 
         assertEquals("1-2-3", value);
@@ -266,97 +225,29 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectInto() {
         Observable.just(1, 1, 1, 1, 2)
-        .collectInto(new HashSet<>(), new BiConsumer<HashSet<Integer>, Integer>() {
-            @Override
-            public void accept(HashSet<Integer> s, Integer v) throws Exception {
-                s.add(v);
-            }
-        })
+        .collectInto(new HashSet<>(), (BiConsumer<HashSet<Integer>, Integer>) HashSet::add)
         .test()
         .assertResult(new HashSet<>(Arrays.asList(1, 2)));
     }
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        }));
+        TestHelper.checkDisposed(Observable.range(1, 3).collect((Supplier<List<Integer>>) ArrayList::new, List::add));
 
-        TestHelper.checkDisposed(Observable.range(1, 3).collect(new Supplier<List<Integer>>() {
-            @Override
-            public List<Integer> get() throws Exception {
-                return new ArrayList<>();
-            }
-        }, new BiConsumer<List<Integer>, Integer>() {
-            @Override
-            public void accept(List<Integer> a, Integer b) throws Exception {
-                a.add(b);
-            }
-        }).toObservable());
+        TestHelper.checkDisposed(Observable.range(1, 3).collect((Supplier<List<Integer>>) ArrayList::new, List::add).toObservable());
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservableToSingle(new Function<Observable<Integer>, SingleSource<List<Integer>>>() {
-            @Override
-            public SingleSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Supplier<List<Integer>>() {
-                    @Override
-                    public List<Integer> get() throws Exception {
-                        return new ArrayList<>();
-                    }
-                }, new BiConsumer<List<Integer>, Integer>() {
-                    @Override
-                    public void accept(List<Integer> a, Integer b) throws Exception {
-                        a.add(b);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservableToSingle((Function<Observable<Integer>, SingleSource<List<Integer>>>) o ->
+            o.collect((Supplier<List<Integer>>) ArrayList::new, List::add));
 
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Integer>, ObservableSource<List<Integer>>>() {
-            @Override
-            public ObservableSource<List<Integer>> apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Supplier<List<Integer>>() {
-                    @Override
-                    public List<Integer> get() throws Exception {
-                        return new ArrayList<>();
-                    }
-                }, new BiConsumer<List<Integer>, Integer>() {
-                    @Override
-                    public void accept(List<Integer> a, Integer b) throws Exception {
-                        a.add(b);
-                    }
-                }).toObservable();
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Integer>, ObservableSource<List<Integer>>>) o ->
+            o.collect((Supplier<List<Integer>>) ArrayList::new, List::add).toObservable());
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return o.collect(new Supplier<List<Integer>>() {
-                    @Override
-                    public List<Integer> get() throws Exception {
-                        return new ArrayList<>();
-                    }
-                }, new BiConsumer<List<Integer>, Integer>() {
-                    @Override
-                    public void accept(List<Integer> a, Integer b) throws Exception {
-                        a.add(b);
-                    }
-                }).toObservable();
-            }
-        }, false, 1, 2, List.of(1));
+        TestHelper.checkBadSourceObservable(o -> o.collect((Supplier<List<Integer>>) ArrayList::new, List::add).toObservable(), false, 1, 2, List.of(1));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -46,11 +46,8 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         PublishSubject<String> w1 = PublishSubject.create();
         PublishSubject<String> w2 = PublishSubject.create();
 
-        Observable<String> combined = Observable.combineLatest(w1, w2, new BiFunction<String, String, String>() {
-            @Override
-            public String apply(String v1, String v2) {
-                throw new RuntimeException("I don't work.");
-            }
+        Observable<String> combined = Observable.combineLatest(w1, w2, (_, _) -> {
+            throw new RuntimeException("I don't work.");
         });
         combined.subscribe(w);
 
@@ -223,41 +220,28 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     }
 
     private Function3<String, String, String, String> getConcat3StringsCombineLatestFunction() {
-        Function3<String, String, String, String> combineLatestFunction = new Function3<String, String, String, String>() {
-            @Override
-            public String apply(String a1, String a2, String a3) {
-                if (a1 == null) {
-                    a1 = "";
-                }
-                if (a2 == null) {
-                    a2 = "";
-                }
-                if (a3 == null) {
-                    a3 = "";
-                }
-                return a1 + a2 + a3;
+        Function3<String, String, String, String> combineLatestFunction = (a1, a2, a3) -> {
+            if (a1 == null) {
+                a1 = "";
             }
+            if (a2 == null) {
+                a2 = "";
+            }
+            if (a3 == null) {
+                a3 = "";
+            }
+            return a1 + a2 + a3;
         };
         return combineLatestFunction;
     }
 
     private BiFunction<String, Integer, String> getConcatStringIntegerCombineLatestFunction() {
-        BiFunction<String, Integer, String> combineLatestFunction = new BiFunction<String, Integer, String>() {
-            @Override
-            public String apply(String s, Integer i) {
-                return getStringValue(s) + getStringValue(i);
-            }
-        };
+        BiFunction<String, Integer, String> combineLatestFunction = (s, i) -> getStringValue(s) + getStringValue(i);
         return combineLatestFunction;
     }
 
     private Function3<String, Integer, int[], String> getConcatStringIntegerIntArrayCombineLatestFunction() {
-        return new Function3<String, Integer, int[], String>() {
-            @Override
-            public String apply(String s, Integer i, int[] iArray) {
-                return getStringValue(s) + getStringValue(i) + getStringValue(iArray);
-            }
-        };
+        return (s, i, iArray) -> getStringValue(s) + getStringValue(i) + getStringValue(iArray);
     }
 
     private static String getStringValue(Object o) {
@@ -272,12 +256,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         }
     }
 
-    BiFunction<Integer, Integer, Integer> or = new BiFunction<Integer, Integer, Integer>() {
-        @Override
-        public Integer apply(Integer t1, Integer t2) {
-            return t1 | t2;
-        }
-    };
+    BiFunction<Integer, Integer, Integer> or = (t1, t2) -> t1 | t2;
 
     @Test
     public void combineSimple() {
@@ -428,13 +407,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @Test
     public void oneToNSources() {
         int n = 30;
-        Function<Object[], List<Object>> func = new Function<Object[], List<Object>>() {
-
-            @Override
-            public List<Object> apply(Object[] args) {
-                return Arrays.asList(args);
-            }
-        };
+        Function<Object[], List<Object>> func = Arrays::asList;
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSources: " + i + " sources");
             List<Observable<Integer>> sources = new ArrayList<>();
@@ -459,13 +432,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @Test
     public void oneToNSourcesScheduled() throws InterruptedException {
         int n = 10;
-        Function<Object[], List<Object>> func = new Function<Object[], List<Object>>() {
-
-            @Override
-            public List<Object> apply(Object[] args) {
-                return Arrays.asList(args);
-            }
-        };
+        Function<Object[], List<Object>> func = Arrays::asList;
         for (int i = 1; i <= n; i++) {
             System.out.println("test1ToNSourcesScheduled: " + i + " sources");
             List<Observable<Integer>> sources = new ArrayList<>();
@@ -517,12 +484,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s2 = Observable.just(2);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2,
-                new BiFunction<Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2) {
-                        return Arrays.asList(t1, t2);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -540,12 +502,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s3 = Observable.just(3);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3,
-                new Function3<Integer, Integer, Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1, Integer t2, Integer t3) {
-                return Arrays.asList(t1, t2, t3);
-            }
-        });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -564,12 +521,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s4 = Observable.just(4);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4,
-                new Function4<Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4) {
-                        return Arrays.asList(t1, t2, t3, t4);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -589,12 +541,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s5 = Observable.just(5);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4, s5,
-                new Function5<Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5) {
-                        return Arrays.asList(t1, t2, t3, t4, t5);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -615,12 +562,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s6 = Observable.just(6);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4, s5, s6,
-                new Function6<Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -642,12 +584,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s7 = Observable.just(7);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4, s5, s6, s7,
-                new Function7<Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -670,12 +607,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s8 = Observable.just(8);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8,
-                new Function8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -699,12 +631,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         Observable<Integer> s9 = Observable.just(9);
 
         Observable<List<Integer>> result = Observable.combineLatest(s1, s2, s3, s4, s5, s6, s7, s8, s9,
-                new Function9<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, List<Integer>>() {
-                    @Override
-                    public List<Integer> apply(Integer t1, Integer t2, Integer t3, Integer t4, Integer t5, Integer t6, Integer t7, Integer t8, Integer t9) {
-                        return Arrays.asList(t1, t2, t3, t4, t5, t6, t7, t8, t9);
-                    }
-                });
+                Arrays::asList);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -718,14 +645,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     @Test
     public void zeroSources() {
         Observable<Object> result = Observable.combineLatest(
-                Collections.<Observable<Object>> emptyList(), new Function<Object[], Object>() {
-
-            @Override
-            public Object apply(Object[] args) {
-                return args;
-            }
-
-        });
+                Collections.<Observable<Object>> emptyList(), args -> args);
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -744,24 +664,16 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         final int SIZE = 2000;
         Observable<Long> timer = Observable.interval(0, 1, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.newThread())
-                .doOnEach(new Consumer<Notification<Long>>() {
-                    @Override
-                    public void accept(Notification<Long> n) {
-                            //                        System.out.println(n);
-                            if (count.incrementAndGet() >= SIZE) {
-                                latch.countDown();
-                            }
-                    }
+                .doOnEach(_ -> {
+                        //                        System.out.println(n);
+                        if (count.incrementAndGet() >= SIZE) {
+                            latch.countDown();
+                        }
                 }).take(SIZE);
 
         TestObserver<Long> to = new TestObserver<>();
 
-        Observable.combineLatest(timer, Observable.<Integer> never(), new BiFunction<Long, Integer, Long>() {
-            @Override
-            public Long apply(Long t1, Integer t2) {
-                return t1;
-            }
-        }).subscribe(to);
+        Observable.combineLatest(timer, Observable.<Integer> never(), (t1, _) -> t1).subscribe(to);
 
         if (!latch.await(SIZE + 1000, TimeUnit.MILLISECONDS)) {
             fail("timed out");
@@ -776,12 +688,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatestArray(new ObservableSource[] {
                 Observable.just(1), Observable.just(2)
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -792,12 +699,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatestArrayDelayError(new ObservableSource[] {
                 Observable.just(1), Observable.just(2)
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -808,12 +710,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatestArrayDelayError(new ObservableSource[] {
                 Observable.just(1), Observable.just(2).concatWith(Observable.<Integer>error(new TestException()))
-        }, new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        }, (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertFailure(TestException.class, "[1, 2]");
     }
@@ -823,12 +720,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatestDelayError(Arrays.asList(
                 Observable.just(1), Observable.just(2)
-        ), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        ), (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertResult("[1, 2]");
     }
@@ -838,12 +730,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatestDelayError(Arrays.asList(
                 Observable.just(1), Observable.just(2).concatWith(Observable.<Integer>error(new TestException()))
-        ), new Function<Object[], Object>() {
-            @Override
-            public Object apply(Object[] a) throws Exception {
-                return Arrays.toString(a);
-            }
-        })
+        ), (Function<Object[], Object>) Arrays::toString)
         .test()
         .assertFailure(TestException.class, "[1, 2]");
     }
@@ -862,12 +749,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(Observable.combineLatest(Observable.never(), Observable.never(), new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        }));
+        TestHelper.checkDisposed(Observable.combineLatest(Observable.never(), Observable.never(), (a, _) -> a));
     }
 
     @Test
@@ -876,19 +758,9 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
         Observable.combineLatest(
                 Observable.just(1)
-                .doOnNext(new Consumer<Integer>() {
-                    @Override
-                    public void accept(Integer v) throws Exception {
-                        to.dispose();
-                    }
-                }),
+                .doOnNext(_ -> to.dispose()),
                 Observable.never(),
-                new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+                        (BiFunction<Object, Object, Object>) (a, _) -> a)
         .subscribe(to);
     }
 
@@ -896,12 +768,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     public void combineAsync() {
         Observable<Integer> source = Observable.range(1, 1000).subscribeOn(Schedulers.computation());
 
-        Observable.combineLatest(source, source, new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        Observable.combineLatest(source, source, (BiFunction<Object, Object, Object>) (a, _) -> a)
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -911,12 +778,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void error() {
-        Observable.combineLatest(Observable.never(), Observable.error(new TestException()), new BiFunction<Object, Object, Object>() {
-            @Override
-            public Object apply(Object a, Object b) throws Exception {
-                return a;
-            }
-        })
+        Observable.combineLatest(Observable.never(), Observable.error(new TestException()), (a, _) -> a)
         .test()
         .assertFailure(TestException.class);
     }
@@ -926,12 +788,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     public void errorDelayed() {
         Observable.combineLatestArrayDelayError(
                 new ObservableSource[] { Observable.error(new TestException()), Observable.just(1) },
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return a;
-                    }
-                },
+                        (Function<Object[], Object>) a -> a,
                 128
         )
         .test()
@@ -943,12 +800,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
     public void errorDelayed2() {
         Observable.combineLatestArrayDelayError(
                 new ObservableSource[] { Observable.error(new TestException()).startWithItem(1), Observable.empty() },
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return a;
-                    }
-                },
+                        (Function<Object[], Object>) a -> a,
                 128
         )
         .test()
@@ -963,28 +815,13 @@ public class ObservableCombineLatestTest extends RxJavaTest {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
                 final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-                TestObserverEx<Integer> to = Observable.combineLatest(ps1, ps2, new BiFunction<Integer, Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer a, Integer b) throws Exception {
-                        return a;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                TestObserverEx<Integer> to = Observable.combineLatest(ps1, ps2, (a, _) -> a).to(TestHelper.<Integer>testConsumer());
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex1);
+                Runnable r2 = () -> ps2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -1020,18 +857,8 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
             Observable.combineLatest(Observable.empty(),
                     Observable.error(new TestException())
-                    .doOnSubscribe(new Consumer<Disposable>() {
-                        @Override
-                        public void accept(Disposable d) throws Exception {
-                            count[0]++;
-                        }
-                    }),
-                    new BiFunction<Object, Object, Object>() {
-                        @Override
-                        public Object apply(Object a, Object b) throws Exception {
-                            return 0;
-                        }
-                    })
+                    .doOnSubscribe(_ -> count[0]++),
+                            (BiFunction<Object, Object, Object>) (_, _) -> 0)
             .test()
             .assertResult();
 
@@ -1052,19 +879,9 @@ public class ObservableCombineLatestTest extends RxJavaTest {
             Observable.combineLatestDelayError(
                     Arrays.asList(Observable.empty(),
                         Observable.error(new TestException())
-                        .doOnSubscribe(new Consumer<Disposable>() {
-                            @Override
-                            public void accept(Disposable d) throws Exception {
-                                count[0]++;
-                            }
-                        })
+                        .doOnSubscribe(_ -> count[0]++)
                     ),
-                    new Function<Object[], Object>() {
-                        @Override
-                        public Object apply(Object[] a) throws Exception {
-                            return 0;
-                        }
-                    })
+                            (Function<Object[], Object>) _ -> 0)
             .test()
             .assertResult();
 
@@ -1085,66 +902,23 @@ public class ObservableCombineLatestTest extends RxJavaTest {
             TestScheduler testScheduler = new TestScheduler();
 
             Observable<Integer> emptyObservable = Observable.timer(10, TimeUnit.MILLISECONDS, testScheduler)
-                    .flatMap(new Function<Long, ObservableSource<Integer>>() {
-                        @Override
-                        public ObservableSource<Integer> apply(Long aLong) throws Exception {
-                            return Observable.error(new Exception());
-                        }
-                    });
-            Observable<Object> errorObservable = Observable.timer(100, TimeUnit.MILLISECONDS, testScheduler).map(new Function<Long, Object>() {
-                @Override
-                public Object apply(Long aLong) throws Exception {
-                    throw new Exception();
-                }
+                    .flatMap((Function<Long, ObservableSource<Integer>>) _ -> Observable.error(new Exception()));
+            Observable<Object> errorObservable = Observable.timer(100, TimeUnit.MILLISECONDS, testScheduler).map(_ -> {
+                throw new Exception();
             });
 
             Observable.combineLatestDelayError(
                     Arrays.asList(
                             emptyObservable
-                                    .doOnEach(new Consumer<Notification<Integer>>() {
-                                        @Override
-                                        public void accept(Notification<Integer> integerNotification) throws Exception {
-                                            System.out.println("emptyObservable: " + integerNotification);
-                                        }
-                                    })
-                                    .doFinally(new Action() {
-                                        @Override
-                                        public void run() throws Exception {
-                                            System.out.println("emptyObservable: doFinally");
-                                        }
-                                    }),
+                                    .doOnEach(integerNotification -> System.out.println("emptyObservable: " + integerNotification))
+                                    .doFinally(() -> System.out.println("emptyObservable: doFinally")),
                             errorObservable
-                                    .doOnEach(new Consumer<Notification<Object>>() {
-                                        @Override
-                                        public void accept(Notification<Object> integerNotification) throws Exception {
-                                            System.out.println("errorObservable: " + integerNotification);
-                                        }
-                                    })
-                                    .doFinally(new Action() {
-                                        @Override
-                                        public void run() throws Exception {
-                                            System.out.println("errorObservable: doFinally");
-                                        }
-                                    })),
-                    new Function<Object[], Object>() {
-                        @Override
-                        public Object apply(Object[] objects) throws Exception {
-                            return 0;
-                        }
-                    }
-            )
-                    .doOnEach(new Consumer<Notification<Object>>() {
-                        @Override
-                        public void accept(Notification<Object> integerNotification) throws Exception {
-                            System.out.println("combineLatestDelayError: " + integerNotification);
-                        }
-                    })
-                    .doFinally(new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            System.out.println("combineLatestDelayError: doFinally");
-                        }
-                    })
+                                    .doOnEach(integerNotification -> System.out.println("errorObservable: " + integerNotification))
+                                    .doFinally(() -> System.out.println("errorObservable: doFinally"))),
+                            (Function<Object[], Object>) _ -> 0
+                    )
+                    .doOnEach(integerNotification -> System.out.println("combineLatestDelayError: " + integerNotification))
+                    .doFinally(() -> System.out.println("combineLatestDelayError: doFinally"))
                     .subscribe(testObserver);
 
             testScheduler.advanceTimeBy(100, TimeUnit.MILLISECONDS);
@@ -1178,12 +952,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
             }
         };
 
-        Observable.combineLatest(ps1, ps2, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) throws Exception {
-                return t1 + t2;
-            }
-        })
+        Observable.combineLatest(ps1, ps2, Integer::sum)
         .subscribe(to);
 
         ps1.onNext(1);
@@ -1197,12 +966,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
                     Observable.just(21).concatWith(Observable.<Integer>error(new TestException())),
                     Observable.just(21).delay(100, TimeUnit.MILLISECONDS)
                 ),
-                new Function<Object[], Object>() {
-                    @Override
-                    public Object apply(Object[] a) throws Exception {
-                        return (Integer)a[0] + (Integer)a[1];
-                    }
-                }
+                        (Function<Object[], Object>) a -> (Integer)a[0] + (Integer)a[1]
                 )
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1211,19 +975,9 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void observableSourcesInIterable() {
-        ObservableSource<Integer> source = new ObservableSource<Integer>() {
-            @Override
-            public void subscribe(Observer<? super Integer> observer) {
-                Observable.just(1).subscribe(observer);
-            }
-        };
+        ObservableSource<Integer> source = observer -> Observable.just(1).subscribe(observer);
 
-        Observable.combineLatest(Arrays.asList(source, source), new Function<Object[], Integer>() {
-            @Override
-            public Integer apply(Object[] t) throws Throwable {
-                return 2;
-            }
-        })
+        Observable.combineLatest(Arrays.asList(source, source), _ -> 2)
         .test()
         .assertResult(2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -113,28 +113,13 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
                 final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-                TestObserver<Void> to = ps1.concatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.fromObservable(ps2);
-                    }
-                }).test();
+                TestObserver<Void> to = ps1.concatMapCompletable(_ -> Completable.fromObservable(ps2)).test();
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex1);
+                Runnable r2 = () -> ps2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -160,11 +145,8 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void fusedPollThrows() {
         Observable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
         .concatMapCompletable(completableComplete())
         .test()
@@ -224,29 +206,16 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     }
 
     private Function<Integer, CompletableSource> completableComplete() {
-        return new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        };
+        return _ -> Completable.complete();
     }
 
     private Function<Integer, CompletableSource> completableError() {
-        return new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        };
+        return _ -> Completable.error(new TestException());
     }
 
     private Function<Integer, CompletableSource> completableThrows() {
-        return new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        return _ -> {
+            throw new TestException();
         };
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -38,12 +38,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normal() {
         Observable.range(1, 5)
-        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer t) {
-                return Observable.range(t, 2);
-            }
-        })
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2))
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -51,12 +46,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayBoundary() {
         Observable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer t) {
-                return Observable.range(t, 2);
-            }
-        }, false)
+        .concatMapEagerDelayError((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), false)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -64,12 +54,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayEnd() {
         Observable.range(1, 5)
-        .concatMapEagerDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer t) {
-                return Observable.range(t, 2);
-            }
-        }, true)
+        .concatMapEagerDelayError((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), true)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -80,12 +65,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final PublishSubject<Integer> inner = PublishSubject.create();
 
         TestObserverEx<Integer> to = main.concatMapEagerDelayError(
-                new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }, false).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, ObservableSource<Integer>>) _ -> inner, false).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
 
@@ -109,12 +89,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final PublishSubject<Integer> inner = PublishSubject.create();
 
         TestObserverEx<Integer> to = main.concatMapEagerDelayError(
-                new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }, true).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, ObservableSource<Integer>>) _ -> inner, true).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
         main.onNext(2);
@@ -139,12 +114,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final PublishSubject<Integer> inner = PublishSubject.create();
 
         TestObserverEx<Integer> to = main.concatMapEager(
-                new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer t) {
-                        return inner;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                (Function<Integer, ObservableSource<Integer>>) _ -> inner).to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
         main.onNext(2);
@@ -167,12 +137,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     public void longEager() {
 
         Observable.range(1, 2 * Observable.bufferSize())
-        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) {
-                return Observable.just(1);
-            }
-        })
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.just(1))
         .test()
         .assertValueCount(2 * Observable.bufferSize())
         .assertNoErrors()
@@ -181,19 +146,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     TestObserver<Object> to;
 
-    Function<Integer, Observable<Integer>> toJust = new Function<Integer, Observable<Integer>>() {
-        @Override
-        public Observable<Integer> apply(Integer t) {
-            return Observable.just(t);
-        }
-    };
+    Function<Integer, Observable<Integer>> toJust = Observable::just;
 
-    Function<Integer, Observable<Integer>> toRange = new Function<Integer, Observable<Integer>>() {
-        @Override
-        public Observable<Integer> apply(Integer t) {
-            return Observable.range(t, 2);
-        }
-    };
+    Function<Integer, Observable<Integer>> toRange = t -> Observable.range(t, 2);
 
     @Before
     public void before() {
@@ -221,12 +176,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness2() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source).subscribe(to);
 
@@ -240,12 +190,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness3() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source).subscribe(to);
 
@@ -259,12 +204,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness4() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source).subscribe(to);
 
@@ -278,12 +218,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness5() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source, source).subscribe(to);
 
@@ -297,12 +232,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness6() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source, source, source).subscribe(to);
 
@@ -316,12 +246,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness7() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source, source, source, source).subscribe(to);
 
@@ -335,12 +260,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness8() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source, source, source, source, source).subscribe(to);
 
@@ -354,12 +274,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void eagerness9() {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> source = Observable.just(1).doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                count.getAndIncrement();
-            }
-        }).hide();
+        Observable<Integer> source = Observable.just(1).doOnNext(_ -> count.getAndIncrement()).hide();
 
         Observable.concatArrayEager(source, source, source, source, source, source, source, source, source).subscribe(to);
 
@@ -406,11 +321,8 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void mapperThrows() {
-        Observable.just(1).concatMapEager(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                throw new TestException();
-            }
+        Observable.just(1).concatMapEager((Function<Integer, Observable<Integer>>) _ -> {
+            throw new TestException();
         }).subscribe(to);
 
         to.assertNoValues();
@@ -430,12 +342,8 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void asynchronousRun() {
-        Observable.range(1, 2).concatMapEager(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                return Observable.range(1, 1000).subscribeOn(Schedulers.computation());
-            }
-        }).observeOn(Schedulers.newThread()).subscribe(to);
+        Observable.range(1, 2).concatMapEager((Function<Integer, Observable<Integer>>) _ -> Observable.range(1, 1000)
+                .subscribeOn(Schedulers.computation())).observeOn(Schedulers.newThread()).subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -448,18 +356,10 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
         final AtomicBoolean once = new AtomicBoolean();
 
-        subject.concatMapEager(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                return Observable.just(t);
-            }
-        })
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer t) {
-                if (once.compareAndSet(false, true)) {
-                    subject.onNext(2);
-                }
+        subject.concatMapEager((Function<Integer, Observable<Integer>>) Observable::just)
+        .doOnNext(_ -> {
+            if (once.compareAndSet(false, true)) {
+                subject.onNext(2);
             }
         })
         .subscribe(to);
@@ -561,63 +461,35 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 2);
-            }
-        }));
+        TestHelper.checkDisposed(Observable.just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.range(1, 2)));
     }
 
     @Test
     public void empty() {
-        Observable.<Integer>empty().hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 2);
-            }
-        })
+        Observable.<Integer>empty().hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.range(1, 2))
         .test()
         .assertResult();
     }
 
     @Test
     public void innerError2() {
-        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        })
+        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void innerErrorMaxConcurrency() {
-        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        }, 1, 128)
+        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()), 1, 128)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void innerCallableThrows() {
-        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.fromCallable((Callable<Integer>) () -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -630,30 +502,15 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
                 final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-                TestObserverEx<Integer> to = ps1.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer v) throws Exception {
-                        return ps2;
-                    }
-                }).to(TestHelper.<Integer>testConsumer());
+                TestObserverEx<Integer> to = ps1.concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> ps2).to(TestHelper.<Integer>testConsumer());
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
                 ps1.onNext(1);
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex1);
+                Runnable r2 = () -> ps2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -682,25 +539,10 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final PublishSubject<Integer> ps1 = PublishSubject.create();
 
-            final TestObserver<Integer> to = ps1.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-                @Override
-                public ObservableSource<Integer> apply(Integer v) throws Exception {
-                    return Observable.never();
-                }
-            }).test();
+            final TestObserver<Integer> to = ps1.concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.never()).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps1.onNext(1);
-                }
-            };
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r1 = () -> ps1.onNext(1);
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
 
@@ -713,12 +555,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1).hide()
-        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                to.dispose();
-                return Observable.never();
-            }
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> {
+            to.dispose();
+            return Observable.never();
         }, 1, 128)
         .subscribe(to);
 
@@ -727,17 +566,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void innerErrorFused() {
-        Observable.<Integer>just(1).hide().concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 2).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer v) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.range(1, 2).map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -756,12 +587,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         };
 
         Observable.<Integer>just(1).hide()
-        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return us;
-            }
-        }, 1, 128)
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> us, 1, 128)
         .subscribe(to);
 
         to
@@ -775,12 +601,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         us.onNext(1);
         us.onComplete();
 
-        us.concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.just(1);
-            }
-        })
+        us.concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.just(1))
         .take(1)
         .test()
         .assertResult(1);
@@ -788,30 +609,15 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.concatMapEager(new Function<Object, ObservableSource<Object>>() {
-                    @Override
-                    public ObservableSource<Object> apply(Object v) throws Exception {
-                        return Observable.just(v);
-                    }
-                });
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.concatMapEager((Function<Object, ObservableSource<Object>>) Observable::just));
     }
 
     @Test
     public void oneDelayed() {
         Observable.just(1, 2, 3, 4, 5)
-        .concatMapEager(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer i) throws Exception {
-                return i == 3 ? Observable.just(i) : Observable
-                        .just(i)
-                        .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached());
-            }
-        })
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) i -> i == 3 ? Observable.just(i) : Observable
+                .just(i)
+                .delay(1, TimeUnit.MILLISECONDS, Schedulers.cached()))
         .observeOn(Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -833,21 +639,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
         Observable.range(1, 1000)
         .buffer(10)
-        .concatMapEager(new Function<List<Integer>, ObservableSource<List<Integer>>>() {
-            @Override
-            public ObservableSource<List<Integer>> apply(List<Integer> v)
-                    throws Exception {
-                return Observable.just(v)
-                        .subscribeOn(Schedulers.cached())
-                        .doOnNext(new Consumer<List<Integer>>() {
-                            @Override
-                            public void accept(List<Integer> v)
-                                    throws Exception {
-                                Thread.sleep(new Random().nextInt(20));
-                            }
-                        });
-            }
-        }
+        .concatMapEager((Function<List<Integer>, ObservableSource<List<Integer>>>) v -> Observable.just(v)
+                .subscribeOn(Schedulers.cached())
+                .doOnNext(_ -> Thread.sleep(new Random().nextInt(20)))
                 , 2, 3)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -992,47 +786,20 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapEager(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapEager((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapEagerDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, false);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapEagerDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapEagerDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapEagerDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -44,23 +44,14 @@ public class ObservableConcatMapSchedulerTest {
     public void boundaryFusion() {
         Observable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMap(new Function<String, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(String v)
-                    throws Exception {
-                return Observable.just(v);
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<String, ObservableSource<? extends Object>>) Observable::just, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -72,23 +63,14 @@ public class ObservableConcatMapSchedulerTest {
     public void boundaryFusionDelayError() {
         Observable.range(1, 10000)
         .observeOn(Schedulers.single())
-        .map(new Function<Integer, String>() {
-            @Override
-            public String apply(Integer t) throws Exception {
-                String name = Thread.currentThread().getName();
-                if (name.contains("RxSingleScheduler")) {
-                    return "RxSingleScheduler";
-                }
-                return name;
+        .map(_ -> {
+            String name = Thread.currentThread().getName();
+            if (name.contains("RxSingleScheduler")) {
+                return "RxSingleScheduler";
             }
+            return name;
         })
-        .concatMapDelayError(new Function<String, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(String v)
-                    throws Exception {
-                return Observable.just(v);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<String, ObservableSource<? extends Object>>) Observable::just, true, 2, ImmediateThinScheduler.INSTANCE)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -99,20 +81,11 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void pollThrows() {
         Observable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>observableStripBoundary())
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Observable.just(v);
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, ObservableSource<Integer>>) Observable::just, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -120,20 +93,11 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void pollThrowsDelayError() {
         Observable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
         .compose(TestHelper.<Integer>observableStripBoundary())
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v)
-                    throws Exception {
-                return Observable.just(v);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) Observable::just, true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
     }
@@ -143,17 +107,7 @@ public class ObservableConcatMapSchedulerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, 5)
-        .concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) throws Exception {
-                return Observable.just(v).doOnDispose(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        counter.getAndIncrement();
-                    }
-                });
-            }
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).doOnDispose(counter::getAndIncrement), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -163,18 +117,12 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void delayErrorCallableTillTheEnd() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override public Observable<Integer> apply(final Integer integer) throws Exception {
-                return Observable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        }, true, 2, ImmediateThinScheduler.INSTANCE)
+            return integer;
+        }), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -182,18 +130,12 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void delayErrorCallableEager() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override public Observable<Integer> apply(final Integer integer) throws Exception {
-                return Observable.fromCallable(new Callable<Integer>() {
-                    @Override public Integer call() throws Exception {
-                        if (integer >= 100) {
-                            throw new NullPointerException("test null exp");
-                        }
-                        return integer;
-                    }
-                });
+        .concatMapDelayError((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
+            if (integer >= 100) {
+                throw new NullPointerException("test null exp");
             }
-        }, false, 2, ImmediateThinScheduler.INSTANCE)
+            return integer;
+        }), false, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -201,12 +143,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperScheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMap(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName());
-            }
-        }, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -219,12 +156,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMap(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName()).hide();
-            }
-        }, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -237,12 +169,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayErrorScheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName());
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -255,12 +182,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayErrorScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName()).hide();
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), false, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -273,12 +195,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayError2Scheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName());
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -291,12 +208,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayError2ScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName()).hide();
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), true, 2, Schedulers.single())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -311,16 +223,13 @@ public class ObservableConcatMapSchedulerTest {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
-        Function<Integer, Observable<Integer>> func = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                Observable<Integer> flowable = Observable.just(t)
-                        .subscribeOn(sch)
-                ;
-                Subject<Integer> processor = UnicastSubject.create();
-                flowable.subscribe(processor);
-                return processor;
-            }
+        Function<Integer, Observable<Integer>> func = t -> {
+            Observable<Integer> flowable = Observable.just(t)
+                    .subscribeOn(sch)
+            ;
+            Subject<Integer> processor = UnicastSubject.create();
+            flowable.subscribe(processor);
+            return processor;
         };
 
         int n = 5000;
@@ -375,12 +284,7 @@ public class ObservableConcatMapSchedulerTest {
             }
             TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.range(0, 1000)
-            .concatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer t) {
-                    return Observable.fromIterable(Collections.singletonList(t));
-                }
-            }, 2, ImmediateThinScheduler.INSTANCE)
+            .concatMap((Function<Integer, Observable<Integer>>) t -> Observable.fromIterable(Collections.singletonList(t)), 2, ImmediateThinScheduler.INSTANCE)
             .observeOn(Schedulers.computation()).subscribe(to);
 
             to.awaitDone(2500, TimeUnit.MILLISECONDS);
@@ -518,12 +422,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapDelayErrorJustSource() {
         Observable.just(0)
-        .concatMapDelayError(new Function<Object, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Object v) throws Exception {
-                return Observable.just(1);
-            }
-        }, true, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<Object, Observable<Integer>>) _ -> Observable.just(1), true, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
 
@@ -532,12 +431,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapJustSource() {
         Observable.just(0).hide()
-        .concatMap(new Function<Object, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Object v) throws Exception {
-                return Observable.just(1);
-            }
-        }, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Object, Observable<Integer>>) _ -> Observable.just(1), 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -545,12 +439,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapJustSourceDelayError() {
         Observable.just(0).hide()
-        .concatMapDelayError(new Function<Object, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Object v) throws Exception {
-                return Observable.just(1);
-            }
-        }, false, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMapDelayError((Function<Object, Observable<Integer>>) _ -> Observable.just(1), false, 16, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertResult(1);
     }
@@ -573,18 +462,8 @@ public class ObservableConcatMapSchedulerTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Observable.just(2)), 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Observable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.concatMap(Functions.justFunction(Observable.just(2)), 2, ImmediateThinScheduler.INSTANCE));
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.concatMapDelayError(Functions.justFunction(Observable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
@@ -653,12 +532,7 @@ public class ObservableConcatMapSchedulerTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> f) throws Exception {
-                return f.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE);
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(f -> f.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
     }
 
     @Test
@@ -715,21 +589,14 @@ public class ObservableConcatMapSchedulerTest {
 
     @Test
     public void badSourceDelayError() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> f) throws Exception {
-                return f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()), true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        }, true, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(f -> f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()),
+                true, 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
     }
 
     @Test
     public void fusedCrash() {
         Observable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -738,10 +605,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void fusedCrashDelayError() {
         Observable.range(1, 2)
-        .map(new Function<Integer, Object>() {
-            @Override
-            public Object apply(Integer v) throws Exception { throw new TestException(); }
-        })
+        .map(_ -> { throw new TestException(); })
         .concatMapDelayError(Functions.justFunction(Observable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -750,11 +614,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void callableCrash() {
         Observable.just(1).hide()
-        .concatMap(Functions.justFunction(Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMap(Functions.justFunction(Observable.fromCallable(() -> {
+            throw new TestException();
         })), 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -763,11 +624,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void callableCrashDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        .concatMapDelayError(Functions.justFunction(Observable.fromCallable(() -> {
+            throw new TestException();
         })), true, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -801,11 +659,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperThrows() {
         Observable.range(1, 2)
-        .concatMap(new Function<Integer, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMap((Function<Integer, ObservableSource<Object>>) _ -> {
+            throw new TestException();
         }, 2, ImmediateThinScheduler.INSTANCE)
         .test()
         .assertFailure(TestException.class);
@@ -817,12 +672,7 @@ public class ObservableConcatMapSchedulerTest {
 
         TestObserver<Integer> to = TestObserver.create();
 
-        source.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.range(v, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        source.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.range(v, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         source.onNext(1);
         source.onNext(2);
@@ -840,12 +690,7 @@ public class ObservableConcatMapSchedulerTest {
 
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.range(1, 3).concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.range(1, 3).concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 1, 2, 1, 2);
         to.assertError(CompositeException.class);
@@ -860,12 +705,7 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return inner;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2);
         to.assertError(TestException.class);
@@ -878,12 +718,7 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return null;
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> null, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertNoValues();
         to.assertError(NullPointerException.class);
@@ -896,11 +731,8 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                throw new TestException();
-            }
+        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> {
+            throw new TestException();
         }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertNoValues();
@@ -913,12 +745,7 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<Integer> to = TestObserver.create();
 
         Observable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMapDelayError(v -> v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
 
         to.assertValues(1, 2, 1, 2);
         to.assertNoErrors();
@@ -930,12 +757,8 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<Integer> to = TestObserver.create();
 
         Observable.range(1, 3)
-        .concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return v == 2 ? Observable.just(3) : Observable.range(1, 2);
-            }
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMapDelayError(v -> v == 2 ? Observable.just(3) : Observable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(to);
 
         to.assertValues(1, 2, 3, 1, 2);
         to.assertNoErrors();
@@ -947,14 +770,9 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<String> to = Observable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMap(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -970,14 +788,9 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<String> to = Observable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, false, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), false, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -993,14 +806,9 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<String> to = Observable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError(new Function<Integer, Observable<String>>() {
-            @Override
-            public Observable<String> apply(Integer t) throws Throwable {
-                return Observable.just(Thread.currentThread().getName())
-                        .repeat(1000)
-                        .observeOn(Schedulers.cached());
-            }
-        }, true, 2, Schedulers.single())
+        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
+                .repeat(1000)
+                .observeOn(Schedulers.cached()), true, 2, Schedulers.single())
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -1013,47 +821,20 @@ public class ObservableConcatMapSchedulerTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMap(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, false, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, true, 2, ImmediateThinScheduler.INSTANCE);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true, 2, ImmediateThinScheduler.INSTANCE));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
@@ -38,12 +38,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void asyncFused() {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
-        TestObserver<Integer> to = us.concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        TestObserver<Integer> to = us.concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test();
 
         us.onNext(1);
@@ -55,34 +50,19 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        }));
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException())));
     }
 
     @Test
     public void dispose2() {
         TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        }));
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException())));
     }
 
     @Test
     public void mainError() {
         Observable.<Integer>error(new TestException())
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -90,12 +70,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void innerError() {
         Observable.<Integer>just(1).hide()
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        })
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
@@ -103,12 +78,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void mainErrorDelayed() {
         Observable.<Integer>error(new TestException())
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -116,12 +86,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void innerErrorDelayError() {
         Observable.<Integer>just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.error(new TestException());
-            }
-        })
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()))
         .test()
         .assertFailure(TestException.class);
     }
@@ -129,17 +94,9 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void innerErrorDelayError2() {
         Observable.<Integer>just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.fromCallable((Callable<Integer>) () -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -160,12 +117,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-                @Override
-                public ObservableSource<Integer> apply(Integer v) throws Exception {
-                    return Observable.range(v, 2);
-                }
-            })
+            .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
             .test()
             .assertResult(1, 2);
 
@@ -191,12 +143,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-                @Override
-                public ObservableSource<Integer> apply(Integer v) throws Exception {
-                    return Observable.range(v, 2);
-                }
-            })
+            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
             .test()
             .assertResult(1, 2);
 
@@ -209,12 +156,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void normalDelayErrors() {
         Observable.just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test()
         .assertResult(1, 2);
     }
@@ -222,12 +164,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void normalDelayErrorsTillTheEnd() {
         Observable.just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        }, true, 16)
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), true, 16)
         .test()
         .assertResult(1, 2);
     }
@@ -240,28 +177,13 @@ public class ObservableConcatMapTest extends RxJavaTest {
                 final PublishSubject<Integer> ps1 = PublishSubject.create();
                 final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-                TestObserver<Integer> to = ps1.concatMap(new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer v) throws Exception {
-                        return ps2;
-                    }
-                }).test();
+                TestObserver<Integer> to = ps1.concatMap((Function<Integer, ObservableSource<Integer>>) _ -> ps2).test();
 
                 final TestException ex1 = new TestException();
                 final TestException ex2 = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps1.onError(ex1);
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps2.onError(ex2);
-                    }
-                };
+                Runnable r1 = () -> ps1.onError(ex1);
+                Runnable r2 = () -> ps2.onError(ex2);
 
                 TestHelper.race(r1, r2);
 
@@ -279,11 +201,8 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void mapperThrows() {
         Observable.just(1).hide()
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -292,18 +211,10 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void fusedPollThrows() {
         Observable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -311,18 +222,10 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void fusedPollThrowsDelayError() {
         Observable.just(1)
-        .map(new Function<Integer, Integer>() {
-            @Override
-            public Integer apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
         })
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(v, 2);
-            }
-        })
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
         .test()
         .assertFailure(TestException.class);
     }
@@ -330,11 +233,8 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void mapperThrowsDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -349,17 +249,12 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         try {
             Observable.just(1).hide()
-            .concatMapDelayError(new Function<Integer, ObservableSource<Integer>>() {
+            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<Integer>() {
                 @Override
-                public ObservableSource<Integer> apply(Integer v) throws Exception {
-                    return new Observable<Integer>() {
-                        @Override
-                        protected void subscribeActual(Observer<? super Integer> observer) {
-                            o[0] = observer;
-                            observer.onSubscribe(Disposable.empty());
-                            observer.onComplete();
-                        }
-                    };
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    o[0] = observer;
+                    observer.onSubscribe(Disposable.empty());
+                    observer.onComplete();
                 }
             })
             .test()
@@ -439,13 +334,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> to = ps.concatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer v)
-                        throws Exception {
-                    return Observable.just(v + 1);
-                }
-            }, 1)
+            TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
             .subscribeWith(new TestObserver<Integer>() {
                 @Override
                 public void onNext(Integer t) {
@@ -475,13 +364,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void reentrantNoOverflowHidden() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = ps.concatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v)
-                    throws Exception {
-                return Observable.just(v + 1).hide();
-            }
-        }, 1)
+        TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
         .subscribeWith(new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -505,17 +388,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, 5)
-        .concatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.just(v).doOnDispose(new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        counter.getAndIncrement();
-                    }
-                });
-            }
-        })
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v).doOnDispose(counter::getAndIncrement))
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -524,47 +397,20 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMap(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, false, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false, 2));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.concatMapDelayError(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, true, 2);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true, 2));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
@@ -82,17 +82,12 @@ public class ObservableConcatTest extends RxJavaTest {
         final Observable<String> odds = Observable.fromArray(o);
         final Observable<String> even = Observable.fromArray(e);
 
-        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
-
-            @Override
-            public void subscribe(Observer<? super Observable<String>> observer) {
-                observer.onSubscribe(Disposable.empty());
-                // simulate what would happen in an Observable
-                observer.onNext(odds);
-                observer.onNext(even);
-                observer.onComplete();
-            }
-
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(observer1 -> {
+            observer1.onSubscribe(Disposable.empty());
+            // simulate what would happen in an Observable
+            observer1.onNext(odds);
+            observer1.onNext(even);
+            observer1.onComplete();
         });
         Observable<String> concat = Observable.concat(observableOfObservables);
 
@@ -157,51 +152,43 @@ public class ObservableConcatTest extends RxJavaTest {
         final CountDownLatch parentHasStarted = new CountDownLatch(1);
         final CountDownLatch parentHasFinished = new CountDownLatch(1);
 
-        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
-
-            @Override
-            public void subscribe(final Observer<? super Observable<String>> observer) {
-                final Disposable d = Disposable.empty();
-                observer.onSubscribe(d);
-                parent.set(new Thread(new Runnable() {
-
-                    @Override
-                    public void run() {
-                        try {
-                            // emit first
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o1");
-                                observer.onNext(Observable.unsafeCreate(o1));
-                            }
-                            // emit second
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o2");
-                                observer.onNext(Observable.unsafeCreate(o2));
-                            }
-
-                            // wait until sometime later and emit third
-                            try {
-                                allowThird.await();
-                            } catch (InterruptedException e) {
-                                observer.onError(e);
-                            }
-                            if (!d.isDisposed()) {
-                                System.out.println("Emit o3");
-                                observer.onNext(Observable.unsafeCreate(o3));
-                            }
-
-                        } catch (Throwable e) {
-                            observer.onError(e);
-                        } finally {
-                            System.out.println("Done parent Observable");
-                            observer.onComplete();
-                            parentHasFinished.countDown();
-                        }
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(observer1 -> {
+            final Disposable d = Disposable.empty();
+            observer1.onSubscribe(d);
+            parent.set(new Thread(() -> {
+                try {
+                    // emit first
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o1");
+                        observer1.onNext(Observable.unsafeCreate(o1));
                     }
-                }));
-                parent.get().start();
-                parentHasStarted.countDown();
-            }
+                    // emit second
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o2");
+                        observer1.onNext(Observable.unsafeCreate(o2));
+                    }
+
+                    // wait until sometime later and emit third
+                    try {
+                        allowThird.await();
+                    } catch (InterruptedException e) {
+                        observer1.onError(e);
+                    }
+                    if (!d.isDisposed()) {
+                        System.out.println("Emit o3");
+                        observer1.onNext(Observable.unsafeCreate(o3));
+                    }
+
+                } catch (Throwable e) {
+                    observer1.onError(e);
+                } finally {
+                    System.out.println("Done parent Observable");
+                    observer1.onComplete();
+                    parentHasFinished.countDown();
+                }
+            }));
+            parent.get().start();
+            parentHasStarted.countDown();
         });
 
         Observable.concat(observableOfObservables).subscribe(observer);
@@ -343,17 +330,12 @@ public class ObservableConcatTest extends RxJavaTest {
 
         Observer<String> observer = TestHelper.mockObserver();
 
-        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(new ObservableSource<Observable<String>>() {
-
-            @Override
-            public void subscribe(Observer<? super Observable<String>> observer) {
-                observer.onSubscribe(Disposable.empty());
-                // simulate what would happen in an Observable
-                observer.onNext(Observable.unsafeCreate(w1));
-                observer.onNext(Observable.unsafeCreate(w2));
-                observer.onComplete();
-            }
-
+        Observable<Observable<String>> observableOfObservables = Observable.unsafeCreate(observer1 -> {
+            observer1.onSubscribe(Disposable.empty());
+            // simulate what would happen in an Observable
+            observer1.onNext(Observable.unsafeCreate(w1));
+            observer1.onNext(Observable.unsafeCreate(w2));
+            observer1.onComplete();
         });
         Observable<String> concat = Observable.concat(observableOfObservables);
         concat.subscribe(observer);
@@ -516,36 +498,31 @@ public class ObservableConcatTest extends RxJavaTest {
         @Override
         public void subscribe(final Observer<? super T> observer) {
             observer.onSubscribe(upstream);
-            t = new Thread(new Runnable() {
-
-                @Override
-                public void run() {
-                    try {
-                        while (count < size && subscribed) {
-                            if (null != values) {
-                                observer.onNext(values.get(count));
-                            } else {
-                                observer.onNext(seed);
-                            }
-                            count++;
-                            //Unblock the main thread to call unsubscribe.
-                            if (null != once) {
-                                once.countDown();
-                            }
-                            //Block until the main thread has called unsubscribe.
-                            if (null != okToContinue) {
-                                okToContinue.await(5, TimeUnit.SECONDS);
-                            }
+            t = new Thread(() -> {
+                try {
+                    while (count < size && subscribed) {
+                        if (null != values) {
+                            observer.onNext(values.get(count));
+                        } else {
+                            observer.onNext(seed);
                         }
-                        if (subscribed) {
-                            observer.onComplete();
+                        count++;
+                        //Unblock the main thread to call unsubscribe.
+                        if (null != once) {
+                            once.countDown();
                         }
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        fail(e.getMessage());
+                        //Block until the main thread has called unsubscribe.
+                        if (null != okToContinue) {
+                            okToContinue.await(5, TimeUnit.SECONDS);
+                        }
                     }
+                    if (subscribed) {
+                        observer.onComplete();
+                    }
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    fail(e.getMessage());
                 }
-
             });
             t.start();
             threadHasStarted.countDown();
@@ -603,12 +580,7 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatVeryLongObservableOfObservables() {
         final int n = 10000;
-        Observable<Observable<Integer>> source = Observable.range(0, n).map(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        Observable<Observable<Integer>> source = Observable.range(0, n).map(Observable::just);
 
         Single<List<Integer>> result = Observable.concat(source).toList();
 
@@ -628,12 +600,7 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatVeryLongObservableOfObservablesTakeHalf() {
         final int n = 10000;
-        Observable<Observable<Integer>> source = Observable.range(0, n).map(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v) {
-                return Observable.just(v);
-            }
-        });
+        Observable<Observable<Integer>> source = Observable.range(0, n).map(Observable::just);
 
         Single<List<Integer>> result = Observable.concat(source).take(n / 2).toList();
 
@@ -662,16 +629,11 @@ public class ObservableConcatTest extends RxJavaTest {
     // https://github.com/ReactiveX/RxJava/issues/1818
     @Test
     public void concatWithNonCompliantSourceDoubleOnComplete() {
-        Observable<String> o = Observable.unsafeCreate(new ObservableSource<String>() {
-
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext("hello");
-                observer.onComplete();
-                observer.onComplete();
-            }
-
+        Observable<String> o = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext("hello");
+            observer.onComplete();
+            observer.onComplete();
         });
 
         TestObserverEx<String> to = new TestObserverEx<>();
@@ -687,16 +649,13 @@ public class ObservableConcatTest extends RxJavaTest {
         final ExecutorService executor = Executors.newFixedThreadPool(2);
         final Scheduler sch = Schedulers.from(executor);
 
-        Function<Integer, Observable<Integer>> func = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t) {
-                Observable<Integer> o = Observable.just(t)
-                        .subscribeOn(sch)
-                ;
-                Subject<Integer> subject = UnicastSubject.create();
-                o.subscribe(subject);
-                return subject;
-            }
+        Function<Integer, Observable<Integer>> func = t -> {
+            Observable<Integer> o = Observable.just(t)
+                    .subscribeOn(sch)
+            ;
+            Subject<Integer> subject = UnicastSubject.create();
+            o.subscribe(subject);
+            return subject;
         };
 
         int n = 5000;
@@ -752,12 +711,7 @@ public class ObservableConcatTest extends RxJavaTest {
             TestObserverEx<Integer> to = new TestObserverEx<>();
 
             Observable.range(0, 1000)
-            .concatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer t) {
-                    return Observable.fromIterable(Collections.singletonList(t));
-                }
-            })
+            .concatMap((Function<Integer, Observable<Integer>>) t -> Observable.fromIterable(Collections.singletonList(t)))
             .observeOn(Schedulers.computation())
             .subscribe(to);
 
@@ -878,12 +832,7 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapIterableBufferSize() {
 
-        Observable.just(1, 2).concatMapIterable(new Function<Integer, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Integer v) throws Exception {
-                return Arrays.asList(1, 2, 3, 4, 5);
-            }
-        })
+        Observable.just(1, 2).concatMapIterable((Function<Integer, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3, 4, 5))
         .test()
         .assertResult(1, 2, 3, 4, 5, 1, 2, 3, 4, 5);
     }
@@ -901,23 +850,13 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapDelayErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .concatMapDelayError(new Function<Object, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Object v) throws Exception {
-                        return Observable.just(1);
-                    }
-                }, true, 16));
+                .concatMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), true, 16));
     }
 
     @Test
     public void concatMapDelayErrorJustSource() {
         Observable.just(0)
-        .concatMapDelayError(new Function<Object, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Object v) throws Exception {
-                return Observable.just(1);
-            }
-        }, true, 16)
+        .concatMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), true, 16)
         .test()
         .assertResult(1);
 
@@ -936,23 +875,13 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .concatMap(new Function<Object, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Object v) throws Exception {
-                        return Observable.just(1);
-                    }
-                }, 16));
+                .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16));
     }
 
     @Test
     public void concatMapJustSource() {
         Observable.just(0)
-        .concatMap(new Function<Object, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Object v) throws Exception {
-                return Observable.just(1);
-            }
-        }, 16)
+        .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16)
         .test()
         .assertResult(1);
 
@@ -962,13 +891,10 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noSubsequentSubscription() {
         final int[] calls = { 0 };
 
-        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Observable<Integer> source = Observable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         });
 
         Observable.concatArray(source, source).firstElement()
@@ -982,13 +908,10 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noSubsequentSubscriptionDelayError() {
         final int[] calls = { 0 };
 
-        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Observable<Integer> source = Observable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         });
 
         Observable.concatArrayDelayError(source, source).firstElement()
@@ -1002,13 +925,10 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noSubsequentSubscriptionIterable() {
         final int[] calls = { 0 };
 
-        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Observable<Integer> source = Observable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         });
 
         Observable.concat(Arrays.asList(source, source)).firstElement()
@@ -1022,13 +942,10 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noSubsequentSubscriptionDelayErrorIterable() {
         final int[] calls = { 0 };
 
-        Observable<Integer> source = Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> s) throws Exception {
-                calls[0]++;
-                s.onNext(1);
-                s.onComplete();
-            }
+        Observable<Integer> source = Observable.create(s -> {
+            calls[0]++;
+            s.onNext(1);
+            s.onComplete();
         });
 
         Observable.concatDelayError(Arrays.asList(source, source)).firstElement()
@@ -1154,12 +1071,7 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noCancelPreviousArray() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Observable<Integer> source = Observable.just(1).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Observable<Integer> source = Observable.just(1).doOnDispose(counter::getAndIncrement);
 
         Observable.concatArray(source, source, source, source, source)
         .test()
@@ -1172,12 +1084,7 @@ public class ObservableConcatTest extends RxJavaTest {
     public void noCancelPreviousIterable() {
         final AtomicInteger counter = new AtomicInteger();
 
-        Observable<Integer> source = Observable.just(1).doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter.getAndIncrement();
-            }
-        });
+        Observable<Integer> source = Observable.just(1).doOnDispose(counter::getAndIncrement);
 
         Observable.concat(Arrays.asList(source, source, source, source, source))
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.MaybeSubject;
 
@@ -31,12 +30,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> to.onNext(100)))
         .subscribe(to);
 
         to.assertResult(1, 2, 3, 4, 5, 100);
@@ -58,12 +52,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.<Integer>error(new TestException())
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> to.onNext(100)))
         .subscribe(to);
 
         to.assertFailure(TestException.class);
@@ -85,12 +74,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.range(1, 5)
-        .concatWith(Maybe.<Integer>fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.onNext(100);
-            }
-        }))
+        .concatWith(Maybe.<Integer>fromAction(() -> to.onNext(100)))
         .take(3)
         .subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Cancellable;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.*;
@@ -37,20 +36,17 @@ public class ObservableCreateTest extends RxJavaTest {
     public void basic() {
         final Disposable d = Disposable.empty();
 
-        Observable.<Integer>create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+        Observable.<Integer>create(e -> {
+            e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
+            e.onNext(1);
+            e.onNext(2);
+            e.onNext(3);
+            e.onComplete();
+            e.onError(new TestException());
+            e.onNext(4);
+            e.onError(new TestException());
+            e.onComplete();
         })
         .test()
         .assertResult(1, 2, 3);
@@ -64,26 +60,18 @@ public class ObservableCreateTest extends RxJavaTest {
         final Disposable d1 = Disposable.empty();
         final Disposable d2 = Disposable.empty();
 
-        Observable.<Integer>create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d1);
-                e.setCancellable(new Cancellable() {
-                    @Override
-                    public void cancel() throws Exception {
-                        d2.dispose();
-                    }
-                });
+        Observable.<Integer>create(e -> {
+            e.setDisposable(d1);
+            e.setCancellable(d2::dispose);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
+            e.onNext(1);
+            e.onNext(2);
+            e.onNext(3);
+            e.onComplete();
+            e.onError(new TestException());
+            e.onNext(4);
+            e.onError(new TestException());
+            e.onComplete();
         })
         .test()
         .assertResult(1, 2, 3);
@@ -97,19 +85,16 @@ public class ObservableCreateTest extends RxJavaTest {
     public void basicWithError() {
         final Disposable d = Disposable.empty();
 
-        Observable.<Integer>create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e.setDisposable(d);
+        Observable.<Integer>create(e -> {
+            e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onError(new TestException());
-                e.onComplete();
-                e.onNext(4);
-                e.onError(new TestException());
-            }
+            e.onNext(1);
+            e.onNext(2);
+            e.onNext(3);
+            e.onError(new TestException());
+            e.onComplete();
+            e.onNext(4);
+            e.onError(new TestException());
         })
         .test()
         .assertFailure(TestException.class, 1, 2, 3);
@@ -122,22 +107,19 @@ public class ObservableCreateTest extends RxJavaTest {
     public void basicSerialized() {
         final Disposable d = Disposable.empty();
 
-        Observable.<Integer>create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
+        Observable.<Integer>create(e -> {
+            e = e.serialize();
 
-                e.setDisposable(d);
+            e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onComplete();
-                e.onError(new TestException());
-                e.onNext(4);
-                e.onError(new TestException());
-                e.onComplete();
-            }
+            e.onNext(1);
+            e.onNext(2);
+            e.onNext(3);
+            e.onComplete();
+            e.onError(new TestException());
+            e.onNext(4);
+            e.onError(new TestException());
+            e.onComplete();
         })
         .test()
         .assertResult(1, 2, 3);
@@ -150,21 +132,18 @@ public class ObservableCreateTest extends RxJavaTest {
     public void basicWithErrorSerialized() {
         final Disposable d = Disposable.empty();
 
-        Observable.<Integer>create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
+        Observable.<Integer>create(e -> {
+            e = e.serialize();
 
-                e.setDisposable(d);
+            e.setDisposable(d);
 
-                e.onNext(1);
-                e.onNext(2);
-                e.onNext(3);
-                e.onError(new TestException());
-                e.onComplete();
-                e.onNext(4);
-                e.onError(new TestException());
-            }
+            e.onNext(1);
+            e.onNext(2);
+            e.onNext(3);
+            e.onError(new TestException());
+            e.onComplete();
+            e.onNext(4);
+            e.onError(new TestException());
         })
         .test()
         .assertFailure(TestException.class, 1, 2, 3);
@@ -174,17 +153,14 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void wrap() {
-        Observable.wrap(new ObservableSource<Integer>() {
-            @Override
-            public void subscribe(Observer<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext(1);
-                observer.onNext(2);
-                observer.onNext(3);
-                observer.onNext(4);
-                observer.onNext(5);
-                observer.onComplete();
-            }
+        Observable.wrap((ObservableSource<Integer>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext(1);
+            observer.onNext(2);
+            observer.onNext(3);
+            observer.onNext(4);
+            observer.onNext(5);
+            observer.onComplete();
         })
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -192,17 +168,14 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void unsafe() {
-        Observable.unsafeCreate(new ObservableSource<Integer>() {
-            @Override
-            public void subscribe(Observer<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onNext(1);
-                observer.onNext(2);
-                observer.onNext(3);
-                observer.onNext(4);
-                observer.onNext(5);
-                observer.onComplete();
-            }
+        Observable.unsafeCreate((ObservableSource<Integer>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onNext(1);
+            observer.onNext(2);
+            observer.onNext(3);
+            observer.onNext(4);
+            observer.onNext(5);
+            observer.onComplete();
         })
         .test()
         .assertResult(1, 2, 3, 4, 5);
@@ -218,17 +191,14 @@ public class ObservableCreateTest extends RxJavaTest {
     public void createNullValue() {
         final Throwable[] error = { null };
 
-        Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
-                }
+        Observable.create((ObservableOnSubscribe<Integer>) e -> {
+            try {
+                e.onNext(null);
+                e.onNext(1);
+                e.onError(new TestException());
+                e.onComplete();
+            } catch (Throwable ex) {
+                error[0] = ex;
             }
         })
         .test()
@@ -242,18 +212,15 @@ public class ObservableCreateTest extends RxJavaTest {
     public void createNullValueSerialized() {
         final Throwable[] error = { null };
 
-        Observable.create(new ObservableOnSubscribe<Integer>() {
-            @Override
-            public void subscribe(ObservableEmitter<Integer> e) throws Exception {
-                e = e.serialize();
-                try {
-                    e.onNext(null);
-                    e.onNext(1);
-                    e.onError(new TestException());
-                    e.onComplete();
-                } catch (Throwable ex) {
-                    error[0] = ex;
-                }
+        Observable.create((ObservableOnSubscribe<Integer>) e -> {
+            e = e.serialize();
+            try {
+                e.onNext(null);
+                e.onNext(1);
+                e.onError(new TestException());
+                e.onComplete();
+            } catch (Throwable ex) {
+                error[0] = ex;
             }
         })
         .test()
@@ -264,11 +231,8 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void callbackThrows() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                throw new TestException();
-            }
+        Observable.create(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -276,67 +240,44 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void nullValue() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                e.onNext(null);
-            }
-        })
+        Observable.create(e -> e.onNext(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void nullThrowable() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                e.onError(null);
-            }
-        })
+        Observable.create(e -> e.onError(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void nullValueSync() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                e.serialize().onNext(null);
-            }
-        })
+        Observable.create(e -> e.serialize().onNext(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void nullThrowableSync() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                e.serialize().onError(null);
-            }
-        })
+        Observable.create(e -> e.serialize().onError(null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void onErrorCrash() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                Disposable d = Disposable.empty();
-                e.setDisposable(d);
-                try {
-                    e.onError(new IOException());
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-                assertTrue(d.isDisposed());
+        Observable.create(e -> {
+            Disposable d = Disposable.empty();
+            e.setDisposable(d);
+            try {
+                e.onError(new IOException());
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+            assertTrue(d.isDisposed());
         })
         .subscribe(new Observer<Object>() {
             @Override
@@ -360,19 +301,16 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void onCompleteCrash() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                Disposable d = Disposable.empty();
-                e.setDisposable(d);
-                try {
-                    e.onComplete();
-                    fail("Should have thrown");
-                } catch (TestException ex) {
-                    // expected
-                }
-                assertTrue(d.isDisposed());
+        Observable.create(e -> {
+            Disposable d = Disposable.empty();
+            e.setDisposable(d);
+            try {
+                e.onComplete();
+                fail("Should have thrown");
+            } catch (TestException ex) {
+                // expected
             }
+            assertTrue(d.isDisposed());
         })
         .subscribe(new Observer<Object>() {
             @Override
@@ -398,30 +336,22 @@ public class ObservableCreateTest extends RxJavaTest {
     public void serialized() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable.create(new ObservableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                    ObservableEmitter<Object> f = e.serialize();
+            Observable.create(e -> {
+                ObservableEmitter<Object> f = e.serialize();
 
-                    assertSame(f, f.serialize());
+                assertSame(f, f.serialize());
 
-                    assertFalse(f.isDisposed());
+                assertFalse(f.isDisposed());
 
-                    final int[] calls = { 0 };
+                final int[] calls = { 0 };
 
-                    f.setCancellable(new Cancellable() {
-                        @Override
-                        public void cancel() throws Exception {
-                            calls[0]++;
-                        }
-                    });
+                f.setCancellable(() -> calls[0]++);
 
-                    e.onComplete();
+                e.onComplete();
 
-                    assertTrue(f.isDisposed());
+                assertTrue(f.isDisposed());
 
-                    assertEquals(1, calls[0]);
-                }
+                assertEquals(1, calls[0]);
             })
             .test()
             .assertResult();
@@ -434,22 +364,16 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void serializedConcurrentOnNext() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                final ObservableEmitter<Object> f = e.serialize();
+        Observable.create(e -> {
+            final ObservableEmitter<Object> f = e.serialize();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                            f.onNext(1);
-                        }
-                    }
-                };
+            Runnable r1 = () -> {
+                for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+                    f.onNext(1);
+                }
+            };
 
-                TestHelper.race(r1, r1);
-            }
+            TestHelper.race(r1, r1);
         })
         .take(TestHelper.RACE_DEFAULT_LOOPS)
         .to(TestHelper.<Object>testConsumer())
@@ -461,32 +385,23 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void serializedConcurrentOnNextOnError() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                final ObservableEmitter<Object> f = e.serialize();
+        Observable.create(e -> {
+            final ObservableEmitter<Object> f = e.serialize();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < 1000; i++) {
-                            f.onNext(1);
-                        }
-                    }
-                };
+            Runnable r1 = () -> {
+                for (int i = 0; i < 1000; i++) {
+                    f.onNext(1);
+                }
+            };
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < 100; i++) {
-                            f.onNext(1);
-                        }
-                        f.onError(new TestException());
-                    }
-                };
+            Runnable r2 = () -> {
+                for (int i = 0; i < 100; i++) {
+                    f.onNext(1);
+                }
+                f.onError(new TestException());
+            };
 
-                TestHelper.race(r1, r2);
-            }
+            TestHelper.race(r1, r2);
         })
         .to(TestHelper.<Object>testConsumer())
         .assertSubscribed()
@@ -496,32 +411,23 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void serializedConcurrentOnNextOnComplete() {
-        TestObserverEx<Object> to = Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                final ObservableEmitter<Object> f = e.serialize();
+        TestObserverEx<Object> to = Observable.create(e -> {
+            final ObservableEmitter<Object> f = e.serialize();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < 1000; i++) {
-                            f.onNext(1);
-                        }
-                    }
-                };
+            Runnable r1 = () -> {
+                for (int i = 0; i < 1000; i++) {
+                    f.onNext(1);
+                }
+            };
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        for (int i = 0; i < 100; i++) {
-                            f.onNext(1);
-                        }
-                        f.onComplete();
-                    }
-                };
+            Runnable r2 = () -> {
+                for (int i = 0; i < 100; i++) {
+                    f.onNext(1);
+                }
+                f.onComplete();
+            };
 
-                TestHelper.race(r1, r2);
-            }
+            TestHelper.race(r1, r2);
         })
         .to(TestHelper.<Object>testConsumer())
         .assertSubscribed()
@@ -534,29 +440,16 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void onErrorRace() {
-        Observable<Object> source = Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                final ObservableEmitter<Object> f = e.serialize();
+        Observable<Object> source = Observable.create(e -> {
+            final ObservableEmitter<Object> f = e.serialize();
 
-                final TestException ex = new TestException();
+            final TestException ex = new TestException();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        f.onError(null);
-                    }
-                };
+            Runnable r1 = () -> f.onError(null);
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        f.onError(ex);
-                    }
-                };
+            Runnable r2 = () -> f.onError(ex);
 
-                TestHelper.race(r1, r2);
-            }
+            TestHelper.race(r1, r2);
         });
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -575,27 +468,14 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void onCompleteRace() {
-        Observable<Object> source = Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                final ObservableEmitter<Object> f = e.serialize();
+        Observable<Object> source = Observable.create(e -> {
+            final ObservableEmitter<Object> f = e.serialize();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        f.onComplete();
-                    }
-                };
+            Runnable r1 = f::onComplete;
 
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        f.onComplete();
-                    }
-                };
+            Runnable r2 = f::onComplete;
 
-                TestHelper.race(r1, r2);
-            }
+            TestHelper.race(r1, r2);
         });
 
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -610,12 +490,9 @@ public class ObservableCreateTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final Boolean[] response = { null };
-            Observable.create(new ObservableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                    e.onNext(1);
-                    response[0] = e.tryOnError(new TestException());
-                }
+            Observable.create(e -> {
+                e.onNext(1);
+                response[0] = e.tryOnError(new TestException());
             })
             .take(1)
             .test()
@@ -634,13 +511,10 @@ public class ObservableCreateTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final Boolean[] response = { null };
-            Observable.create(new ObservableOnSubscribe<Object>() {
-                @Override
-                public void subscribe(ObservableEmitter<Object> e) throws Exception {
-                    e = e.serialize();
-                    e.onNext(1);
-                    response[0] = e.tryOnError(new TestException());
-                }
+            Observable.create(e -> {
+                e = e.serialize();
+                e.onNext(1);
+                response[0] = e.tryOnError(new TestException());
             })
             .take(1)
             .test()
@@ -656,12 +530,9 @@ public class ObservableCreateTest extends RxJavaTest {
 
     @Test
     public void emitterHasToString() {
-        Observable.create(new ObservableOnSubscribe<Object>() {
-            @Override
-            public void subscribe(ObservableEmitter<Object> emitter) throws Exception {
-                assertTrue(emitter.toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
-                assertTrue(emitter.serialize().toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
-            }
+        Observable.create(emitter -> {
+            assertTrue(emitter.toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
+            assertTrue(emitter.serialize().toString().contains(ObservableCreate.CreateEmitter.class.getSimpleName()));
         }).test().assertEmpty();
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
@@ -24,8 +24,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.rxjava4.functions.Action;
 import org.junit.*;
 import org.mockito.InOrder;
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
@@ -53,16 +51,13 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithOnDroppedCallbackWithEx() throws Throwable {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishNext(observer, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishNext(observer, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Action whenDisposed = mock(Action.class);
@@ -91,16 +86,13 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithOnDroppedCallback() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishNext(observer, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishNext(observer, 999, "four");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Observer<Object> drops = TestHelper.mockObserver();
@@ -123,15 +115,12 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithCompleted() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
-                publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
-                publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
-                publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            publishNext(observer, 100, "one");    // Should be skipped since "two" will arrive before the timeout expires.
+            publishNext(observer, 400, "two");    // Should be published since "three" will arrive after the timeout expires.
+            publishNext(observer, 900, "three");   // Should be skipped since onComplete will arrive before the timeout expires.
+            publishCompleted(observer, 1000);     // Should be published as soon as the timeout expires.
         });
 
         Observable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
@@ -149,21 +138,18 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceNeverEmits() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                // all should be skipped since they are happening faster than the 200ms timeout
-                publishNext(observer, 100, "a");    // Should be skipped
-                publishNext(observer, 200, "b");    // Should be skipped
-                publishNext(observer, 300, "c");    // Should be skipped
-                publishNext(observer, 400, "d");    // Should be skipped
-                publishNext(observer, 500, "e");    // Should be skipped
-                publishNext(observer, 600, "f");    // Should be skipped
-                publishNext(observer, 700, "g");    // Should be skipped
-                publishNext(observer, 800, "h");    // Should be skipped
-                publishCompleted(observer, 900);     // Should be published as soon as the timeout expires.
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            // all should be skipped since they are happening faster than the 200ms timeout
+            publishNext(observer, 100, "a");    // Should be skipped
+            publishNext(observer, 200, "b");    // Should be skipped
+            publishNext(observer, 300, "c");    // Should be skipped
+            publishNext(observer, 400, "d");    // Should be skipped
+            publishNext(observer, 500, "e");    // Should be skipped
+            publishNext(observer, 600, "f");    // Should be skipped
+            publishNext(observer, 700, "g");    // Should be skipped
+            publishNext(observer, 800, "h");    // Should be skipped
+            publishCompleted(observer, 900);     // Should be published as soon as the timeout expires.
         });
 
         Observable<String> sampled = source.debounce(200, TimeUnit.MILLISECONDS, scheduler);
@@ -179,15 +165,12 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceWithError() {
-        Observable<String> source = Observable.unsafeCreate(new ObservableSource<String>() {
-            @Override
-            public void subscribe(Observer<? super String> observer) {
-                observer.onSubscribe(Disposable.empty());
-                Exception error = new TestException();
-                publishNext(observer, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
-                publishNext(observer, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.
-                publishError(observer, 700, error);   // Should be published as soon as the timeout expires.
-            }
+        Observable<String> source = Observable.unsafeCreate(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            Exception error = new TestException();
+            publishNext(observer, 100, "one");    // Should be published since "two" will arrive after the timeout expires.
+            publishNext(observer, 600, "two");    // Should be skipped since onError will arrive before the timeout expires.
+            publishError(observer, 700, error);   // Should be published as soon as the timeout expires.
         });
 
         Observable<String> sampled = source.debounce(400, TimeUnit.MILLISECONDS, scheduler);
@@ -204,43 +187,22 @@ public class ObservableDebounceTest extends RxJavaTest {
     }
 
     private <T> void publishCompleted(final Observer<T> observer, long delay) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                observer.onComplete();
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(observer::onComplete, delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishError(final Observer<T> observer, long delay, final Exception error) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                observer.onError(error);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> observer.onError(error), delay, TimeUnit.MILLISECONDS);
     }
 
     private <T> void publishNext(final Observer<T> observer, final long delay, final T value) {
-        innerScheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                observer.onNext(value);
-            }
-        }, delay, TimeUnit.MILLISECONDS);
+        innerScheduler.schedule(() -> observer.onNext(value), delay, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void debounceSelectorNormal1() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> debouncer = PublishSubject.create();
-        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return debouncer;
-            }
-        };
+        Function<Integer, Observable<Integer>> debounceSel = _ -> debouncer;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -270,12 +232,8 @@ public class ObservableDebounceTest extends RxJavaTest {
     @Test
     public void debounceSelectorFuncThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
-        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Observable<Integer>> debounceSel = _ -> {
+            throw new TestException();
         };
 
         Observer<Object> o = TestHelper.mockObserver();
@@ -292,13 +250,7 @@ public class ObservableDebounceTest extends RxJavaTest {
     @Test
     public void debounceSelectorObservableThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
-        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return Observable.error(new TestException());
-            }
-        };
+        Function<Integer, Observable<Integer>> debounceSel = _ -> Observable.error(new TestException());
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -334,13 +286,7 @@ public class ObservableDebounceTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> debouncer = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> debounceSel = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return debouncer;
-            }
-        };
+        Function<Integer, Observable<Integer>> debounceSel = _ -> debouncer;
 
         Observer<Object> o = TestHelper.mockObserver();
 
@@ -423,29 +369,9 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void badSourceSelector() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return o.debounce(new Function<Integer, ObservableSource<Long>>() {
-                    @Override
-                    public ObservableSource<Long> apply(Integer v) throws Exception {
-                        return Observable.timer(1, TimeUnit.SECONDS);
-                    }
-                });
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(o -> o.debounce(_ -> Observable.timer(1, TimeUnit.SECONDS)), false, 1, 1, 1);
 
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(final Observable<Integer> o) throws Exception {
-                return Observable.just(1).debounce(new Function<Integer, ObservableSource<Integer>>() {
-                    @Override
-                    public ObservableSource<Integer> apply(Integer v) throws Exception {
-                        return o;
-                    }
-                });
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(o -> Observable.just(1).debounce(_ -> o), false, 1, 1, 1);
     }
 
     @Test
@@ -457,12 +383,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Observable<Object> o) throws Exception {
-                return o.debounce(Functions.justFunction(Observable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<Object>>) o -> o.debounce(Functions.justFunction(Observable.never())));
     }
 
     @Test
@@ -470,12 +391,9 @@ public class ObservableDebounceTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         BehaviorSubject.createDefault(1)
-        .debounce(new Function<Integer, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Integer o) throws Exception {
-                to.dispose();
-                return Observable.never();
-            }
+        .debounce(_ -> {
+            to.dispose();
+            return Observable.never();
         })
         .subscribeWith(to)
         .assertEmpty();
@@ -505,20 +423,17 @@ public class ObservableDebounceTest extends RxJavaTest {
         final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
 
         TestObserver<Integer> to = Observable.range(1, 2)
-        .debounce(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer o) throws Exception {
-                if (o != 1) {
-                    return Observable.never();
-                }
-                return new Observable<Integer>() {
-                    @Override
-                    protected void subscribeActual(Observer<? super Integer> observer) {
-                        observer.onSubscribe(Disposable.empty());
-                        ref.set(observer);
-                    }
-                };
+        .debounce(o -> {
+            if (o != 1) {
+                return Observable.never();
             }
+            return new Observable<Integer>() {
+                @Override
+                protected void subscribeActual(Observer<? super Integer> observer) {
+                    observer.onSubscribe(Disposable.empty());
+                    ref.set(observer);
+                }
+            };
         })
         .test();
 
@@ -530,13 +445,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void timedDoubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeFlowable(new Function<Flowable<Object>, Publisher<Object>>() {
-            @Override
-            public Publisher<Object> apply(Flowable<Object> f)
-                    throws Exception {
-                return f.debounce(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeFlowable(f -> f.debounce(1, TimeUnit.SECONDS));
     }
 
     @Test
@@ -583,12 +492,7 @@ public class ObservableDebounceTest extends RxJavaTest {
 
     @Test
     public void debounceOnEmpty() {
-        Observable.empty().debounce(new Function<Object, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Object o) {
-                return Observable.just(new Object());
-            }
-        }).subscribe();
+        Observable.empty().debounce(_ -> Observable.just(new Object())).subscribe();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelaySubscriptionOtherTest.java
@@ -19,9 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subjects.PublishSubject;
@@ -37,12 +35,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Observable.just(1)
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(to);
 
@@ -70,12 +63,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Observable.just(1)
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(to);
 
@@ -104,12 +92,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Observable.just(1)
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(to);
 
@@ -137,12 +120,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Observable.<Integer>error(new TestException())
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(to);
 
@@ -170,12 +148,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
         final AtomicInteger subscribed = new AtomicInteger();
 
         Observable.<Integer>error(new TestException())
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                subscribed.getAndIncrement();
-            }
-        })
+        .doOnSubscribe(_ -> subscribed.getAndIncrement())
         .delaySubscription(other)
         .subscribe(to);
 
@@ -196,12 +169,7 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
 
     @Test
     public void badSourceOther() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return Observable.just(1).delaySubscription(o);
-            }
-        }, false, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(o -> Observable.just(1).delaySubscription(o), false, 1, 1, 1);
     }
 
     @Test
@@ -212,12 +180,9 @@ public class ObservableDelaySubscriptionOtherTest extends RxJavaTest {
                 final TestObserver<Boolean> observer = TestObserver.create();
                 observer.withTag(s.getClass().getSimpleName());
 
-                Observable.<Boolean>create(new ObservableOnSubscribe<Boolean>() {
-                    @Override
-                    public void subscribe(ObservableEmitter<Boolean> emitter) throws Exception {
-                      emitter.onNext(Thread.interrupted());
-                      emitter.onComplete();
-                    }
+                Observable.<Boolean>create(emitter -> {
+                  emitter.onNext(Thread.interrupted());
+                  emitter.onComplete();
                 })
                 .delaySubscription(100, TimeUnit.MILLISECONDS, s)
                 .subscribe(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
@@ -123,14 +123,11 @@ public class ObservableDelayTest extends RxJavaTest {
     @Test
     public void delayWithError() {
         Observable<Long> source = Observable.interval(1L, TimeUnit.SECONDS, scheduler)
-        .map(new Function<Long, Long>() {
-            @Override
-            public Long apply(Long value) {
-                if (value == 1L) {
-                    throw new RuntimeException("error!");
-                }
-                return value;
+        .map(value -> {
+            if (value == 1L) {
+                throw new RuntimeException("error!");
             }
+            return value;
         });
         Observable<Long> delayed = source.delay(1L, TimeUnit.SECONDS, scheduler);
         delayed.subscribe(observer);
@@ -242,12 +239,7 @@ public class ObservableDelayTest extends RxJavaTest {
             delays.add(delay);
         }
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delays.get(t1);
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = delays::get;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -272,13 +264,7 @@ public class ObservableDelayTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
@@ -298,13 +284,7 @@ public class ObservableDelayTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
@@ -323,12 +303,8 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayWithObservableDelayFunctionThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, Observable<Integer>> delayFunc = _ -> {
+            throw new TestException();
         };
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -347,13 +323,7 @@ public class ObservableDelayTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
@@ -371,19 +341,8 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayWithObservableSubscriptionNormal() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> get() {
-                return delay;
-            }
-        };
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Supplier<Observable<Integer>> subFunc = () -> delay;
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -406,19 +365,10 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayWithObservableSubscriptionFunctionThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> get() {
-                throw new TestException();
-            }
+        Supplier<Observable<Integer>> subFunc = () -> {
+            throw new TestException();
         };
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -440,19 +390,8 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayWithObservableSubscriptionThrows() {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> get() {
-                return delay;
-            }
-        };
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Supplier<Observable<Integer>> subFunc = () -> delay;
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -474,13 +413,7 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayWithObservableEmptyDelayer() {
         PublishSubject<Integer> source = PublishSubject.create();
 
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return Observable.empty();
-            }
-        };
+        Function<Integer, Observable<Integer>> delayFunc = _ -> Observable.empty();
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
 
@@ -500,19 +433,8 @@ public class ObservableDelayTest extends RxJavaTest {
         PublishSubject<Integer> source = PublishSubject.create();
         final PublishSubject<Integer> sdelay = PublishSubject.create();
         final PublishSubject<Integer> delay = PublishSubject.create();
-        Supplier<Observable<Integer>> subFunc = new Supplier<Observable<Integer>>() {
-            @Override
-            public Observable<Integer> get() {
-                return sdelay;
-            }
-        };
-        Function<Integer, Observable<Integer>> delayFunc = new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return delay;
-            }
-        };
+        Supplier<Observable<Integer>> subFunc = () -> sdelay;
+        Function<Integer, Observable<Integer>> delayFunc = _ -> delay;
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -537,12 +459,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         final Observable<Long> delayer = Observable.timer(500L, TimeUnit.MILLISECONDS, scheduler);
 
-        Function<Long, Observable<Long>> delayFunc = new Function<Long, Observable<Long>>() {
-            @Override
-            public Observable<Long> apply(Long t1) {
-                return delayer;
-            }
-        };
+        Function<Long, Observable<Long>> delayFunc = _ -> delayer;
 
         Observable<Long> delayed = source.delay(delayFunc);
         delayed.subscribe(observer);
@@ -591,13 +508,7 @@ public class ObservableDelayTest extends RxJavaTest {
             subjects.add(PublishSubject.<Integer> create());
         }
 
-        Observable<Integer> result = source.delay(new Function<Integer, Observable<Integer>>() {
-
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return subjects.get(t1);
-            }
-        });
+        Observable<Integer> result = source.delay((Function<Integer, Observable<Integer>>) subjects::get);
 
         Observer<Object> o = TestHelper.mockObserver();
         InOrder inOrder = inOrder(o);
@@ -626,14 +537,7 @@ public class ObservableDelayTest extends RxJavaTest {
     public void delayEmitsEverything() {
         Observable<Integer> source = Observable.range(1, 5);
         Observable<Integer> delayed = source.delay(500L, TimeUnit.MILLISECONDS, scheduler);
-        delayed = delayed.doOnEach(new Consumer<Notification<Integer>>() {
-
-            @Override
-            public void accept(Notification<Integer> t1) {
-                System.out.println(t1);
-            }
-
-        });
+        delayed = delayed.doOnEach(System.out::println);
         TestObserver<Integer> observer = new TestObserver<>();
         delayed.subscribe(observer);
         // all will be delivered after 500ms since range does not delay between them
@@ -702,14 +606,7 @@ public class ObservableDelayTest extends RxJavaTest {
     public void backpressureWithSelectorDelay() {
         TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
-                .delay(new Function<Integer, Observable<Long>>() {
-
-                    @Override
-                    public Observable<Long> apply(Integer i) {
-                        return Observable.timer(100, TimeUnit.MILLISECONDS);
-                    }
-
-                })
+                .delay((Function<Integer, Observable<Long>>) _ -> Observable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
                 .map(new Function<Integer, Integer>() {
 
@@ -738,14 +635,7 @@ public class ObservableDelayTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(Observable.timer(500, TimeUnit.MILLISECONDS)
-                , new Function<Integer, Observable<Long>>() {
-
-                    @Override
-                    public Observable<Long> apply(Integer i) {
-                        return Observable.timer(100, TimeUnit.MILLISECONDS);
-                    }
-
-                })
+                , (Function<Integer, Observable<Long>>) _ -> Observable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
                 .map(new Function<Integer, Integer>() {
 
@@ -872,12 +762,9 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable.<String>error(new Exception())
                 .delay(0, TimeUnit.MILLISECONDS, Schedulers.newThread())
-                .doOnError(new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable throwable) throws Exception {
-                        thread.set(Thread.currentThread());
-                        latch.countDown();
-                    }
+                .doOnError(_ -> {
+                    thread.set(Thread.currentThread());
+                    latch.countDown();
                 })
                 .onErrorResumeWith(Observable.<String>empty())
                 .subscribe();
@@ -896,19 +783,9 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.delay(1, TimeUnit.SECONDS);
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.delay(1, TimeUnit.SECONDS));
 
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.delay(Functions.justFunction(Observable.never()));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.delay(Functions.justFunction(Observable.never())));
     }
 
     @Test
@@ -971,12 +848,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
     @Test
     public void itemDelayReturnsNull() {
-        Observable.just(1).delay(new Function<Integer, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Integer t) throws Exception {
-                return null;
-            }
-        })
+        Observable.just(1).delay((Function<Integer, Observable<Object>>) _ -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The itemDelay returned a null ObservableSource");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
@@ -41,14 +41,11 @@ public class ObservableDistinctTest extends RxJavaTest {
     Observer<String> w;
 
     // nulls lead to exceptions
-    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
-        @Override
-        public String apply(String s) {
-            if (s.equals("x")) {
-                return "XX";
-            }
-            return s.toUpperCase();
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = s -> {
+        if (s.equals("x")) {
+            return "XX";
         }
+        return s.toUpperCase();
     };
 
     @Before
@@ -175,11 +172,8 @@ public class ObservableDistinctTest extends RxJavaTest {
     @Test
     public void collectionSupplierThrows() {
         Observable.just(1)
-        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
-            @Override
-            public Collection<Object> get() throws Exception {
-                throw new TestException();
-            }
+        .distinct(Functions.identity(), (Supplier<Collection<Object>>) () -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);
@@ -188,12 +182,7 @@ public class ObservableDistinctTest extends RxJavaTest {
     @Test
     public void collectionSupplierIsNull() {
         Observable.just(1)
-        .distinct(Functions.identity(), new Supplier<Collection<Object>>() {
-            @Override
-            public Collection<Object> get() throws Exception {
-                return null;
-            }
-        })
+        .distinct(Functions.identity(), (Supplier<Collection<Object>>) () -> null)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(NullPointerException.class)
         .assertErrorMessage(ExceptionHelper.nullWarning("The collectionSupplier returned a null Collection."));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChangedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctUntilChangedTest.java
@@ -38,14 +38,11 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
     Observer<String> w2;
 
     // nulls lead to exceptions
-    final Function<String, String> TO_UPPER_WITH_EXCEPTION = new Function<String, String>() {
-        @Override
-        public String apply(String s) {
-            if (s.equals("x")) {
-                return "xx";
-            }
-            return s.toUpperCase();
+    final Function<String, String> TO_UPPER_WITH_EXCEPTION = s -> {
+        if (s.equals("x")) {
+            return "xx";
         }
+        return s.toUpperCase();
     };
 
     @Before
@@ -114,12 +111,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
 
         TestObserver<String> to = TestObserver.create();
 
-        source.distinctUntilChanged(new BiPredicate<String, String>() {
-            @Override
-            public boolean test(String a, String b) {
-                return a.compareToIgnoreCase(b) == 0;
-            }
-        })
+        source.distinctUntilChanged((a, b) -> a.compareToIgnoreCase(b) == 0)
         .subscribe(to);
 
         to.assertValues("a", "b", "A", "C");
@@ -133,11 +125,8 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
 
         TestObserver<String> to = TestObserver.create();
 
-        source.distinctUntilChanged(new BiPredicate<String, String>() {
-            @Override
-            public boolean test(String a, String b) {
-                throw new TestException();
-            }
+        source.distinctUntilChanged((_, _) -> {
+            throw new TestException();
         })
         .subscribe(to);
 
@@ -151,12 +140,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.just(1, 2, 2, 3, 3, 4, 5)
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .subscribe(to);
 
         to.assertFuseable()
@@ -172,12 +156,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-            @Override
-            public boolean test(Integer a, Integer b) throws Exception {
-                return a.equals(b);
-            }
-        })
+        .distinctUntilChanged(Integer::equals)
         .subscribe(to);
 
         TestHelper.emit(us, 1, 2, 2, 3, 3, 4, 5);
@@ -193,22 +172,16 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Integer>() {
-                @Override
-                public void subscribe(Observer<? super Integer> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onNext(3);
-                    observer.onError(new IOException());
-                    observer.onComplete();
-                }
+            Observable.wrap((ObservableSource<Integer>) observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onNext(3);
+                observer.onError(new IOException());
+                observer.onComplete();
             })
-            .distinctUntilChanged(new BiPredicate<Integer, Integer>() {
-                @Override
-                public boolean test(Integer a, Integer b) throws Exception {
-                    throw new TestException();
-                }
+            .distinctUntilChanged((_, _) -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class, 1);
@@ -229,12 +202,7 @@ public class ObservableDistinctUntilChangedTest extends RxJavaTest {
 
         PublishSubject<Mutable> ps = PublishSubject.create();
 
-        TestObserver<Mutable> to = ps.distinctUntilChanged(new Function<Mutable, Object>() {
-            @Override
-            public Object apply(Mutable m) throws Exception {
-                return m.value;
-            }
-        })
+        TestObserver<Mutable> to = ps.distinctUntilChanged((Function<Mutable, Object>) m1 -> m1.value)
         .test();
 
         ps.onNext(m);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -33,12 +33,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     final List<Integer> values = new ArrayList<>();
 
-    final Consumer<Integer> afterNext = new Consumer<Integer>() {
-        @Override
-        public void accept(Integer e) throws Exception {
-            values.add(-e);
-        }
-    };
+    final Consumer<Integer> afterNext = e -> values.add(-e);
 
     final TestObserver<Integer> to = new TestObserver<Integer>() {
         @Override
@@ -241,11 +236,8 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrows() {
         Observable.just(1, 2)
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class, 1);
@@ -254,11 +246,8 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrowsConditional() {
         Observable.just(1, 2)
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .test()
@@ -268,11 +257,8 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
     @Test
     public void consumerThrowsConditional2() {
         Observable.just(1, 2).hide()
-        .doAfterNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer e) throws Exception {
-                throw new TestException();
-            }
+        .doAfterNext(_ -> {
+            throw new TestException();
         })
         .filter(Functions.alwaysTrue())
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
@@ -84,18 +84,10 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Observable<Object> f) throws Exception {
-                return f.doFinally(ObservableDoFinallyTest.this);
-            }
-        });
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Observable<Object> f) throws Exception {
-                return f.doFinally(ObservableDoFinallyTest.this).filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<Object>>) f ->
+            f.doFinally(ObservableDoFinallyTest.this));
+        TestHelper.checkDoubleOnSubscribeObservable((Function<Observable<Object>, Observable<Object>>) f ->
+            f.doFinally(ObservableDoFinallyTest.this).filter(Functions.alwaysTrue()));
     }
 
     @Test
@@ -305,11 +297,8 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .test()
             .assertResult(1)
@@ -326,11 +315,8 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1)
-            .doFinally(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new TestException();
-                }
+            .doFinally(() -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -445,37 +431,12 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         final List<String> list = new ArrayList<>();
 
         Observable.error(new TestException())
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("dispose");
-            }
-        })
-        .doFinally(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("finally");
-            }
-        })
+        .doOnDispose(() -> list.add("dispose"))
+        .doFinally(() -> list.add("finally"))
         .subscribe(
-                new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) throws Exception {
-                        list.add("onNext");
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        list.add("onError");
-                    }
-                },
-                new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("onComplete");
-                    }
-                });
+                _ -> list.add("onNext"),
+                _ -> list.add("onError"),
+                () -> list.add("onComplete"));
 
         assertEquals(Arrays.asList("onError", "finally"), list);
     }
@@ -485,37 +446,12 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         final List<String> list = new ArrayList<>();
 
         Observable.just(1)
-        .doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("dispose");
-            }
-        })
-        .doFinally(new Action() {
-            @Override
-            public void run() throws Exception {
-                list.add("finally");
-            }
-        })
+        .doOnDispose(() -> list.add("dispose"))
+        .doFinally(() -> list.add("finally"))
         .subscribe(
-                new Consumer<Object>() {
-                    @Override
-                    public void accept(Object v) throws Exception {
-                        list.add("onNext");
-                    }
-                },
-                new Consumer<Throwable>() {
-                    @Override
-                    public void accept(Throwable e) throws Exception {
-                        list.add("onError");
-                    }
-                },
-                new Action() {
-                    @Override
-                    public void run() throws Exception {
-                        list.add("onComplete");
-                    }
-                });
+                (Consumer<Object>) _ -> list.add("onNext"),
+                _ -> list.add("onError"),
+                () -> list.add("onComplete"));
 
         assertEquals(Arrays.asList("onNext", "onComplete", "finally"), list);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
@@ -26,7 +26,6 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.operators.QueueFuseable;
@@ -70,14 +69,11 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnEachWithError() {
         Observable<String> base = Observable.just("one", "fail", "two", "three", "fail");
-        Observable<String> errs = base.map(new Function<String, String>() {
-            @Override
-            public String apply(String s) {
-                if ("fail".equals(s)) {
-                    throw new RuntimeException("Forced Failure");
-                }
-                return s;
+        Observable<String> errs = base.map(s -> {
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
             }
+            return s;
         });
 
         Observable<String> doOnEach = errs.doOnEach(sideEffectObserver);
@@ -99,12 +95,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     public void doOnEachWithErrorInCallback() {
         Observable<String> base = Observable.just("one", "two", "fail", "three");
-        Observable<String> doOnEach = base.doOnNext(new Consumer<String>() {
-            @Override
-            public void accept(String s) {
-                if ("fail".equals(s)) {
-                    throw new RuntimeException("Forced Failure");
-                }
+        Observable<String> doOnEach = base.doOnNext(s -> {
+            if ("fail".equals(s)) {
+                throw new RuntimeException("Forced Failure");
             }
         });
 
@@ -125,19 +118,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         for (int i = 0; i < expectedCount; i++) {
             Observable
                     .just(Boolean.TRUE, Boolean.FALSE)
-                    .takeWhile(new Predicate<Boolean>() {
-                        @Override
-                        public boolean test(Boolean value) {
-                            return value;
-                        }
-                    })
+                    .takeWhile(value -> value)
                     .toList()
-                    .doOnSuccess(new Consumer<List<Boolean>>() {
-                        @Override
-                        public void accept(List<Boolean> booleans) {
-                            count.incrementAndGet();
-                        }
-                    })
+                    .doOnSuccess(_ -> count.incrementAndGet())
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
@@ -151,19 +134,9 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         for (int i = 0; i < expectedCount; i++) {
             Observable
                     .just(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE)
-                    .takeWhile(new Predicate<Boolean>() {
-                        @Override
-                        public boolean test(Boolean value) {
-                            return value;
-                        }
-                    })
+                    .takeWhile(value -> value)
                     .toList()
-                    .doOnSuccess(new Consumer<List<Boolean>>() {
-                        @Override
-                        public void accept(List<Boolean> booleans) {
-                            count.incrementAndGet();
-                        }
-                    })
+                    .doOnSuccess(_ -> count.incrementAndGet())
                     .subscribe();
         }
         assertEquals(expectedCount, count.get());
@@ -205,11 +178,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
 
         Observable.error(new TestException())
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) {
-                throw new TestException();
-            }
+        .doOnError(_ -> {
+            throw new TestException();
         }).subscribe(to);
 
         to.assertNoValues();
@@ -229,21 +199,15 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new IOException());
-                    observer.onComplete();
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onError(new IOException());
+                observer.onComplete();
             })
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException();
-                }
+            .doOnNext(_ -> {
+                throw new TestException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -259,18 +223,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onError(new TestException());
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onError(new TestException());
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .test()
             .assertFailure(TestException.class);
@@ -286,18 +244,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onComplete();
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onComplete();
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .test()
             .assertResult();
@@ -310,18 +262,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onCompleteCrash() {
-        Observable.wrap(new ObservableSource<Object>() {
-            @Override
-            public void subscribe(Observer<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onComplete();
-            }
+        Observable.wrap(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onComplete();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IOException();
-            }
+        .doOnComplete(() -> {
+            throw new IOException();
         })
         .test()
         .assertFailure(IOException.class);
@@ -332,21 +278,15 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new IOException());
-                    observer.onComplete();
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onNext(1);
+                observer.onNext(2);
+                observer.onError(new IOException());
+                observer.onComplete();
             })
-            .doOnNext(new Consumer<Object>() {
-                @Override
-                public void accept(Object e) throws Exception {
-                    throw new TestException();
-                }
+            .doOnNext(_ -> {
+                throw new TestException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -363,18 +303,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onError(new TestException());
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onError(new TestException());
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -390,12 +324,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     public void onCompleteAfter() {
         final int[] call = { 0 };
         Observable.just(1)
-        .doAfterTerminate(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doAfterTerminate(() -> call[0]++)
         .test()
         .assertResult(1);
 
@@ -407,18 +336,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Observable.wrap(new ObservableSource<Object>() {
-                @Override
-                public void subscribe(Observer<? super Object> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onComplete();
-                }
+            Observable.wrap(observer -> {
+                observer.onSubscribe(Disposable.empty());
+                observer.onComplete();
             })
-            .doAfterTerminate(new Action() {
-                @Override
-                public void run() throws Exception {
-                    throw new IOException();
-                }
+            .doAfterTerminate(() -> {
+                throw new IOException();
             })
             .filter(Functions.alwaysTrue())
             .test()
@@ -432,18 +355,12 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void onCompleteCrashConditional() {
-        Observable.wrap(new ObservableSource<Object>() {
-            @Override
-            public void subscribe(Observer<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onComplete();
-            }
+        Observable.wrap(observer -> {
+            observer.onSubscribe(Disposable.empty());
+            observer.onComplete();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new IOException();
-            }
+        .doOnComplete(() -> {
+            throw new IOException();
         })
         .filter(Functions.alwaysTrue())
         .test()
@@ -453,11 +370,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
     @Test
     public void onErrorOnErrorCrashConditional() {
         TestObserverEx<Object> to = Observable.error(new TestException("Outer"))
-        .doOnError(new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                throw new TestException("Inner");
-            }
+        .doOnError(_ -> {
+            throw new TestException("Inner");
         })
         .filter(Functions.alwaysTrue())
         .to(TestHelper.testConsumer())
@@ -477,18 +391,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0, 0 };
 
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .subscribe(to);
 
         to.assertFuseable()
@@ -507,18 +411,10 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .doOnNext(_ -> {
+            throw new TestException();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnComplete(() -> call[0]++)
         .subscribe(to);
 
         to.assertFuseable()
@@ -536,18 +432,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0, 0 };
 
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
@@ -567,18 +453,10 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         final int[] call = { 0 };
 
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .doOnNext(_ -> {
+            throw new TestException();
         })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[0]++;
-            }
-        })
+        .doOnComplete(() -> call[0]++)
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
@@ -599,18 +477,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .subscribe(to);
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
@@ -633,18 +501,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
@@ -668,18 +526,8 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us.hide()
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                call[0]++;
-            }
-        })
-        .doOnComplete(new Action() {
-            @Override
-            public void run() throws Exception {
-                call[1]++;
-            }
-        })
+        .doOnNext(_ -> call[0]++)
+        .doOnComplete(() -> call[1]++)
         .filter(Functions.alwaysTrue())
         .subscribe(to);
 
@@ -700,11 +548,6 @@ public class ObservableDoOnEachTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.doOnEach(new TestObserver<>());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.doOnEach(new TestObserver<>()));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -32,12 +31,7 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
     @Test
     public void doOnSubscribe() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> o = Observable.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    count.incrementAndGet();
-            }
-        });
+        Observable<Integer> o = Observable.just(1).doOnSubscribe(_ -> count.incrementAndGet());
 
         o.subscribe();
         o.subscribe();
@@ -48,17 +42,7 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
     @Test
     public void doOnSubscribe2() throws Exception {
         final AtomicInteger count = new AtomicInteger();
-        Observable<Integer> o = Observable.just(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    count.incrementAndGet();
-            }
-        }).take(1).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    count.incrementAndGet();
-            }
-        });
+        Observable<Integer> o = Observable.just(1).doOnSubscribe(_ -> count.incrementAndGet()).take(1).doOnSubscribe(_ -> count.incrementAndGet());
 
         o.subscribe();
         assertEquals(2, count.get());
@@ -70,27 +54,12 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
         final AtomicInteger countBefore = new AtomicInteger();
         final AtomicInteger countAfter = new AtomicInteger();
         final AtomicReference<Observer<? super Integer>> sref = new AtomicReference<>();
-        Observable<Integer> o = Observable.unsafeCreate(new ObservableSource<Integer>() {
-
-            @Override
-            public void subscribe(Observer<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                onSubscribed.incrementAndGet();
-                sref.set(observer);
-            }
-
-        }).doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    countBefore.incrementAndGet();
-            }
-        }).publish().refCount()
-        .doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    countAfter.incrementAndGet();
-            }
-        });
+        Observable<Integer> o = Observable.unsafeCreate((ObservableSource<Integer>) observer -> {
+            observer.onSubscribe(Disposable.empty());
+            onSubscribed.incrementAndGet();
+            sref.set(observer);
+        }).doOnSubscribe(_ -> countBefore.incrementAndGet()).publish().refCount()
+        .doOnSubscribe(_ -> countAfter.incrementAndGet());
 
         o.subscribe();
         o.subscribe();
@@ -121,11 +90,8 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .doOnSubscribe(new Consumer<Disposable>() {
-                @Override
-                public void accept(Disposable d) throws Exception {
-                    throw new TestException("First");
-                }
+            .doOnSubscribe(_ -> {
+                throw new TestException("First");
             })
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnUnsubscribeTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.BehaviorSubject;
 
@@ -43,29 +42,20 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnDispose(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that upper stream will be notified for un-subscription
-                        // from a child Observer
-                            upperLatch.countDown();
-                            upperCount.incrementAndGet();
-                    }
+                .doOnDispose(() -> {
+                    // Test that upper stream will be notified for un-subscription
+                    // from a child Observer
+                        upperLatch.countDown();
+                        upperCount.incrementAndGet();
                 })
-                .doOnNext(new Consumer<Long>() {
-                    @Override
-                    public void accept(Long aLong) {
-                            // Ensure there is at least some onNext events before un-subscription happens
-                            onNextLatch.countDown();
-                    }
+                .doOnNext(_ -> {
+                        // Ensure there is at least some onNext events before un-subscription happens
+                        onNextLatch.countDown();
                 })
-                .doOnDispose(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that lower stream will be notified for a direct un-subscription
-                            lowerLatch.countDown();
-                            lowerCount.incrementAndGet();
-                    }
+                .doOnDispose(() -> {
+                    // Test that lower stream will be notified for a direct un-subscription
+                        lowerLatch.countDown();
+                        lowerCount.incrementAndGet();
                 });
 
         List<Disposable> subscriptions = new ArrayList<>();
@@ -105,28 +95,19 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
                 // The stream needs to be infinite to ensure the stream does not terminate
                 // before it is unsubscribed
                 .interval(50, TimeUnit.MILLISECONDS)
-                .doOnDispose(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that upper stream will be notified for un-subscription
-                            upperLatch.countDown();
-                            upperCount.incrementAndGet();
-                    }
+                .doOnDispose(() -> {
+                    // Test that upper stream will be notified for un-subscription
+                        upperLatch.countDown();
+                        upperCount.incrementAndGet();
                 })
-                .doOnNext(new Consumer<Long>() {
-                    @Override
-                    public void accept(Long aLong) {
-                            // Ensure there is at least some onNext events before un-subscription happens
-                            onNextLatch.countDown();
-                    }
+                .doOnNext(_ -> {
+                        // Ensure there is at least some onNext events before un-subscription happens
+                        onNextLatch.countDown();
                 })
-                .doOnDispose(new Action() {
-                    @Override
-                    public void run() {
-                        // Test that lower stream will be notified for un-subscription
-                            lowerLatch.countDown();
-                            lowerCount.incrementAndGet();
-                    }
+                .doOnDispose(() -> {
+                    // Test that lower stream will be notified for un-subscription
+                        lowerLatch.countDown();
+                        lowerCount.incrementAndGet();
                 })
                 .publish()
                 .refCount();
@@ -161,12 +142,9 @@ public class ObservableDoOnUnsubscribeTest extends RxJavaTest {
         final AtomicInteger disposeCalled = new AtomicInteger();
 
         final BehaviorSubject<Integer> s = BehaviorSubject.create();
-        s.doOnDispose(new Action() {
-            @Override
-            public void run() throws Exception {
-                disposeCalled.incrementAndGet();
-                s.onNext(2);
-            }
+        s.doOnDispose(() -> {
+            disposeCalled.incrementAndGet();
+            s.onNext(2);
         })
         .firstOrError()
         .subscribe()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFilterTest.java
@@ -21,7 +21,6 @@ import org.mockito.Mockito;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 import io.reactivex.rxjava4.subjects.UnicastSubject;
@@ -32,13 +31,7 @@ public class ObservableFilterTest extends RxJavaTest {
     @Test
     public void filter() {
         Observable<String> w = Observable.just("one", "two", "three");
-        Observable<String> observable = w.filter(new Predicate<String>() {
-
-            @Override
-            public boolean test(String t1) {
-                return t1.equals("two");
-            }
-        });
+        Observable<String> observable = w.filter(t1 -> t1.equals("two"));
 
         Observer<String> observer = TestHelper.mockObserver();
 
@@ -58,12 +51,7 @@ public class ObservableFilterTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Observable<Object> o) throws Exception {
-                return o.filter(Functions.alwaysTrue());
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.filter(Functions.alwaysTrue()));
     }
 
     @Test
@@ -71,12 +59,7 @@ public class ObservableFilterTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(to);
 
         to.assertFusionMode(QueueFuseable.SYNC)
@@ -90,12 +73,7 @@ public class ObservableFilterTest extends RxJavaTest {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
         us
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(to);
 
         TestHelper.emit(us, 1, 2, 3, 4, 5);
@@ -109,12 +87,7 @@ public class ObservableFilterTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY | QueueFuseable.BOUNDARY);
 
         Observable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v % 2 == 0;
-            }
-        })
+        .filter(v -> v % 2 == 0)
         .subscribe(to);
 
         to.assertFusionMode(QueueFuseable.NONE)
@@ -124,11 +97,8 @@ public class ObservableFilterTest extends RxJavaTest {
     @Test
     public void filterThrows() {
         Observable.range(1, 5)
-        .filter(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .filter(_ -> {
+            throw new TestException();
         })
         .test()
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFirstTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFirstTest.java
@@ -31,12 +31,7 @@ public class ObservableFirstTest extends RxJavaTest {
     SingleObserver<Object> wo;
     MaybeObserver<Object> wm;
 
-    private static final Predicate<String> IS_D = new Predicate<String>() {
-        @Override
-        public boolean test(String value) {
-            return "d".equals(value);
-        }
-    };
+    private static final Predicate<String> IS_D = "d"::equals;
 
     @Before
     public void before() {
@@ -131,12 +126,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateObservable() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -151,12 +141,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndOneElementObservable() {
         Observable<Integer> o = Observable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -171,12 +156,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndEmptyObservable() {
         Observable<Integer> o = Observable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement().toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -232,12 +212,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateObservable() {
         Observable<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(8).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -252,12 +227,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndOneElementObservable() {
         Observable<Integer> o = Observable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(4).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -272,12 +242,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndEmptyObservable() {
         Observable<Integer> o = Observable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(2).toObservable();
 
         Observer<Integer> observer = TestHelper.mockObserver();
@@ -366,12 +331,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicate() {
         Maybe<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         o.subscribe(wm);
@@ -384,12 +344,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndOneElement() {
         Maybe<Integer> o = Observable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         o.subscribe(wm);
@@ -402,12 +357,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstWithPredicateAndEmpty() {
         Maybe<Integer> o = Observable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .firstElement();
 
         o.subscribe(wm);
@@ -456,12 +406,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicate() {
         Single<Integer> o = Observable.just(1, 2, 3, 4, 5, 6)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(8);
 
         o.subscribe(wo);
@@ -474,12 +419,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndOneElement() {
         Single<Integer> o = Observable.just(1, 2)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(4);
 
         o.subscribe(wo);
@@ -492,12 +432,7 @@ public class ObservableFirstTest extends RxJavaTest {
     @Test
     public void firstOrDefaultWithPredicateAndEmpty() {
         Single<Integer> o = Observable.just(1)
-                .filter(new Predicate<Integer>() {
-                    @Override
-                    public boolean test(Integer t1) {
-                        return t1 % 2 == 0;
-                    }
-                })
+                .filter(t1 -> t1 % 2 == 0)
                 .first(2);
 
         o.subscribe(wo);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -36,12 +36,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalObservable() {
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).toObservable()
+        .flatMapCompletable(_ -> Completable.complete()).toObservable()
         .test()
         .assertResult();
     }
@@ -51,11 +46,8 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable(_ -> {
+            throw new TestException();
         }).<Integer>toObservable()
         .test();
 
@@ -73,12 +65,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return null;
-            }
-        }).<Integer>toObservable()
+        .flatMapCompletable(_ -> null).<Integer>toObservable()
         .test();
 
         assertTrue(ps.hasObservers());
@@ -93,12 +80,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorObservable() {
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, true).toObservable()
+        .flatMapCompletable(_ -> Completable.complete(), true).toObservable()
         .test()
         .assertResult();
     }
@@ -106,12 +88,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalAsyncObservable() {
         Observable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Observable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        }).toObservable()
+        .flatMapCompletable(_ -> Observable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements()).toObservable()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -120,12 +97,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAllObservable() {
         TestObserverEx<Integer> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true).<Integer>toObservable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true).<Integer>toObservable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -139,12 +111,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAllObservable() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true).<Integer>toObservable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true).<Integer>toObservable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -158,12 +125,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuterObservable() {
         Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, false).toObservable()
+        .flatMapCompletable(_ -> Completable.complete(), false).toObservable()
         .test()
         .assertFailure(TestException.class);
     }
@@ -173,12 +135,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).<Integer>toObservable()
+        .flatMapCompletable(_ -> Completable.complete()).<Integer>toObservable()
         .subscribe(to);
 
         to
@@ -190,23 +147,13 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void disposedObservable() {
         TestHelper.checkDisposed(Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }).toObservable());
+        .flatMapCompletable(_ -> Completable.complete()).toObservable());
     }
 
     @Test
     public void normal() {
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .test()
         .assertResult();
     }
@@ -216,11 +163,8 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Void> to = ps
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapCompletable(_ -> {
+            throw new TestException();
         })
         .test();
 
@@ -238,12 +182,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Void> to = ps
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapCompletable(_ -> null)
         .test();
 
         assertTrue(ps.hasObservers());
@@ -258,12 +197,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, true)
+        .flatMapCompletable(_ -> Completable.complete(), true)
         .test()
         .assertResult();
     }
@@ -271,12 +205,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         Observable.range(1, 1000)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Observable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements();
-            }
-        })
+        .flatMapCompletable(_ -> Observable.range(1, 100).subscribeOn(Schedulers.computation()).ignoreElements())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult();
@@ -285,12 +214,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestObserverEx<Void> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true)
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -304,12 +228,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAll() {
         TestObserverEx<Void> to = Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.error(new TestException());
-            }
-        }, true)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), true)
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -323,12 +242,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuter() {
         Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }, false)
+        .flatMapCompletable(_ -> Completable.complete(), false)
         .test()
         .assertFailure(TestException.class);
     }
@@ -338,12 +252,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .<Integer>toObservable()
         .subscribe(to);
 
@@ -356,32 +265,22 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void disposed() {
         TestHelper.checkDisposed(Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        }));
+        .flatMapCompletable(_ -> Completable.complete()));
     }
 
     @Test
     public void innerObserver() {
         Observable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
+        .flatMapCompletable(_ -> new Completable() {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return new Completable() {
-                    @Override
-                    protected void subscribeActual(CompletableObserver observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)observer).dispose();
+                ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .test();
@@ -389,28 +288,13 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return o.flatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.complete();
-                    }
-                });
-            }
-        }, false, 1, null);
+        TestHelper.checkBadSourceObservable(o -> o.flatMapCompletable(_ -> Completable.complete()), false, 1, null);
     }
 
     @Test
     public void fusedInternalsObservable() {
         Observable.range(1, 10)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
-            @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return Completable.complete();
-            }
-        })
+        .flatMapCompletable(_ -> Completable.complete())
         .toObservable()
         .subscribe(new Observer<Object>() {
             @Override
@@ -442,21 +326,16 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void innerObserverObservable() {
         Observable.range(1, 3)
-        .flatMapCompletable(new Function<Integer, CompletableSource>() {
+        .flatMapCompletable(_ -> new Completable() {
             @Override
-            public CompletableSource apply(Integer v) throws Exception {
-                return new Completable() {
-                    @Override
-                    protected void subscribeActual(CompletableObserver observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(CompletableObserver observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        ((Disposable)observer).dispose();
+                ((Disposable)observer).dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .toObservable()
@@ -465,47 +344,19 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
 
     @Test
     public void badSourceObservable() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return o.flatMapCompletable(new Function<Integer, CompletableSource>() {
-                    @Override
-                    public CompletableSource apply(Integer v) throws Exception {
-                        return Completable.complete();
-                    }
-                }).toObservable();
-            }
-        }, false, 1, null);
+        TestHelper.checkBadSourceObservable(o -> o.flatMapCompletable(_ -> Completable.complete()).toObservable(), false, 1, null);
     }
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Observable<Integer> upstream) {
-                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
+            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Completable>() {
-            @Override
-            public Completable apply(Observable<Integer> upstream) {
-                return upstream.flatMapCompletable(new Function<Integer, Completable>() {
-                    @Override
-                    public Completable apply(Integer v) throws Throwable {
-                        return Completable.complete().hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
+            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -36,12 +36,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normal() {
         Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -49,12 +44,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalEmpty() {
         Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.empty();
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.empty())
         .test()
         .assertResult();
     }
@@ -62,12 +52,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        }, true)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, true)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -75,12 +60,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -95,11 +75,8 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test();
 
@@ -117,12 +94,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> null)
         .test();
 
         assertTrue(ps.hasObservers());
@@ -138,12 +110,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void normalDelayErrorAll() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
                 .concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.error(new TestException());
-            }
-        }, true)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()), true)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -157,12 +124,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void takeAsync() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> Maybe.just(v).subscribeOn(Schedulers.computation()))
         .take(2)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -177,12 +139,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void take() {
         Observable.range(1, 10)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(v);
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just)
         .take(2)
         .test()
         .assertResult(1, 2);
@@ -190,17 +147,9 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void middleError() {
-        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapMaybe(new Function<String, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(final String s) throws NumberFormatException {
-                //return Single.just(Integer.valueOf(s)); //This works
-                return Maybe.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws NumberFormatException {
-                        return Integer.valueOf(s);
-                    }
-                });
-            }
+        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapMaybe((Function<String, MaybeSource<Integer>>) s -> {
+            //return Single.just(Integer.valueOf(s)); //This works
+            return Maybe.fromCallable(() -> Integer.valueOf(s));
         })
         .test()
         .assertFailure(NumberFormatException.class, 1);
@@ -209,12 +158,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void asyncFlatten() {
         Observable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.just(1).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.just(1).subscribeOn(Schedulers.computation()))
         .take(500)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -227,12 +171,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void asyncFlattenNone() {
         Observable.range(1, 1000)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>empty().subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>empty().subscribeOn(Schedulers.computation()))
         .take(500)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -244,14 +183,11 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = Observable.range(1, 2)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return ps.singleElement();
-                }
-                return Maybe.error(new TestException());
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v == 2) {
+                return ps.singleElement();
             }
+            return Maybe.error(new TestException());
         }, true)
         .test();
 
@@ -267,14 +203,11 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = Observable.range(1, 2)
-        .flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return ps.singleElement();
-                }
-                return Maybe.error(new TestException());
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
+            if (v == 2) {
+                return ps.singleElement();
             }
+            return Maybe.error(new TestException());
         }, true)
         .test();
 
@@ -286,12 +219,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(PublishSubject.<Integer>create().flatMapMaybe(new Function<Integer, MaybeSource<Integer>>() {
-            @Override
-            public MaybeSource<Integer> apply(Integer v) throws Exception {
-                return Maybe.<Integer>empty();
-            }
-        }));
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.<Integer>empty()));
     }
 
     @Test
@@ -310,12 +238,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
-                return f.flatMapMaybe(Functions.justFunction(Maybe.just(2)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.flatMapMaybe(Functions.justFunction(Maybe.just(2))));
     }
 
     @Test
@@ -379,12 +302,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         };
 
         Observable.just(ps1, ps2)
-                .flatMapMaybe(new Function<PublishSubject<Integer>, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(PublishSubject<Integer> v) throws Exception {
-                        return v.singleElement();
-                    }
-                })
+                .flatMapMaybe((Function<PublishSubject<Integer>, MaybeSource<Integer>>) Observable::singleElement)
         .subscribe(to);
 
         ps1.onNext(1);
@@ -411,12 +329,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         };
 
         Observable.just(ps1, ps2, ps3)
-                .flatMapMaybe(new Function<PublishSubject<Integer>, MaybeSource<Integer>>() {
-                    @Override
-                    public MaybeSource<Integer> apply(PublishSubject<Integer> v) throws Exception {
-                        return v.singleElement();
-                    }
-                })
+                .flatMapMaybe((Function<PublishSubject<Integer>, MaybeSource<Integer>>) Observable::singleElement)
         .subscribe(to);
 
         ps1.onNext(1);
@@ -431,21 +344,16 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapMaybe(new Function<Integer, MaybeSource<Object>>() {
+        Observable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() {
             @Override
-            public MaybeSource<Object> apply(Integer v) throws Exception {
-                return new Maybe<Object>() {
-                    @Override
-                    protected void subscribeActual(MaybeObserver<? super Object> observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(MaybeObserver<? super Object> observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        to.dispose();
+                to.dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .subscribe(to);
@@ -456,32 +364,14 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMapMaybe(new Function<Integer, Maybe<Integer>>() {
-                    @Override
-                    public Maybe<Integer> apply(Integer v) throws Throwable {
-                        return Maybe.just(v).hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -36,12 +36,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normal() {
         Observable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -49,12 +44,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        }, true)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, true)
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -62,12 +52,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalAsync() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()
@@ -82,11 +67,8 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                throw new TestException();
-            }
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> {
+            throw new TestException();
         })
         .test();
 
@@ -104,12 +86,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return null;
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> null)
         .test();
 
         assertTrue(ps.hasObservers());
@@ -124,12 +101,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestObserverEx<Integer> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.error(new TestException());
-            }
-        }, true)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()), true)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -143,12 +115,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void takeAsync() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> Single.just(v).subscribeOn(Schedulers.computation()))
         .take(2)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -163,12 +130,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void take() {
         Observable.range(1, 10)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(v);
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just)
         .take(2)
         .test()
         .assertResult(1, 2);
@@ -176,17 +138,9 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void middleError() {
-        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapSingle(new Function<String, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(final String s) throws NumberFormatException {
-                //return Single.just(Integer.valueOf(s)); //This works
-                return Single.fromCallable(new Callable<Integer>() {
-                    @Override
-                    public Integer call() throws NumberFormatException {
-                        return Integer.valueOf(s);
-                    }
-                });
-            }
+        Observable.fromArray(new String[]{"1", "a", "2"}).flatMapSingle((Function<String, SingleSource<Integer>>) s -> {
+            //return Single.just(Integer.valueOf(s)); //This works
+            return Single.fromCallable(() -> Integer.valueOf(s));
         })
         .test()
         .assertFailure(NumberFormatException.class, 1);
@@ -195,12 +149,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void asyncFlatten() {
         Observable.range(1, 1000)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.just(1).subscribeOn(Schedulers.computation());
-            }
-        })
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.just(1).subscribeOn(Schedulers.computation()))
         .take(500)
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
@@ -215,14 +164,11 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = Observable.range(1, 2)
-        .flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                if (v == 2) {
-                    return ps.singleOrError();
-                }
-                return Single.error(new TestException());
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
+            if (v == 2) {
+                return ps.singleOrError();
             }
+            return Single.error(new TestException());
         }, true)
         .test();
 
@@ -235,12 +181,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void disposed() {
-        TestHelper.checkDisposed(PublishSubject.<Integer>create().flatMapSingle(new Function<Integer, SingleSource<Integer>>() {
-            @Override
-            public SingleSource<Integer> apply(Integer v) throws Exception {
-                return Single.<Integer>just(1);
-            }
-        }));
+        TestHelper.checkDisposed(PublishSubject.<Integer>create().flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.<Integer>just(1)));
     }
 
     @Test
@@ -259,12 +200,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(new Function<Observable<Object>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Observable<Object> f) throws Exception {
-                return f.flatMapSingle(Functions.justFunction(Single.just(2)));
-            }
-        });
+        TestHelper.checkDoubleOnSubscribeObservable(f -> f.flatMapSingle(Functions.justFunction(Single.just(2))));
     }
 
     @Test
@@ -328,12 +264,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         };
 
         Observable.just(ps1, ps2)
-                .flatMapSingle(new Function<PublishSubject<Integer>, SingleSource<Integer>>() {
-                    @Override
-                    public SingleSource<Integer> apply(PublishSubject<Integer> v) throws Exception {
-                        return v.singleOrError();
-                    }
-                })
+                .flatMapSingle((Function<PublishSubject<Integer>, SingleSource<Integer>>) Observable::singleOrError)
         .subscribe(to);
 
         ps1.onNext(1);
@@ -346,21 +277,16 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapSingle(new Function<Integer, SingleSource<Object>>() {
+        Observable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() {
             @Override
-            public SingleSource<Object> apply(Integer v) throws Exception {
-                return new Single<Object>() {
-                    @Override
-                    protected void subscribeActual(SingleObserver<? super Object> observer) {
-                        observer.onSubscribe(Disposable.empty());
+            protected void subscribeActual(SingleObserver<? super Object> observer) {
+                observer.onSubscribe(Disposable.empty());
 
-                        assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable)observer).isDisposed());
 
-                        to.dispose();
+                to.dispose();
 
-                        assertTrue(((Disposable)observer).isDisposed());
-                    }
-                };
+                assertTrue(((Disposable)observer).isDisposed());
             }
         })
         .subscribe(to);
@@ -371,32 +297,14 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMapSingle(new Function<Integer, Single<Integer>>() {
-                    @Override
-                    public Single<Integer> apply(Integer v) throws Throwable {
-                        return Single.just(v).hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -45,19 +45,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                return list;
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        Function<Integer, List<Integer>> func = _ -> list;
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -76,19 +65,10 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void collectionFunctionThrows() {
         Observer<Object> o = TestHelper.mockObserver();
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                throw new TestException();
-            }
+        Function<Integer, List<Integer>> func = _ -> {
+            throw new TestException();
         };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -105,18 +85,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         final List<Integer> list = Arrays.asList(1, 2, 3);
 
-        Function<Integer, List<Integer>> func = new Function<Integer, List<Integer>>() {
-            @Override
-            public List<Integer> apply(Integer t1) {
-                return list;
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                throw new TestException();
-            }
+        Function<Integer, List<Integer>> func = _ -> list;
+        BiFunction<Integer, Integer, Integer> resFunc = (_, _) -> {
+            throw new TestException();
         };
 
         List<Integer> source = Arrays.asList(16, 32, 64);
@@ -132,19 +103,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void mergeError() {
         Observer<Object> o = TestHelper.mockObserver();
 
-        Function<Integer, Observable<Integer>> func = new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return Observable.error(new TestException());
-            }
-        };
-        BiFunction<Integer, Integer, Integer> resFunc = new BiFunction<Integer, Integer, Integer>() {
-
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 | t2;
-            }
-        };
+        Function<Integer, Observable<Integer>> func = _ -> Observable.error(new TestException());
+        BiFunction<Integer, Integer, Integer> resFunc = (t1, t2) -> t1 | t2;
 
         List<Integer> source = Arrays.asList(16, 32, 64);
 
@@ -156,23 +116,11 @@ public class ObservableFlatMapTest extends RxJavaTest {
     }
 
     <T, R> Function<T, R> just(final R value) {
-        return new Function<T, R>() {
-
-            @Override
-            public R apply(T t1) {
-                return value;
-            }
-        };
+        return _ -> value;
     }
 
     <R> Supplier<R> just0(final R value) {
-        return new Supplier<R>() {
-
-            @Override
-            public R get() {
-                return value;
-            }
-        };
+        return () -> value;
     }
 
     @Test
@@ -223,20 +171,14 @@ public class ObservableFlatMapTest extends RxJavaTest {
     }
 
     <R> Supplier<R> funcThrow0(R r) {
-        return new Supplier<R>() {
-            @Override
-            public R get() {
-                throw new TestException();
-            }
+        return () -> {
+            throw new TestException();
         };
     }
 
     <T, R> Function<T, R> funcThrow(T t, R r) {
-        return new Function<T, R>() {
-            @Override
-            public R apply(T t) {
-                throw new TestException();
-            }
+        return _ -> {
+            throw new TestException();
         };
     }
 
@@ -308,22 +250,16 @@ public class ObservableFlatMapTest extends RxJavaTest {
     }
 
     private static <T> Observable<T> composer(Observable<T> source, final AtomicInteger subscriptionCount, final int m) {
-        return source.doOnSubscribe(new Consumer<Disposable>() {
-            @Override
-            public void accept(Disposable d) {
-                    int n = subscriptionCount.getAndIncrement();
-                    if (n >= m) {
-                        Assert.fail("Too many subscriptions! " + (n + 1));
-                    }
-            }
-        }).doOnComplete(new Action() {
-            @Override
-            public void run() {
-                    int n = subscriptionCount.decrementAndGet();
-                    if (n < 0) {
-                        Assert.fail("Too many unsubscriptions! " + (n - 1));
-                    }
-            }
+        return source.doOnSubscribe(_ -> {
+                int n = subscriptionCount.getAndIncrement();
+                if (n >= m) {
+                    Assert.fail("Too many subscriptions! " + (n + 1));
+                }
+        }).doOnComplete(() -> {
+                int n = subscriptionCount.decrementAndGet();
+                if (n < 0) {
+                    Assert.fail("Too many unsubscriptions! " + (n - 1));
+                }
         });
     }
 
@@ -332,13 +268,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final int m = 4;
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Observable<Integer> source = Observable.range(1, 10)
-        .flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
-                        .subscribeOn(Schedulers.computation());
-            }
-        }, m);
+        .flatMap((Function<Integer, Observable<Integer>>) t1 -> composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
+                .subscribeOn(Schedulers.computation()), m);
 
         TestObserver<Integer> to = new TestObserver<>();
 
@@ -358,18 +289,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final int m = 4;
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Observable<Integer> source = Observable.range(1, 10)
-            .flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer t1) {
-                return composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
-                        .subscribeOn(Schedulers.computation());
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer t1, Integer t2) {
-                return t1 * 1000 + t2;
-            }
-        }, m);
+            .flatMap((Function<Integer, Observable<Integer>>) t1 -> composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
+                    .subscribeOn(Schedulers.computation()), (t1, t2) -> t1 * 1000 + t2, m);
 
         TestObserver<Integer> to = new TestObserver<>();
 
@@ -482,12 +403,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         for (int i = 0; i < 1000; i++) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            Observable.range(1, 1000).flatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer t) {
-                    return Observable.just(1).subscribeOn(Schedulers.computation());
-                }
-            }).subscribe(to);
+            Observable.range(1, 1000).flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.just(1).subscribeOn(Schedulers.computation())).subscribe(to);
 
             to.awaitDone(5, TimeUnit.SECONDS);
             to.assertNoErrors();
@@ -501,12 +417,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         for (final int n : new int[] { 1, 1000, 1000000 }) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            Observable.just(1, 2).flatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer t) {
-                    return Observable.range(1, n);
-                }
-            }).subscribe(to);
+            Observable.just(1, 2).flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.range(1, n)).subscribe(to);
 
             System.out.println("flatMapTwoNestedSync >> @ " + n);
             to.assertNoErrors();
@@ -518,17 +429,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapper() {
         Observable.just(1)
-        .flatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.just(v * 10);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10), Integer::sum, true)
         .test()
         .assertResult(11);
     }
@@ -536,17 +437,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperWithError() {
         Observable.just(1)
-        .flatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.just(v * 10).concatWith(Observable.<Integer>error(new TestException()));
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10).concatWith(Observable.<Integer>error(new TestException())), Integer::sum, true)
         .test()
         .assertFailure(TestException.class, 11);
     }
@@ -554,29 +445,14 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperMaxConcurrency() {
         Observable.just(1, 2)
-        .flatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.just(v * 10);
-            }
-        }, new BiFunction<Integer, Integer, Integer>() {
-            @Override
-            public Integer apply(Integer a, Integer b) throws Exception {
-                return a + b;
-            }
-        }, true, 1)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10), Integer::sum, true, 1)
         .test()
         .assertResult(11, 22);
     }
 
     @Test
     public void flatMapEmpty() {
-        assertSame(Observable.empty(), Observable.empty().flatMap(new Function<Object, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Object v) throws Exception {
-                return Observable.just(v);
-            }
-        }));
+        assertSame(Observable.empty(), Observable.empty().flatMap((Function<Object, ObservableSource<Object>>) Observable::just));
     }
 
     @Test
@@ -602,11 +478,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
     @Test
     public void mergeScalarError() {
-        Observable.merge(Observable.just(Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw new TestException();
-            }
+        Observable.merge(Observable.just(Observable.fromCallable(() -> {
+            throw new TestException();
         })).hide())
         .test()
         .assertFailure(TestException.class);
@@ -665,19 +538,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
             final TestObserver<Integer> to = Observable.merge(Observable.just(ps)).test();
 
-            Runnable r1 = new Runnable() {
-                @Override
-                public void run() {
-                    ps.onComplete();
-                }
-            };
+            Runnable r1 = ps::onComplete;
 
-            Runnable r2 = new Runnable() {
-                @Override
-                public void run() {
-                    to.dispose();
-                }
-            };
+            Runnable r2 = to::dispose;
 
             TestHelper.race(r1, r2);
         }
@@ -686,17 +549,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void fusedInnerThrows() {
         Observable.just(1).hide()
-        .flatMap(new Function<Integer, ObservableSource<Object>>() {
-            @Override
-            public ObservableSource<Object> apply(Integer v) throws Exception {
-                return Observable.range(1, 2).map(new Function<Integer, Object>() {
-                    @Override
-                    public Object apply(Integer w) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        })
+        .flatMap((Function<Integer, ObservableSource<Object>>) _ -> Observable.range(1, 2).map(_ -> {
+            throw new TestException();
+        }))
         .test()
         .assertFailure(TestException.class);
     }
@@ -704,17 +559,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void fusedInnerThrows2() {
         TestObserverEx<Integer> to = Observable.range(1, 2).hide()
-        .flatMap(new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) throws Exception {
-                return Observable.range(1, 2).map(new Function<Integer, Integer>() {
-                    @Override
-                    public Integer apply(Integer w) throws Exception {
-                        throw new TestException();
-                    }
-                });
-            }
-        }, true)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.range(1, 2).map((Function<Integer, Integer>) _ -> {
+            throw new TestException();
+        }), true)
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -729,18 +576,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
             TestObserver<Object> to = Observable.merge(
-                    Observable.just(1).observeOn(Schedulers.single()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    }),
-                    Observable.just(1).observeOn(Schedulers.computation()).map(new Function<Integer, Object>() {
-                        @Override
-                        public Object apply(Integer v) throws Exception {
-                            return Thread.currentThread().getName().substring(0, 4);
-                        }
-                    })
+                    Observable.just(1).observeOn(Schedulers.single()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4)),
+                    Observable.just(1).observeOn(Schedulers.computation()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4))
             )
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
@@ -763,18 +600,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
                 final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
 
-                Runnable r1 = new Runnable() {
-                    @Override
-                    public void run() {
-                        to.dispose();
-                    }
-                };
-                Runnable r2 = new Runnable() {
-                    @Override
-                    public void run() {
-                        ps.onComplete();
-                    }
-                };
+                Runnable r1 = to::dispose;
+                Runnable r2 = ps::onComplete;
 
                 TestHelper.race(r1, r2);
 
@@ -801,19 +628,11 @@ public class ObservableFlatMapTest extends RxJavaTest {
                     ps.onNext(just);
                     ps.onNext(just2);
 
-                    Runnable r1 = new Runnable() {
-                        @Override
-                        public void run() {
-                            just2.onNext(1);
-                            to.dispose();
-                        }
+                    Runnable r1 = () -> {
+                        just2.onNext(1);
+                        to.dispose();
                     };
-                    Runnable r2 = new Runnable() {
-                        @Override
-                        public void run() {
-                            just.onNext(1);
-                        }
-                    };
+                    Runnable r2 = () -> just.onNext(1);
 
                     TestHelper.race(r1, r2);
 
@@ -828,17 +647,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void iterableMapperFunctionReturnsNull() {
         Observable.just(1)
-        .flatMapIterable(new Function<Integer, Iterable<Object>>() {
-            @Override
-            public Iterable<Object> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer v, Object w) throws Exception {
-                return v;
-            }
-        })
+        .flatMapIterable((Function<Integer, Iterable<Object>>) _ -> null, (BiFunction<Integer, Object, Object>) (v, _) -> v)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null Iterable");
     }
@@ -846,17 +655,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void combinerMapperFunctionReturnsNull() {
         Observable.just(1)
-        .flatMap(new Function<Integer, Observable<Object>>() {
-            @Override
-            public Observable<Object> apply(Integer v) throws Exception {
-                return null;
-            }
-        }, new BiFunction<Integer, Object, Object>() {
-            @Override
-            public Object apply(Integer v, Object w) throws Exception {
-                return v;
-            }
-        })
+        .flatMap((Function<Integer, Observable<Object>>) _ -> null, (BiFunction<Integer, Object, Object>) (v, _) -> v)
         .to(TestHelper.<Object>testConsumer())
         .assertFailureAndMessage(NullPointerException.class, "The mapper returned a null ObservableSource");
     }
@@ -865,39 +664,23 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void failingFusedInnerCancelsSource() {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(_ -> counter.getAndIncrement())
+        .flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.<Integer>fromIterable(() -> new Iterator<Integer>() {
             @Override
-            public void accept(Integer v) throws Exception {
-                counter.getAndIncrement();
+            public boolean hasNext() {
+                return true;
             }
-        })
-        .flatMap(new Function<Integer, Observable<Integer>>() {
+
             @Override
-            public Observable<Integer> apply(Integer v)
-                    throws Exception {
-                return Observable.<Integer>fromIterable(new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            @Override
-                            public boolean hasNext() {
-                                return true;
-                            }
-
-                            @Override
-                            public Integer next() {
-                                throw new TestException();
-                            }
-
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                });
+            public Integer next() {
+                throw new TestException();
             }
-        })
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        }))
         .test()
         .assertFailure(TestException.class);
 
@@ -910,13 +693,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> to = ps.flatMap(new Function<Integer, Observable<Integer>>() {
-                @Override
-                public Observable<Integer> apply(Integer v)
-                        throws Exception {
-                    return Observable.just(v + 1);
-                }
-            }, 1)
+            TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
             .subscribeWith(new TestObserver<Integer>() {
                 @Override
                 public void onNext(Integer t) {
@@ -946,13 +723,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarQueueNoOverflowHidden() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = ps.flatMap(new Function<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Integer v)
-                    throws Exception {
-                return Observable.just(v + 1).hide();
-            }
-        }, 1)
+        TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
         .subscribeWith(new TestObserver<Integer>() {
             @Override
             public void onNext(Integer t) {
@@ -978,23 +749,15 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         ObservableFlatMap.MergeObserver<Integer, Integer> merger =
-                new ObservableFlatMap.MergeObserver<>(to, new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer t)
-                            throws Exception {
-                        if (t == 0) {
-                            return fusedSource
-                                    .map(new Function<Integer, Integer>() {
-                                        @Override
-                                        public Integer apply(Integer v)
-                                                throws Exception {
-                                            throw new TestException();
-                                        }
-                                    })
-                                    .compose(TestHelper.<Integer>observableStripBoundary());
-                        }
-                        return Observable.range(10 * t, 5);
+                new ObservableFlatMap.MergeObserver<>(to, (Function<Integer, Observable<Integer>>) t -> {
+                    if (t == 0) {
+                        return fusedSource
+                                .map((Function<Integer, Integer>) _ -> {
+                                    throw new TestException();
+                                })
+                                .compose(TestHelper.<Integer>observableStripBoundary());
                     }
+                    return Observable.range(10 * t, 5);
                 }, true, Integer.MAX_VALUE, 128);
 
         merger.onSubscribe(Disposable.empty());
@@ -1021,21 +784,13 @@ public class ObservableFlatMapTest extends RxJavaTest {
         PublishSubject<Integer> ps4 = PublishSubject.create();
 
         TestObserver<Integer> to = Observable.just(ps1, ps2, ps3, ps4)
-        .flatMap(new Function<PublishSubject<Integer>, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(PublishSubject<Integer> v) throws Exception {
-                return v;
-            }
-        }, 2)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                if (v == 1) {
-                    // this will make sure the drain loop detects two completed
-                    // inner sources and replaces them with fresh ones
-                    ps1.onComplete();
-                    ps2.onComplete();
-                }
+        .flatMap((Function<PublishSubject<Integer>, ObservableSource<Integer>>) v -> v, 2)
+        .doOnNext(v -> {
+            if (v == 1) {
+                // this will make sure the drain loop detects two completed
+                // inner sources and replaces them with fresh ones
+                ps1.onComplete();
+                ps2.onComplete();
             }
         })
         .test();
@@ -1055,32 +810,14 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
     @Test
     public void undeliverableUponCancel() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMap(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                });
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide()));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
-        TestHelper.checkUndeliverableUponCancel(new ObservableConverter<Integer, Observable<Integer>>() {
-            @Override
-            public Observable<Integer> apply(Observable<Integer> upstream) {
-                return upstream.flatMap(new Function<Integer, Observable<Integer>>() {
-                    @Override
-                    public Observable<Integer> apply(Integer v) throws Throwable {
-                        return Observable.just(v).hide();
-                    }
-                }, true);
-            }
-        });
+        TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
+            upstream.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
@@ -31,64 +31,33 @@ public class ObservableFlattenIterableTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(PublishSubject.create().flatMapIterable(new Function<Object, Iterable<Integer>>() {
-            @Override
-            public Iterable<Integer> apply(Object v) throws Exception {
-                return Arrays.asList(10, 20);
-            }
-        }));
+        TestHelper.checkDisposed(PublishSubject.create().flatMapIterable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(10, 20)));
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> o) throws Exception {
-                return o.flatMapIterable(new Function<Object, Iterable<Integer>>() {
-                    @Override
-                    public Iterable<Integer> apply(Object v) throws Exception {
-                        return Arrays.asList(10, 20);
-                    }
-                });
-            }
-        }, false, 1, 1, 10, 20);
+        TestHelper.checkBadSourceObservable(o -> o.flatMapIterable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(10, 20)), false, 1, 1, 10, 20);
     }
 
     @Test
     public void failingInnerCancelsSource() {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(_ -> counter.getAndIncrement())
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
             @Override
-            public void accept(Integer v) throws Exception {
-                counter.getAndIncrement();
+            public boolean hasNext() {
+                return true;
             }
-        })
-        .flatMapIterable(new Function<Integer, Iterable<Integer>>() {
+
             @Override
-            public Iterable<Integer> apply(Integer v)
-                    throws Exception {
-                return new Iterable<Integer>() {
-                    @Override
-                    public Iterator<Integer> iterator() {
-                        return new Iterator<Integer>() {
-                            @Override
-                            public boolean hasNext() {
-                                return true;
-                            }
+            public Integer next() {
+                throw new TestException();
+            }
 
-                            @Override
-                            public Integer next() {
-                                throw new TestException();
-                            }
-
-                            @Override
-                            public void remove() {
-                                throw new UnsupportedOperationException();
-                            }
-                        };
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableForEachTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.PublishSubject;
@@ -36,18 +35,8 @@ public class ObservableForEachTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5)
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        })
-        .forEachWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return v < 3;
-            }
-        });
+        .doOnNext(list::add)
+        .forEachWhile(v -> v < 3);
 
         assertEquals(Arrays.asList(1, 2, 3), list);
     }
@@ -57,35 +46,15 @@ public class ObservableForEachTest extends RxJavaTest {
         final List<Object> list = new ArrayList<>();
 
         Observable.range(1, 5).concatWith(Observable.<Integer>error(new TestException()))
-        .doOnNext(new Consumer<Integer>() {
-            @Override
-            public void accept(Integer v) throws Exception {
-                list.add(v);
-            }
-        })
-        .forEachWhile(new Predicate<Integer>() {
-            @Override
-            public boolean test(Integer v) throws Exception {
-                return true;
-            }
-        }, new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable e) throws Exception {
-                list.add(100);
-            }
-        });
+        .doOnNext(list::add)
+        .forEachWhile(_ -> true, _ -> list.add(100));
 
         assertEquals(Arrays.asList(1, 2, 3, 4, 5, 100), list);
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(new Function<Observable<Integer>, Object>() {
-            @Override
-            public Object apply(Observable<Integer> f) throws Exception {
-                return f.forEachWhile(Functions.alwaysTrue());
-            }
-        }, false, 1, 1, (Object[])null);
+        TestHelper.checkBadSourceObservable(f -> f.forEachWhile(Functions.alwaysTrue()), false, 1, 1, (Object[])null);
     }
 
     @Test
@@ -105,11 +74,8 @@ public class ObservableForEachTest extends RxJavaTest {
     public void whilePredicateThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable.just(1).forEachWhile(new Predicate<Integer>() {
-                @Override
-                public boolean test(Integer v) throws Exception {
-                    throw new TestException();
-                }
+            Observable.just(1).forEachWhile(_ -> {
+                throw new TestException();
             });
 
             TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
@@ -125,11 +91,8 @@ public class ObservableForEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.<Integer>error(new TestException("Outer"))
-            .forEachWhile(Functions.alwaysTrue(), new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable v) throws Exception {
-                    throw new TestException("Inner");
-                }
+            .forEachWhile(Functions.alwaysTrue(), _ -> {
+                throw new TestException("Inner");
             });
 
             TestHelper.assertError(errors, 0, CompositeException.class);
@@ -148,11 +111,8 @@ public class ObservableForEachTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1).forEachWhile(Functions.alwaysTrue(), Functions.emptyConsumer(),
-                    new Action() {
-                        @Override
-                        public void run() throws Exception {
-                            throw new TestException();
-                        }
+                    () -> {
+                        throw new TestException();
                     });
 
             TestHelper.assertUndeliverable(errors, 0, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromActionTest.java
@@ -35,12 +35,7 @@ public class ObservableFromActionTest extends RxJavaTest {
     public void fromAction() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Observable.fromAction(atomicInteger::incrementAndGet)
             .test()
             .assertResult();
 
@@ -51,12 +46,7 @@ public class ObservableFromActionTest extends RxJavaTest {
     public void fromActionTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = atomicInteger::incrementAndGet;
 
         Observable.fromAction(run)
             .test()
@@ -75,12 +65,7 @@ public class ObservableFromActionTest extends RxJavaTest {
     public void fromActionInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable<Object> source = Observable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Observable<Object> source = Observable.fromAction(atomicInteger::incrementAndGet);
 
         assertEquals(0, atomicInteger.get());
 
@@ -93,11 +78,8 @@ public class ObservableFromActionTest extends RxJavaTest {
 
     @Test
     public void fromActionThrows() {
-        Observable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Observable.fromAction(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -108,12 +90,7 @@ public class ObservableFromActionTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Observable<Void> m = Observable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                counter[0]++;
-            }
-        });
+        Observable<Void> m = Observable.fromAction(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -129,12 +106,9 @@ public class ObservableFromActionTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Object> to = Observable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                }
+            TestObserver<Object> to = Observable.fromAction(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
             }).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -168,12 +142,7 @@ public class ObservableFromActionTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.dispose();
-            }
-        })
+        Observable.fromAction(to::dispose)
         .subscribeWith(to)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromCallableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromCallableTest.java
@@ -21,13 +21,11 @@ import java.util.List;
 import java.util.concurrent.*;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
@@ -96,22 +94,19 @@ public class ObservableFromCallableTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.call()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.call()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Observable<String> fromCallableObservable = Observable.fromCallable(func);
@@ -145,11 +140,8 @@ public class ObservableFromCallableTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Observable<Object> fromCallableObservable = Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                throw checkedException;
-            }
+        Observable<Object> fromCallableObservable = Observable.fromCallable(() -> {
+            throw checkedException;
         });
 
         Observer<Object> observer = TestHelper.mockObserver();
@@ -165,18 +157,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
     public void fusedFlatMapExecution() {
         final int[] calls = { 0 };
 
-        Observable.just(1).flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Observable.just(1).flatMap(_ -> Observable.fromCallable((Callable<Object>) () -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -187,18 +168,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
     public void fusedFlatMapExecutionHidden() {
         final int[] calls = { 0 };
 
-        Observable.just(1).hide().flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Observable.just(1).hide().flatMap(_ -> Observable.fromCallable((Callable<Object>) () -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -207,36 +177,14 @@ public class ObservableFromCallableTest extends RxJavaTest {
 
     @Test
     public void fusedFlatMapNull() {
-        Observable.just(1).flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Observable.just(1).flatMap(_ -> Observable.fromCallable(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void fusedFlatMapNullHidden() {
-        Observable.just(1).hide().flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromCallable(new Callable<Object>() {
-                    @Override
-                    public Object call() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Observable.just(1).hide().flatMap(_ -> Observable.fromCallable(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -244,12 +192,9 @@ public class ObservableFromCallableTest extends RxJavaTest {
     @Test
     public void disposedOnArrival() {
         final int[] count = { 0 };
-        Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                count[0]++;
-                return 1;
-            }
+        Observable.fromCallable((Callable<Object>) () -> {
+            count[0]++;
+            return 1;
         })
                 .test(true)
                 .assertEmpty();
@@ -261,12 +206,9 @@ public class ObservableFromCallableTest extends RxJavaTest {
     public void disposedOnCall() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.fromCallable(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                to.dispose();
-                return 1;
-            }
+        Observable.fromCallable(() -> {
+            to.dispose();
+            return 1;
         })
                 .subscribe(to);
 
@@ -279,12 +221,9 @@ public class ObservableFromCallableTest extends RxJavaTest {
         try {
             final TestObserver<Integer> to = new TestObserver<>();
 
-            Observable.fromCallable(new Callable<Integer>() {
-                @Override
-                public Integer call() throws Exception {
-                    to.dispose();
-                    throw new TestException();
-                }
+            Observable.fromCallable((Callable<Integer>) () -> {
+                to.dispose();
+                throw new TestException();
             })
                     .subscribe(to);
 
@@ -298,12 +237,7 @@ public class ObservableFromCallableTest extends RxJavaTest {
 
     @Test
     public void take() {
-        Observable.fromCallable(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return 1;
-            }
-        })
+        Observable.fromCallable((Callable<Object>) () -> 1)
                 .take(1)
                 .test()
                 .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromCompletableTest.java
@@ -36,12 +36,7 @@ public class ObservableFromCompletableTest extends RxJavaTest {
     public void fromCompletable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        }))
+        Observable.fromCompletable(Completable.fromAction(atomicInteger::incrementAndGet))
             .test()
             .assertResult();
 
@@ -52,12 +47,7 @@ public class ObservableFromCompletableTest extends RxJavaTest {
     public void fromCompletableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Action run = new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Action run = atomicInteger::incrementAndGet;
 
         Observable.fromCompletable(Completable.fromAction(run))
             .test()
@@ -76,12 +66,7 @@ public class ObservableFromCompletableTest extends RxJavaTest {
     public void fromCompletableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable<Object> source = Observable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                atomicInteger.incrementAndGet();
-            }
-        }));
+        Observable<Object> source = Observable.fromCompletable(Completable.fromAction(atomicInteger::incrementAndGet));
 
         assertEquals(0, atomicInteger.get());
 
@@ -94,11 +79,8 @@ public class ObservableFromCompletableTest extends RxJavaTest {
 
     @Test
     public void fromCompletableThrows() {
-        Observable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                throw new UnsupportedOperationException();
-            }
+        Observable.fromCompletable(Completable.fromAction(() -> {
+            throw new UnsupportedOperationException();
         }))
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -111,12 +93,9 @@ public class ObservableFromCompletableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Object> to = Observable.fromCompletable(Completable.fromAction(new Action() {
-                @Override
-                public void run() throws Exception {
-                    cdl1.countDown();
-                    cdl2.await(5, TimeUnit.SECONDS);
-                }
+            TestObserver<Object> to = Observable.fromCompletable(Completable.fromAction(() -> {
+                cdl1.countDown();
+                cdl2.await(5, TimeUnit.SECONDS);
             })).subscribeOn(Schedulers.single()).test();
 
             assertTrue(cdl1.await(5, TimeUnit.SECONDS));
@@ -150,12 +129,7 @@ public class ObservableFromCompletableTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.fromCompletable(Completable.fromAction(new Action() {
-            @Override
-            public void run() throws Exception {
-                to.dispose();
-            }
-        }))
+        Observable.fromCompletable(Completable.fromAction(to::dispose))
         .subscribeWith(to)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
@@ -57,29 +57,22 @@ public class ObservableFromIterableTest extends RxJavaTest {
      */
     @Test
     public void rawIterable() {
-        Iterable<String> it = new Iterable<String>() {
+        Iterable<String> it = () -> new Iterator<String>() {
+
+            int i;
 
             @Override
-            public Iterator<String> iterator() {
-                return new Iterator<String>() {
+            public boolean hasNext() {
+                return i < 3;
+            }
 
-                    int i;
+            @Override
+            public String next() {
+                return String.valueOf(++i);
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        return i < 3;
-                    }
-
-                    @Override
-                    public String next() {
-                        return String.valueOf(++i);
-                    }
-
-                    @Override
-                    public void remove() {
-                    }
-
-                };
+            @Override
+            public void remove() {
             }
 
         };
@@ -141,35 +134,29 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredWithBackpressure() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = new Iterable<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() {
+
+            int count = 1;
 
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-
-                    int count = 1;
-
-                    @Override
-                    public void remove() {
-                        // ignore
-                    }
-
-                    @Override
-                    public boolean hasNext() {
-                        if (count > 1) {
-                            called.set(true);
-                            return false;
-                        }
-                        return true;
-                    }
-
-                    @Override
-                    public Integer next() {
-                        return count++;
-                    }
-
-                };
+            public void remove() {
+                // ignore
             }
+
+            @Override
+            public boolean hasNext() {
+                if (count > 1) {
+                    called.set(true);
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return count++;
+            }
+
         };
         Observable.fromIterable(iterable).take(1).subscribe();
         assertFalse(called.get());
@@ -178,35 +165,29 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredFastPath() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = new Iterable<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() {
 
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-
-                    @Override
-                    public void remove() {
-                        // ignore
-                    }
-
-                    int count = 1;
-
-                    @Override
-                    public boolean hasNext() {
-                        if (count > 1) {
-                            called.set(true);
-                            return false;
-                        }
-                        return true;
-                    }
-
-                    @Override
-                    public Integer next() {
-                        return count++;
-                    }
-
-                };
+            public void remove() {
+                // ignore
             }
+
+            int count = 1;
+
+            @Override
+            public boolean hasNext() {
+                if (count > 1) {
+                    called.set(true);
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public Integer next() {
+                return count++;
+            }
+
         };
         Observable.fromIterable(iterable).subscribe(new DefaultObserver<Integer>() {
 
@@ -234,12 +215,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
 
         Observable.fromIterable(Arrays.asList(1, 2, 3, 4)).concatMap(
-        new Function<Integer, ObservableSource<Integer>>() {
-            @Override
-            public ObservableSource<Integer> apply(Integer v) {
-                return Observable.range(v, 2);
-            }
-        }).subscribe(to);
+                (Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2)).subscribe(to);
 
         to.assertValues(1, 2, 2, 3, 3, 4, 4, 5);
         to.assertNoErrors();
@@ -264,30 +240,25 @@ public class ObservableFromIterableTest extends RxJavaTest {
     public void hasNextCancels() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.fromIterable(new Iterable<Integer>() {
+        Observable.fromIterable(() -> new Iterator<Integer>() {
+            int count;
+
             @Override
-            public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() {
-                    int count;
+            public boolean hasNext() {
+                if (++count == 2) {
+                    to.dispose();
+                }
+                return true;
+            }
 
-                    @Override
-                    public boolean hasNext() {
-                        if (++count == 2) {
-                            to.dispose();
-                        }
-                        return true;
-                    }
+            @Override
+            public Integer next() {
+                return 1;
+            }
 
-                    @Override
-                    public Integer next() {
-                        return 1;
-                    }
-
-                    @Override
-                    public void remove() {
-                        throw new UnsupportedOperationException();
-                    }
-                };
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
             }
         })
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromRunnableTest.java
@@ -36,12 +36,7 @@ public class ObservableFromRunnableTest extends RxJavaTest {
     public void fromRunnable() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        })
+        Observable.fromRunnable(atomicInteger::incrementAndGet)
             .test()
             .assertResult();
 
@@ -52,12 +47,7 @@ public class ObservableFromRunnableTest extends RxJavaTest {
     public void fromRunnableTwice() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Runnable run = new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        };
+        Runnable run = atomicInteger::incrementAndGet;
 
         Observable.fromRunnable(run)
             .test()
@@ -76,12 +66,7 @@ public class ObservableFromRunnableTest extends RxJavaTest {
     public void fromRunnableInvokesLazy() {
         final AtomicInteger atomicInteger = new AtomicInteger();
 
-        Observable<Object> source = Observable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                atomicInteger.incrementAndGet();
-            }
-        });
+        Observable<Object> source = Observable.fromRunnable(atomicInteger::incrementAndGet);
 
         assertEquals(0, atomicInteger.get());
 
@@ -94,11 +79,8 @@ public class ObservableFromRunnableTest extends RxJavaTest {
 
     @Test
     public void fromRunnableThrows() {
-        Observable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                throw new UnsupportedOperationException();
-            }
+        Observable.fromRunnable(() -> {
+            throw new UnsupportedOperationException();
         })
             .test()
             .assertFailure(UnsupportedOperationException.class);
@@ -109,12 +91,7 @@ public class ObservableFromRunnableTest extends RxJavaTest {
     public void callable() throws Throwable {
         final int[] counter = { 0 };
 
-        Observable<Void> m = Observable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                counter[0]++;
-            }
-        });
+        Observable<Void> m = Observable.fromRunnable(() -> counter[0]++);
 
         assertTrue(m.getClass().toString(), m instanceof Supplier);
 
@@ -130,16 +107,13 @@ public class ObservableFromRunnableTest extends RxJavaTest {
             final CountDownLatch cdl1 = new CountDownLatch(1);
             final CountDownLatch cdl2 = new CountDownLatch(1);
 
-            TestObserver<Object> to = Observable.fromRunnable(new Runnable() {
-                @Override
-                public void run() {
-                    cdl1.countDown();
-                    try {
-                        cdl2.await(5, TimeUnit.SECONDS);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        throw new TestException(e);
-                    }
+            TestObserver<Object> to = Observable.fromRunnable(() -> {
+                cdl1.countDown();
+                try {
+                    cdl2.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    throw new TestException(e);
                 }
             }).subscribeOn(Schedulers.single()).test();
 
@@ -174,12 +148,7 @@ public class ObservableFromRunnableTest extends RxJavaTest {
     public void cancelWhileRunning() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.fromRunnable(new Runnable() {
-            @Override
-            public void run() {
-                to.dispose();
-            }
-        })
+        Observable.fromRunnable(to::dispose)
         .subscribeWith(to)
         .assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromSupplierTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromSupplierTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import io.reactivex.rxjava4.core.*;
@@ -96,22 +95,19 @@ public class ObservableFromSupplierTest extends RxJavaTest {
         final CountDownLatch funcLatch = new CountDownLatch(1);
         final CountDownLatch observerLatch = new CountDownLatch(1);
 
-        when(func.get()).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                observerLatch.countDown();
+        when(func.get()).thenAnswer((Answer<String>) _ -> {
+            observerLatch.countDown();
 
-                try {
-                    funcLatch.await();
-                } catch (InterruptedException e) {
-                    // It's okay, unsubscription causes Thread interruption
+            try {
+                funcLatch.await();
+            } catch (InterruptedException e) {
+                // It's okay, unsubscription causes Thread interruption
 
-                    // Restoring interruption status of the Thread
-                    Thread.currentThread().interrupt();
-                }
-
-                return "should_not_be_delivered";
+                // Restoring interruption status of the Thread
+                Thread.currentThread().interrupt();
             }
+
+            return "should_not_be_delivered";
         });
 
         Observable<String> fromSupplierObservable = Observable.fromSupplier(func);
@@ -145,11 +141,8 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     public void shouldAllowToThrowCheckedException() {
         final Exception checkedException = new Exception("test exception");
 
-        Observable<Object> fromSupplierObservable = Observable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                throw checkedException;
-            }
+        Observable<Object> fromSupplierObservable = Observable.fromSupplier(() -> {
+            throw checkedException;
         });
 
         Observer<Object> observer = TestHelper.mockObserver();
@@ -165,18 +158,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     public void fusedFlatMapExecution() {
         final int[] calls = { 0 };
 
-        Observable.just(1).flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Observable.just(1).flatMap(_ -> Observable.fromSupplier((Supplier<Object>) () -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -187,18 +169,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     public void fusedFlatMapExecutionHidden() {
         final int[] calls = { 0 };
 
-        Observable.just(1).hide().flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return ++calls[0];
-                    }
-                });
-            }
-        })
+        Observable.just(1).hide().flatMap(_ -> Observable.fromSupplier((Supplier<Object>) () -> ++calls[0]))
         .test()
         .assertResult(1);
 
@@ -207,36 +178,14 @@ public class ObservableFromSupplierTest extends RxJavaTest {
 
     @Test
     public void fusedFlatMapNull() {
-        Observable.just(1).flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Observable.just(1).flatMap(_ -> Observable.fromSupplier(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
 
     @Test
     public void fusedFlatMapNullHidden() {
-        Observable.just(1).hide().flatMap(new Function<Integer, ObservableSource<? extends Object>>() {
-            @Override
-            public ObservableSource<? extends Object> apply(Integer v)
-                    throws Exception {
-                return Observable.fromSupplier(new Supplier<Object>() {
-                    @Override
-                    public Object get() throws Exception {
-                        return null;
-                    }
-                });
-            }
-        })
+        Observable.just(1).hide().flatMap(_ -> Observable.fromSupplier(() -> null))
         .test()
         .assertFailure(NullPointerException.class);
     }
@@ -244,12 +193,9 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     @Test
     public void disposedOnArrival() {
         final int[] count = { 0 };
-        Observable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                count[0]++;
-                return 1;
-            }
+        Observable.fromSupplier((Supplier<Object>) () -> {
+            count[0]++;
+            return 1;
         })
         .test(true)
         .assertEmpty();
@@ -261,12 +207,9 @@ public class ObservableFromSupplierTest extends RxJavaTest {
     public void disposedOnCall() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.fromSupplier(new Supplier<Integer>() {
-            @Override
-            public Integer get() throws Exception {
-                to.dispose();
-                return 1;
-            }
+        Observable.fromSupplier(() -> {
+            to.dispose();
+            return 1;
         })
                 .subscribe(to);
 
@@ -279,12 +222,9 @@ public class ObservableFromSupplierTest extends RxJavaTest {
         try {
             final TestObserver<Integer> to = new TestObserver<>();
 
-            Observable.fromSupplier(new Supplier<Integer>() {
-                @Override
-                public Integer get() throws Exception {
-                    to.dispose();
-                    throw new TestException();
-                }
+            Observable.fromSupplier((Supplier<Integer>) () -> {
+                to.dispose();
+                throw new TestException();
             })
             .subscribe(to);
 
@@ -298,12 +238,7 @@ public class ObservableFromSupplierTest extends RxJavaTest {
 
     @Test
     public void take() {
-        Observable.fromSupplier(new Supplier<Object>() {
-            @Override
-            public Object get() throws Exception {
-                return 1;
-            }
-        })
+        Observable.fromSupplier((Supplier<Object>) () -> 1)
         .take(1)
         .test()
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableCombineLatestTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableCombineLatestTests.java
@@ -37,24 +37,9 @@ public class ObservableCombineLatestTests extends RxJavaTest {
         Observable.<Movie, CoolRating, Result> combineLatest(horrors, ratings, combine);
     }
 
-    BiFunction<Media, Rating, ExtendedResult> combine = new BiFunction<Media, Rating, ExtendedResult>() {
-        @Override
-        public ExtendedResult apply(Media m, Rating r) {
-            return new ExtendedResult();
-        }
-    };
+    BiFunction<Media, Rating, ExtendedResult> combine = (_, _) -> new ExtendedResult();
 
-    Consumer<Result> action = new Consumer<Result>() {
-        @Override
-        public void accept(Result t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<Result> action = t1 -> System.out.println("Result: " + t1);
 
-    Consumer<ExtendedResult> extendedAction = new Consumer<ExtendedResult>() {
-        @Override
-        public void accept(ExtendedResult t1) {
-            System.out.println("Result: " + t1);
-        }
-    };
+    Consumer<ExtendedResult> extendedAction = t1 -> System.out.println("Result: " + t1);
 }

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
@@ -44,12 +44,7 @@ public class ObservableCovarianceTest extends RxJavaTest {
 
     @Test
     public void sortedList() {
-        Comparator<Media> sortFunction = new Comparator<Media>() {
-            @Override
-            public int compare(Media t1, Media t2) {
-                return 1;
-            }
-        };
+        Comparator<Media> sortFunction = (_, _) -> 1;
 
         // this one would work without the covariance generics
         Observable<Media> o = Observable.just(new Movie(), new TVSeason(), new Album());
@@ -65,43 +60,13 @@ public class ObservableCovarianceTest extends RxJavaTest {
         Observable<Movie> movies = Observable.just(new HorrorMovie(), new ActionMovie(), new Movie());
         TestObserverEx<String> to = new TestObserverEx<>();
         movies
-        .groupBy(new Function<Movie, Object>() {
-            @Override
-            public Object apply(Movie v) {
-                return v.getClass();
-            }
-        })
-        .doOnNext(new Consumer<GroupedObservable<Object, Movie>>() {
-            @Override
-            public void accept(GroupedObservable<Object, Movie> g) {
-                System.out.println(g.getKey());
-            }
-        })
-        .flatMap(new Function<GroupedObservable<Object, Movie>, Observable<String>>() {
-            @Override
-            public Observable<String> apply(GroupedObservable<Object, Movie> g) {
-                return g
-                .doOnNext(new Consumer<Movie>() {
-                    @Override
-                    public void accept(Movie pv) {
-                        System.out.println(pv);
-                    }
-                })
-                .compose(new ObservableTransformer<Movie, Movie>() {
-                    @Override
-                    public Observable<Movie> apply(Observable<Movie> m) {
-                        return m.concatWith(Observable.just(new ActionMovie()));
-                    }
-                }
-                )
-                .map(new Function<Movie, String>() {
-                    @Override
-                    public String apply(Movie v) {
-                        return v.toString();
-                    }
-                });
-            }
-        })
+        .groupBy((Function<Movie, Object>) Movie::getClass)
+        .doOnNext(g -> System.out.println(g.getKey()))
+        .flatMap((Function<GroupedObservable<Object, Movie>, Observable<String>>) g -> g
+        .doOnNext(System.out::println)
+        .compose(m -> m.concatWith(Observable.just(new ActionMovie()))
+        )
+        .map(Object::toString))
         .subscribe(to);
         to.assertTerminated();
         to.assertNoErrors();
@@ -113,41 +78,21 @@ public class ObservableCovarianceTest extends RxJavaTest {
     @Test
     public void covarianceOfCompose() {
         Observable<HorrorMovie> movie = Observable.just(new HorrorMovie());
-        Observable<Movie> movie2 = movie.compose(new ObservableTransformer<HorrorMovie, Movie>() {
-            @Override
-            public Observable<Movie> apply(Observable<HorrorMovie> t) {
-                return Observable.just(new Movie());
-            }
-        });
+        Observable<Movie> movie2 = movie.compose(t -> Observable.just(new Movie()));
     }
 
     @SuppressWarnings("unused")
     @Test
     public void covarianceOfCompose2() {
         Observable<Movie> movie = Observable.<Movie> just(new HorrorMovie());
-        Observable<HorrorMovie> movie2 = movie.compose(new ObservableTransformer<Movie, HorrorMovie>() {
-            @Override
-            public Observable<HorrorMovie> apply(Observable<Movie> t) {
-                return Observable.just(new HorrorMovie());
-            }
-        });
+        Observable<HorrorMovie> movie2 = movie.compose(t -> Observable.just(new HorrorMovie()));
     }
 
     @SuppressWarnings("unused")
     @Test
     public void covarianceOfCompose3() {
         Observable<Movie> movie = Observable.<Movie>just(new HorrorMovie());
-        Observable<HorrorMovie> movie2 = movie.compose(new ObservableTransformer<Movie, HorrorMovie>() {
-            @Override
-            public Observable<HorrorMovie> apply(Observable<Movie> t) {
-                return Observable.just(new HorrorMovie()).map(new Function<HorrorMovie, HorrorMovie>() {
-                    @Override
-                    public HorrorMovie apply(HorrorMovie v) {
-                        return v;
-                    }
-                });
-            }
-        }
+        Observable<HorrorMovie> movie2 = movie.compose(t -> Observable.just(new HorrorMovie()).map(v -> v)
         );
     }
 
@@ -155,17 +100,7 @@ public class ObservableCovarianceTest extends RxJavaTest {
     @Test
     public void covarianceOfCompose4() {
         Observable<HorrorMovie> movie = Observable.just(new HorrorMovie());
-        Observable<HorrorMovie> movie2 = movie.compose(new ObservableTransformer<HorrorMovie, HorrorMovie>() {
-            @Override
-            public Observable<HorrorMovie> apply(Observable<HorrorMovie> t1) {
-                return t1.map(new Function<HorrorMovie, HorrorMovie>() {
-                    @Override
-                    public HorrorMovie apply(HorrorMovie v) {
-                        return v;
-                    }
-                });
-            }
-        });
+        Observable<HorrorMovie> movie2 = movie.compose(t1 -> t1.map(v -> v));
     }
 
     @Test
@@ -176,44 +111,36 @@ public class ObservableCovarianceTest extends RxJavaTest {
         movies.compose(deltaTransformer);
     }
 
-    static Function<List<List<Movie>>, Observable<Movie>> calculateDelta = new Function<List<List<Movie>>, Observable<Movie>>() {
-        @Override
-        public Observable<Movie> apply(List<List<Movie>> listOfLists) {
-            if (listOfLists.size() == 1) {
-                return Observable.fromIterable(listOfLists.get(0));
-            } else {
-                // diff the two
-                List<Movie> newList = listOfLists.get(1);
-                List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
+    static Function<List<List<Movie>>, Observable<Movie>> calculateDelta = listOfLists -> {
+        if (listOfLists.size() == 1) {
+            return Observable.fromIterable(listOfLists.get(0));
+        } else {
+            // diff the two
+            List<Movie> newList = listOfLists.get(1);
+            List<Movie> oldList = new ArrayList<>(listOfLists.get(0));
 
-                Set<Movie> delta = new LinkedHashSet<>();
-                delta.addAll(newList);
-                // remove all that match in old
-                delta.removeAll(oldList);
+            Set<Movie> delta = new LinkedHashSet<>();
+            delta.addAll(newList);
+            // remove all that match in old
+            delta.removeAll(oldList);
 
-                // filter oldList to those that aren't in the newList
-                oldList.removeAll(newList);
+            // filter oldList to those that aren't in the newList
+            oldList.removeAll(newList);
 
-                // for all left in the oldList we'll create DROP events
-                for (@SuppressWarnings("unused") Movie old : oldList) {
-                    delta.add(new Movie());
-                }
-
-                return Observable.fromIterable(delta);
+            // for all left in the oldList we'll create DROP events
+            for (@SuppressWarnings("unused") Movie old : oldList) {
+                delta.add(new Movie());
             }
+
+            return Observable.fromIterable(delta);
         }
     };
 
-    static ObservableTransformer<List<Movie>, Movie> deltaTransformer = new ObservableTransformer<List<Movie>, Movie>() {
-        @Override
-        public Observable<Movie> apply(Observable<List<Movie>> movieList) {
-            return movieList
-                .startWithItem(new ArrayList<>())
-                .buffer(2, 1)
-                .skip(1)
-                .flatMap(calculateDelta);
-        }
-    };
+    static ObservableTransformer<List<Movie>, Movie> deltaTransformer = movieList -> movieList
+        .startWithItem(new ArrayList<>())
+        .buffer(2, 1)
+        .skip(1)
+        .flatMap(calculateDelta);
 
     /*
      * Most tests are moved into their applicable classes such as [Operator]Tests.java

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableDoOnTest.java
@@ -21,19 +21,13 @@ import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
 
 public class ObservableDoOnTest extends RxJavaTest {
 
     @Test
     public void doOnEach() {
         final AtomicReference<String> r = new AtomicReference<>();
-        String output = Observable.just("one").doOnNext(new Consumer<String>() {
-            @Override
-            public void accept(String v) {
-                r.set(v);
-            }
-        }).blockingSingle();
+        String output = Observable.just("one").doOnNext(r::set).blockingSingle();
 
         assertEquals("one", output);
         assertEquals("one", r.get());
@@ -45,12 +39,7 @@ public class ObservableDoOnTest extends RxJavaTest {
         Throwable t = null;
         try {
             Observable.<String> error(new RuntimeException("an error"))
-            .doOnError(new Consumer<Throwable>() {
-                @Override
-                public void accept(Throwable v) {
-                    r.set(v);
-                }
-            }).blockingSingle();
+            .doOnError(r::set).blockingSingle();
             fail("expected exception, not a return value");
         } catch (Throwable e) {
             t = e;
@@ -63,12 +52,7 @@ public class ObservableDoOnTest extends RxJavaTest {
     @Test
     public void doOnCompleted() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Observable.just("one").doOnComplete(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        }).blockingSingle();
+        String output = Observable.just("one").doOnComplete(() -> r.set(true)).blockingSingle();
 
         assertEquals("one", output);
         assertTrue(r.get());
@@ -77,12 +61,7 @@ public class ObservableDoOnTest extends RxJavaTest {
     @Test
     public void doOnTerminateComplete() {
         final AtomicBoolean r = new AtomicBoolean();
-        String output = Observable.just("one").doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        }).blockingSingle();
+        String output = Observable.just("one").doOnTerminate(() -> r.set(true)).blockingSingle();
 
         assertEquals("one", output);
         assertTrue(r.get());
@@ -92,12 +71,7 @@ public class ObservableDoOnTest extends RxJavaTest {
     @Test
     public void doOnTerminateError() {
         final AtomicBoolean r = new AtomicBoolean();
-        Observable.<String>error(new TestException()).doOnTerminate(new Action() {
-            @Override
-            public void run() {
-                r.set(true);
-            }
-        })
+        Observable.<String>error(new TestException()).doOnTerminate(() -> r.set(true))
         .test()
         .assertFailure(TestException.class);
         assertTrue(r.get());


### PR DESCRIPTION
Will go over the unit tests in ASCII order of the classpath and classes.

IntelliJ: Inspect -> *RedundantCast*, Inspect -> *Anonymous type can be replaced by lambda*
Search regexp: `new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

/* NFI */ = Not Functional Interface so break the regexp pattern

If you complain instead of proposing a PR about "why not convert to method references" you'll be banned. 

Related: #8080