### PR TITLE
4.x: API turn Completable concatX and mergeX into config-based

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -15,14 +15,14 @@ package io.reactivex.rxjava4.core;
 
 import java.util.*;
 import java.util.concurrent.*;
-
-import static java.util.concurrent.Flow.*;
+import java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.core.config.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
-import io.reactivex.rxjava4.internal.functions.*;
+import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.fuseable.*;
 import io.reactivex.rxjava4.internal.jdk8.*;
 import io.reactivex.rxjava4.internal.observers.*;
@@ -192,14 +192,7 @@ public abstract class Completable implements CompletableSource {
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
     public static Completable concatArray(@NonNull CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
-        if (sources.length == 0) {
-            return complete();
-        } else
-        if (sources.length == 1) {
-            return wrap(sources[0]);
-        }
-        return RxJavaPlugins.onAssembly(new CompletableConcatArray(sources));
+        return concatArray(CompletableConcatConfig.DEFAULT, sources);
     }
 
     /**
@@ -211,16 +204,29 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the sources to concatenate
+     * @param config the configuration record for this operator
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static Completable concatArrayDelayError(@NonNull CompletableSource... sources) {
-        return Flowable.fromArray(sources).concatMapCompletableDelayError(Functions.identity(), true, 2);
+    public static Completable concatArray(@NonNull CompletableConcatConfig config, @NonNull CompletableSource... sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(config, "config is null");
+        if (sources.length == 0) {
+            return complete();
+        } else
+        if (sources.length == 1) {
+            return wrap(sources[0]);
+        }
+        if (config.delayError()) {
+            return Flowable.fromArray(sources).concatMapCompletableDelayError(Functions.identity(), true, config.prefetch());
+        }
+        return RxJavaPlugins.onAssembly(new CompletableConcatArray(sources));
+
     }
 
     /**
@@ -239,9 +245,7 @@ public abstract class Completable implements CompletableSource {
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable concat(@NonNull Iterable<@NonNull ? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
-
-        return RxJavaPlugins.onAssembly(new CompletableConcatIterable(sources));
+        return concat(sources, CompletableConcatConfig.DEFAULT);
     }
 
     /**
@@ -264,7 +268,7 @@ public abstract class Completable implements CompletableSource {
     @BackpressureSupport(BackpressureKind.FULL)
     @NonNull
     public static Completable concat(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
-        return concat(sources, 2);
+        return concat(sources, CompletableConcatConfig.DEFAULT);
     }
 
     /**
@@ -279,19 +283,24 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the sources to concatenate
-     * @param prefetch the number of sources to prefetch from the sources
+     * @param config the operatar configuration record
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code prefetch} is non-positive
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable concat(@NonNull Publisher<@NonNull ? extends CompletableSource> sources, int prefetch) {
+    public static Completable concat(@NonNull Publisher<@NonNull ? extends CompletableSource> sources,
+            @NonNull CompletableConcatConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new CompletableConcat(sources, prefetch));
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayError()) {
+            return Flowable.fromPublisher(sources).concatMapCompletableDelayError(Functions.identity(), true, config.prefetch());
+        }
+        return RxJavaPlugins.onAssembly(new CompletableConcat(sources, config.prefetch()));
     }
 
     /**
@@ -303,65 +312,21 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the sources to concatenate
+     * @param config the configuration record for this operator
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable concatDelayError(@NonNull Iterable<@NonNull ? extends CompletableSource> sources) {
-        return Flowable.fromIterable(sources).concatMapCompletableDelayError(Functions.identity());
-    }
-
-    /**
-     * Returns a {@code Completable} which completes only when all sources complete, one after another.
-     * <p>
-     * <img width="640" height="396" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.concatDelayError.p.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
-     *  and expects the other {@link Publisher} to honor it as well.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param sources the sources to concatenate
-     * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
-    @NonNull
-    public static Completable concatDelayError(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
-        return concatDelayError(sources, 2);
-    }
-
-    /**
-     * Returns a {@code Completable} which completes only when all sources complete, one after another.
-     * <p>
-     * <img width="640" height="359" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.concatDelayError.pn.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Completable} honors the backpressure of the downstream consumer
-     *  and expects the other {@link Publisher} to honor it as well.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param sources the sources to concatenate
-     * @param prefetch the number of sources to prefetch from the sources
-     * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code prefetch} is non-positive
-     * @since 3.0.0
-     */
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
-    public static Completable concatDelayError(@NonNull Publisher<@NonNull ? extends CompletableSource> sources, int prefetch) {
-        return Flowable.fromPublisher(sources).concatMapCompletableDelayError(Functions.identity(), true, prefetch);
+    public static Completable concat(@NonNull Iterable<@NonNull ? extends CompletableSource> sources, @NonNull CompletableConcatConfig config) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayError()) {
+            return Flowable.fromIterable(sources).concatMapCompletableDelayError(Functions.identity(), true, config.prefetch());
+        }
+        return RxJavaPlugins.onAssembly(new CompletableConcatIterable(sources));
     }
 
     /**
@@ -434,7 +399,7 @@ public abstract class Completable implements CompletableSource {
     public static Single<Boolean> sequenceEqual(@NonNull CompletableSource source1, @NonNull CompletableSource source2) { // NOPMD
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
-        return mergeArrayDelayError(source1, source2).andThen(Single.just(true));
+        return mergeArray(CompletableMergeConfig.DEFAULT, source1, source2).andThen(Single.just(true));
     }
 
     /**
@@ -801,28 +766,18 @@ public abstract class Completable implements CompletableSource {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeArrayDelayError(CompletableSource...)} to merge sources and terminate only when all source {@code CompletableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param sources the array of {@code CompletableSource}s.
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeArrayDelayError(CompletableSource...)
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
     public static Completable mergeArray(@NonNull CompletableSource... sources) {
-        Objects.requireNonNull(sources, "sources is null");
-        if (sources.length == 0) {
-            return complete();
-        } else
-        if (sources.length == 1) {
-            return wrap(sources[0]);
-        }
-        return RxJavaPlugins.onAssembly(new CompletableMergeArray(sources));
+        return mergeArray(CompletableMergeConfig.DEFAULT, sources);
     }
 
     /**
@@ -843,21 +798,17 @@ public abstract class Completable implements CompletableSource {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code CompletableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param sources the {@link Iterable} sequence of {@code CompletableSource}s.
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeDelayError(Iterable)
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     public static Completable merge(@NonNull Iterable<@NonNull ? extends CompletableSource> sources) {
-        Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new CompletableMergeIterable(sources));
+        return merge(sources, CompletableMergeConfig.DEFAULT);
     }
 
     /**
@@ -881,21 +832,18 @@ public abstract class Completable implements CompletableSource {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code CompletableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param sources the {@code Publisher} sequence of {@code CompletableSource}s.
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeDelayError(Publisher)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
     @NonNull
     public static Completable merge(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
-        return merge0(sources, Integer.MAX_VALUE, false);
+        return merge(sources, new CompletableMergeConfig(false, Integer.MAX_VALUE));
     }
 
     /**
@@ -920,52 +868,24 @@ public abstract class Completable implements CompletableSource {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Completable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code CompletableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param sources the {@code Publisher} sequence of {@code CompletableSource}s.
-     * @param maxConcurrency the maximum number of concurrent subscriptions
+     * @param config the configuration record for this operator
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code maxConcurrency} is less than 1
-     * @see #mergeDelayError(Publisher, int)
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @BackpressureSupport(BackpressureKind.FULL)
     @NonNull
-    public static Completable merge(@NonNull Publisher<@NonNull ? extends CompletableSource> sources, int maxConcurrency) {
-        return merge0(sources, maxConcurrency, false);
-    }
-
-    /**
-     * Returns a {@code Completable} instance that keeps subscriptions to a limited number of {@link CompletableSource}s at once and
-     * completes only when all source {@code CompletableSource}s terminate in one way or another, combining any exceptions
-     * signaled by either the source {@link Publisher} or the inner {@code CompletableSource} instances.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the given {@code Publisher} in a bounded manner,
-     *  requesting {@code maxConcurrency} items first, then keeps requesting as
-     *  many more as the inner {@code CompletableSource}s terminate.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge0} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param sources the {@code Publisher} sequence of {@code CompletableSource}s.
-     * @param maxConcurrency the maximum number of concurrent subscriptions
-     * @param delayErrors delay all errors from the main source and from the inner {@code CompletableSource}s?
-     * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is less than 1
-     */
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
-    private static Completable merge0(@NonNull Publisher<@NonNull ? extends CompletableSource> sources, int maxConcurrency, boolean delayErrors) {
+    public static Completable merge(@NonNull Publisher<@NonNull ? extends CompletableSource> sources,
+            @NonNull CompletableMergeConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new CompletableMerge(sources, maxConcurrency, delayErrors));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new CompletableMerge(sources, config.maxConcurrency(), config.delayErrors()));
     }
 
     /**
@@ -979,16 +899,28 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of {@code CompletableSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
-    public static Completable mergeArrayDelayError(@NonNull CompletableSource... sources) {
+    public static Completable mergeArray(@NonNull CompletableMergeConfig config, @NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new CompletableMergeArrayDelayError(sources));
+        Objects.requireNonNull(config, "config is null");
+        if (sources.length == 0) {
+            return complete();
+        } else
+        if (sources.length == 1) {
+            return wrap(sources[0]);
+        }
+        if (config.delayErrors()) {
+            return RxJavaPlugins.onAssembly(new CompletableMergeArrayDelayError(sources /* TODO , config.maxConcurrency() */));
+        }
+        return RxJavaPlugins.onAssembly(new CompletableMergeArray(sources /* TODO , config.maxConcurrency() */));
+
     }
 
     /**
@@ -1002,69 +934,21 @@ public abstract class Completable implements CompletableSource {
      *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the sequence of {@code CompletableSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static Completable mergeDelayError(@NonNull Iterable<@NonNull ? extends CompletableSource> sources) {
+    public static Completable merge(@NonNull Iterable<@NonNull ? extends CompletableSource> sources, @NonNull CompletableMergeConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorIterable(sources));
-    }
-
-    /**
-     * Returns a {@code Completable} that subscribes to all {@link CompletableSource}s in the source sequence and delays
-     * any error emitted by either the sources {@link Publisher} or any of the inner {@code CompletableSource}s until all of
-     * them terminate in a way or another.
-     * <p>
-     * <img width="640" height="466" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.mergeDelayError.p.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator consumes the {@code Publisher} in an unbounded manner
-     *  (requesting {@link Long#MAX_VALUE} from it).</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param sources the sequence of {@code CompletableSource}s
-     * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.UNBOUNDED_IN)
-    @NonNull
-    public static Completable mergeDelayError(@NonNull Publisher<@NonNull ? extends CompletableSource> sources) {
-        return merge0(sources, Integer.MAX_VALUE, true);
-    }
-
-    /**
-     * Returns a {@code Completable} that subscribes to a limited number of inner {@link CompletableSource}s at once in
-     * the source sequence and delays any error emitted by either the sources
-     * {@link Publisher} or any of the inner {@code CompletableSource}s until all of
-     * them terminate in a way or another.
-     * <p>
-     * <img width="640" height="440" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.mergeDelayError.pn.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator requests {@code maxConcurrency} items from the {@code Publisher}
-     *  upfront and keeps requesting as many more as many inner {@code CompletableSource}s terminate.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param sources the sequence of {@code CompletableSource}s
-     * @param maxConcurrency the maximum number of concurrent subscriptions to have
-     *                       at a time to the inner {@code CompletableSource}s
-     * @return the new {@code Completable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @BackpressureSupport(BackpressureKind.FULL)
-    @NonNull
-    public static Completable mergeDelayError(@NonNull Publisher<@NonNull ? extends CompletableSource> sources, int maxConcurrency) {
-        return merge0(sources, maxConcurrency, true);
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayErrors()) {
+            return RxJavaPlugins.onAssembly(new CompletableMergeDelayErrorIterable(sources /* TODO , config.maxConcurrency() */));
+        }
+        return RxJavaPlugins.onAssembly(new CompletableMergeIterable(sources /* TODO , config.maxConcurrency() */));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/CompletableConcatConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/CompletableConcatConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Completable.concat() operators.
+ * @param delayError should the error propagation be delayed?
+ * @param prefetch the number of source sequences to request from a backpressured source
+ * @since 4.0.0
+ */
+public record CompletableConcatConfig(boolean delayError, int prefetch) {
+
+    /**
+     * The default configuration with no error delays and prefetch of 2.
+     */
+    public static final CompletableConcatConfig DEFAULT = new CompletableConcatConfig(false, 2);
+
+    /**
+     * The default configuration with error delays and prefetch of 2.
+     */
+    public static final CompletableConcatConfig DELAY_ERROR = new CompletableConcatConfig(true, 2);
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     */
+    public CompletableConcatConfig(boolean delayError) {
+        this(delayError, 2);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param prefetch the number of source sequences to request from a backpressured source
+     */
+    public CompletableConcatConfig(int prefetch) {
+        this(false, prefetch);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     * @param prefetch the number of source sequences to request from a backpressured source
+     */
+    public CompletableConcatConfig(boolean delayError, int prefetch) {
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        this.delayError = delayError;
+        this.prefetch = prefetch;
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Completable.merge() operators.
+ * @param delayErrors should the error propagation be delayed?
+ * @param maxConcurrency the number of source sequences run concurrently
+ * @since 4.0.0
+ */
+public record CompletableMergeConfig(boolean delayErrors, int maxConcurrency) {
+
+    /**
+     * The default config with no error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     */
+    public static final CompletableMergeConfig DEFAULT = new CompletableMergeConfig(false, Flowable.bufferSize());
+
+    /**
+     * The default config with error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     */
+    public static final CompletableMergeConfig DELAY_ERRORS = new CompletableMergeConfig(true, Flowable.bufferSize());
+
+    /**
+     * Constructs a configuration record.
+     * @param delayErrors should the error propagation be delayed?
+     */
+    public CompletableMergeConfig(boolean delayErrors) {
+        this(delayErrors, 2);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param maxConcurrency the number of source sequences run concurrently
+     */
+    public CompletableMergeConfig(int maxConcurrency) {
+        this(false, maxConcurrency);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayErrors should the error propagation be delayed?
+     * @param maxConcurrency the number of source sequences run concurrently
+     */
+    public CompletableMergeConfig(boolean delayErrors, int maxConcurrency) {
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
+        this.delayErrors = delayErrors;
+        this.maxConcurrency = maxConcurrency;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.config.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -321,7 +322,7 @@ public class CompletableTest extends RxJavaTest {
                 .repeat(10)
                 .doOnRequest(requested::add);
 
-        Completable c = Completable.concat(cs, 5);
+        Completable c = Completable.concat(cs, new CompletableConcatConfig(5));
 
         c.blockingAwait();
 
@@ -683,7 +684,7 @@ public class CompletableTest extends RxJavaTest {
                 .repeat(10)
                 .doOnRequest(requested::add);
 
-        Completable c = Completable.merge(cs, 5);
+        Completable c = Completable.merge(cs, new CompletableMergeConfig(5));
 
         c.blockingAwait();
 
@@ -693,14 +694,14 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void mergeDelayErrorEmpty() {
-        Completable c = Completable.mergeArrayDelayError();
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorSingleSource() {
-        Completable c = Completable.mergeArrayDelayError(normal.completable);
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, normal.completable);
 
         c.blockingAwait();
 
@@ -709,14 +710,14 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorSingleSourceThrows() {
-        Completable c = Completable.mergeArrayDelayError(error.completable);
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, error.completable);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorMultipleSources() {
-        Completable c = Completable.mergeArrayDelayError(normal.completable, normal.completable, normal.completable);
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, normal.completable, normal.completable, normal.completable);
 
         c.blockingAwait();
 
@@ -725,7 +726,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void mergeDelayErrorMultipleOneThrows() {
-        Completable c = Completable.mergeArrayDelayError(normal.completable, error.completable, normal.completable);
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, normal.completable, error.completable, normal.completable);
 
         try {
             c.blockingAwait();
@@ -736,28 +737,28 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorMultipleOneIsNull() {
-        Completable c = Completable.mergeArrayDelayError(normal.completable, null);
+        Completable c = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, normal.completable, null);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorIterableEmpty() {
-        Completable c = Completable.mergeDelayError(Collections.<Completable>emptyList());
+        Completable c = Completable.merge(Collections.<Completable>emptyList(), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test(expected = NullPointerException.class)
     public void mergeDelayErrorIterableIteratorNull() {
-        Completable c = Completable.mergeDelayError((Iterable<Completable>) () -> null);
+        Completable c = Completable.merge((Iterable<Completable>) () -> null, CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorIterableSingle() {
-        Completable c = Completable.mergeDelayError(Collections.singleton(normal.completable));
+        Completable c = Completable.merge(Collections.singleton(normal.completable), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
 
@@ -766,7 +767,8 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void mergeDelayErrorIterableMany() {
-        Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, normal.completable, normal.completable));
+        Completable c = Completable.merge(
+                Arrays.asList(normal.completable, normal.completable, normal.completable), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
 
@@ -775,14 +777,15 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableOneThrows() {
-        Completable c = Completable.mergeDelayError(Collections.singleton(error.completable));
+        Completable c = Completable.merge(Collections.singleton(error.completable), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorIterableManyOneThrows() {
-        Completable c = Completable.mergeDelayError(Arrays.asList(normal.completable, error.completable, normal.completable));
+        Completable c = Completable.merge(
+                Arrays.asList(normal.completable, error.completable, normal.completable), CompletableMergeConfig.DELAY_ERRORS);
 
         try {
             c.blockingAwait();
@@ -793,44 +796,44 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIterableThrows() {
-        Completable c = Completable.mergeDelayError((Iterable<Completable>) () -> {
+        Completable c = Completable.merge((Iterable<Completable>) () -> {
             throw new TestException();
-        });
+        }, CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIteratorHasNextThrows() {
-        Completable c = Completable.mergeDelayError(new IterableIteratorHasNextThrows());
+        Completable c = Completable.merge(new IterableIteratorHasNextThrows(), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorIterableIteratorNextThrows() {
-        Completable c = Completable.mergeDelayError(new IterableIteratorNextThrows());
+        Completable c = Completable.merge(new IterableIteratorNextThrows(), CompletableMergeConfig.DELAY_ERRORS);
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorObservableEmpty() {
-        Completable c = Completable.mergeDelayError(Flowable.<Completable>empty());
+        Completable c = Completable.merge(Flowable.<Completable>empty(), new CompletableMergeConfig(true));
 
         c.blockingAwait();
     }
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorObservableError() {
-        Completable c = Completable.mergeDelayError(Flowable.<Completable>error(TestException::new));
+        Completable c = Completable.merge(Flowable.<Completable>error(TestException::new), new CompletableMergeConfig(true));
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorObservableSingle() {
-        Completable c = Completable.mergeDelayError(Flowable.just(normal.completable));
+        Completable c = Completable.merge(Flowable.just(normal.completable), new CompletableMergeConfig(true));
 
         c.blockingAwait();
 
@@ -839,14 +842,14 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorObservableSingleThrows() {
-        Completable c = Completable.mergeDelayError(Flowable.just(error.completable));
+        Completable c = Completable.merge(Flowable.just(error.completable), new CompletableMergeConfig(true));
 
         c.blockingAwait();
     }
 
     @Test
     public void mergeDelayErrorObservableMany() {
-        Completable c = Completable.mergeDelayError(Flowable.just(normal.completable).repeat(3));
+        Completable c = Completable.merge(Flowable.just(normal.completable).repeat(3), new CompletableMergeConfig(true));
 
         c.blockingAwait();
 
@@ -855,7 +858,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test(expected = TestException.class)
     public void mergeDelayErrorObservableManyOneThrows() {
-        Completable c = Completable.mergeDelayError(Flowable.just(normal.completable, error.completable));
+        Completable c = Completable.merge(Flowable.just(normal.completable, error.completable), new CompletableMergeConfig(true));
 
         c.blockingAwait();
     }
@@ -868,7 +871,7 @@ public class CompletableTest extends RxJavaTest {
                 .repeat(10)
                 .doOnRequest(requested::add);
 
-        Completable c = Completable.mergeDelayError(cs, 5);
+        Completable c = Completable.merge(cs, new CompletableMergeConfig(true, 5));
 
         c.blockingAwait();
 

--- a/src/test/java/io/reactivex/rxjava4/core/config/CompletableConcatConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/CompletableConcatConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+
+public class CompletableConcatConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new CompletableConcatConfig(true).delayError(), "delayError - true");
+        assertFalse(new CompletableConcatConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new CompletableConcatConfig(5).prefetch(), "prefetch - 5");
+        assertEquals(5, new CompletableConcatConfig(true, 5).prefetch(), "prefetch both - true, 5");
+        assertEquals(5, new CompletableConcatConfig(false, 5).prefetch(), "prefetch both - false, 5");
+        assertTrue(new CompletableConcatConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new CompletableConcatConfig(false, 5).delayError(), "delayError both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/CompletableMergeConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/CompletableMergeConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+
+public class CompletableMergeConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new CompletableMergeConfig(true).delayErrors(), "delayErrors - true");
+        assertFalse(new CompletableMergeConfig(false).delayErrors(), "delayErrors - false");
+        assertEquals(5, new CompletableMergeConfig(5).maxConcurrency(), "maxConcurrency - 5");
+        assertEquals(5, new CompletableMergeConfig(true, 5).maxConcurrency(), "maxConcurrency both - true, 5");
+        assertEquals(5, new CompletableMergeConfig(false, 5).maxConcurrency(), "maxConcurrency both - false, 5");
+        assertTrue(new CompletableMergeConfig(true, 5).delayErrors(), "delayErrors both - true, 5");
+        assertFalse(new CompletableMergeConfig(false, 5).delayErrors(), "delayErrors both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatArrayDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatArrayDelayErrorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.Completable;
+import io.reactivex.rxjava4.core.config.CompletableConcatConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.Action;
 
@@ -27,7 +28,7 @@ public class CompletableConcatArrayDelayErrorTest {
         Action action1 = mock(Action.class);
         Action action2 = mock(Action.class);
 
-        Completable.concatArrayDelayError(
+        Completable.concatArray(CompletableConcatConfig.DELAY_ERROR,
                 Completable.fromAction(action1),
                 Completable.error(new TestException()),
                 Completable.fromAction(action2)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatDelayErrorTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.CompletableConcatConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.Action;
 
@@ -30,11 +31,11 @@ public class CompletableConcatDelayErrorTest {
         Action action1 = mock(Action.class);
         Action action2 = mock(Action.class);
 
-        Completable.concatDelayError(Arrays.asList(
+        Completable.concat(Arrays.asList(
                 Completable.fromAction(action1),
                 Completable.error(new TestException()),
                 Completable.fromAction(action2)
-        ))
+        ), CompletableConcatConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
 
@@ -48,11 +49,11 @@ public class CompletableConcatDelayErrorTest {
         Action action1 = mock(Action.class);
         Action action2 = mock(Action.class);
 
-        Completable.concatDelayError(Flowable.fromArray(
+        Completable.concat(Flowable.fromArray(
                 Completable.fromAction(action1),
                 Completable.error(new TestException()),
                 Completable.fromAction(action2)
-        ))
+        ), new CompletableConcatConfig(true))
         .test()
         .assertFailure(TestException.class);
 
@@ -66,11 +67,11 @@ public class CompletableConcatDelayErrorTest {
         Action action1 = mock(Action.class);
         Action action2 = mock(Action.class);
 
-        Completable.concatDelayError(Flowable.fromArray(
+        Completable.concat(Flowable.fromArray(
                 Completable.fromAction(action1),
                 Completable.error(new TestException()),
                 Completable.fromAction(action2)
-        ), 1)
+        ), new CompletableConcatConfig(true, 1))
         .test()
         .assertFailure(TestException.class);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatTest.java
@@ -18,10 +18,11 @@ import static org.junit.Assert.*;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 
-import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.CompletableConcatConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.observers.TestObserver;
@@ -44,7 +45,7 @@ public class CompletableConcatTest extends RxJavaTest {
                     s.onNext(Completable.never());
                     s.onNext(Completable.never());
                     s.onComplete();
-                }), 1
+                }), new CompletableConcatConfig(1)
             )
             .test()
             .assertFailure(QueueOverflowException.class);
@@ -58,7 +59,7 @@ public class CompletableConcatTest extends RxJavaTest {
     @Test
     public void invalidPrefetch() {
         try {
-            Completable.concat(Flowable.just(Completable.complete()), -99);
+            Completable.concat(Flowable.just(Completable.complete()), new CompletableConcatConfig(-99));
             fail("Should have thrown IllegalArgumentExceptio");
         } catch (IllegalArgumentException ex) {
             assertEquals("prefetch > 0 required but it was -99", ex.getMessage());
@@ -112,14 +113,14 @@ public class CompletableConcatTest extends RxJavaTest {
 
     @Test
     public void unboundedIn() {
-        Completable.concat(Flowable.just(Completable.complete()).hide(), Integer.MAX_VALUE)
+        Completable.concat(Flowable.just(Completable.complete()).hide(), new CompletableConcatConfig(Integer.MAX_VALUE))
         .test()
         .assertResult();
     }
 
     @Test
     public void syncFusedUnboundedIn() {
-        Completable.concat(Flowable.just(Completable.complete()), Integer.MAX_VALUE)
+        Completable.concat(Flowable.just(Completable.complete()), new CompletableConcatConfig(Integer.MAX_VALUE))
         .test()
         .assertResult();
     }
@@ -130,7 +131,7 @@ public class CompletableConcatTest extends RxJavaTest {
         up.onNext(Completable.complete());
         up.onComplete();
 
-        Completable.concat(up, Integer.MAX_VALUE)
+        Completable.concat(up, new CompletableConcatConfig(Integer.MAX_VALUE))
         .test()
         .assertResult();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
@@ -16,12 +16,13 @@ package io.reactivex.rxjava4.internal.operators.completable;
 import static org.junit.Assert.*;
 
 import java.util.*;
+import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.CompletableMergeConfig;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
@@ -36,7 +37,7 @@ public class CompletableMergeTest extends RxJavaTest {
     @Test
     public void invalidPrefetch() {
         try {
-            Completable.merge(Flowable.just(Completable.complete()), -99);
+            Completable.merge(Flowable.just(Completable.complete()), new CompletableMergeConfig(-99));
             fail("Should have thrown IllegalArgumentExceptio");
         } catch (IllegalArgumentException ex) {
             assertEquals("maxConcurrency > 0 required but it was -99", ex.getMessage());
@@ -64,7 +65,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void cancelAfterFirstDelayError() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeArrayDelayError(new Completable() /* NFI */ {
+        Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -83,7 +84,7 @@ public class CompletableMergeTest extends RxJavaTest {
         try {
             final CompletableObserver[] co = { null };
 
-            Completable.mergeArrayDelayError(Completable.complete(), new Completable() /* NFI */ {
+            Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, Completable.complete(), new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -118,7 +119,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void completeAfterMainDelayError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeArrayDelayError(Completable.complete(), pp.ignoreElements())
+        TestObserver<Void> to = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, Completable.complete(), pp.ignoreElements())
         .test();
 
         pp.onComplete();
@@ -130,7 +131,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void errorAfterMainDelayError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeArrayDelayError(Completable.complete(), pp.ignoreElements())
+        TestObserver<Void> to = Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, Completable.complete(), pp.ignoreElements())
         .test();
 
         pp.onError(new TestException());
@@ -185,7 +186,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void innerErrorDelayError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp.ignoreElements())).test();
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp.ignoreElements()), new CompletableMergeConfig(true)).test();
 
         pp.onError(new TestException());
 
@@ -239,7 +240,7 @@ public class CompletableMergeTest extends RxJavaTest {
             final PublishProcessor<Integer> pp1 = PublishProcessor.create();
             final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-            TestObserverEx<Void> to = Completable.mergeDelayError(pp1.map(_ -> pp2.ignoreElements()))
+            TestObserverEx<Void> to = Completable.merge(pp1.map(_ -> pp2.ignoreElements()), new CompletableMergeConfig(true))
                     .to(TestHelper.<Void>testConsumer());
 
             pp1.onNext(1);
@@ -267,7 +268,8 @@ public class CompletableMergeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.merge(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        TestObserver<Void> to = Completable.merge(
+                Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), new CompletableMergeConfig(true, 1))
         .test();
 
         assertTrue(pp1.hasSubscribers());
@@ -287,7 +289,8 @@ public class CompletableMergeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        TestObserver<Void> to = Completable.merge(
+                Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), new CompletableMergeConfig(true, 1))
         .test();
 
         assertTrue(pp1.hasSubscribers());
@@ -307,7 +310,7 @@ public class CompletableMergeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeDelayError(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), 1)
+        TestObserver<Void> to = Completable.merge(Flowable.just(pp1.ignoreElements(), pp2.ignoreElements()), new CompletableMergeConfig(true, 1))
         .test();
 
         assertTrue(pp1.hasSubscribers());
@@ -328,8 +331,8 @@ public class CompletableMergeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestObserver<Void> to = Completable.mergeDelayError(
-        pp0.map(PublishProcessor::ignoreElements), 1)
+        TestObserver<Void> to = Completable.merge(
+        pp0.map(PublishProcessor::ignoreElements), new CompletableMergeConfig(true, 1))
         .test();
 
         pp0.onNext(pp1);
@@ -353,7 +356,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void mainDoubleOnError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Completable.mergeDelayError(new Flowable<Completable>() /* NFI */ {
+            Completable.merge(new Flowable<Completable>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Completable> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -361,7 +364,7 @@ public class CompletableMergeTest extends RxJavaTest {
                     s.onError(new TestException("First"));
                     s.onError(new TestException("Second"));
                 }
-            })
+            }, new CompletableMergeConfig(true))
             .to(TestHelper.<Void>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 
@@ -376,14 +379,14 @@ public class CompletableMergeTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final CompletableObserver[] o = { null };
-            Completable.mergeDelayError(Flowable.just(new Completable() /* NFI */ {
+            Completable.merge(Flowable.just(new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     observer.onSubscribe(Disposable.empty());
                     observer.onError(new TestException("First"));
                     o[0] = observer;
                 }
-            }))
+            }), new CompletableMergeConfig(true))
             .to(TestHelper.<Void>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 
@@ -399,7 +402,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void innerIsDisposed() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError(Flowable.just(new Completable() /* NFI */ {
+        Completable.merge(Flowable.just(new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -409,7 +412,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
                 assertTrue(((Disposable)observer).isDisposed());
             }
-        }))
+        }), new CompletableMergeConfig(true))
         .subscribe(to);
     }
 
@@ -446,7 +449,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorIterableCancel() {
-        Completable.mergeDelayError(Collections.singletonList(Completable.complete()))
+        Completable.merge(Collections.singletonList(Completable.complete()), CompletableMergeConfig.DELAY_ERRORS)
         .test(true)
         .assertEmpty();
     }
@@ -455,7 +458,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterHasNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 to.dispose();
@@ -471,7 +474,7 @@ public class CompletableMergeTest extends RxJavaTest {
             public void remove() {
                 throw new UnsupportedOperationException();
             }
-        })
+        }, CompletableMergeConfig.DELAY_ERRORS)
         .subscribe(to);
 
         to.assertEmpty();
@@ -481,7 +484,7 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.mergeDelayError((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -497,7 +500,7 @@ public class CompletableMergeTest extends RxJavaTest {
             public void remove() {
                 throw new UnsupportedOperationException();
             }
-        })
+        }, CompletableMergeConfig.DELAY_ERRORS)
         .subscribe(to);
 
         to.assertEmpty();
@@ -518,20 +521,20 @@ public class CompletableMergeTest extends RxJavaTest {
     @Test
     public void arrayUndeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
-            Completable.mergeArrayDelayError(upstream.ignoreElements(), Completable.complete().hide()));
+            Completable.mergeArray(CompletableMergeConfig.DELAY_ERRORS, upstream.ignoreElements(), Completable.complete().hide()));
     }
 
     @Test
     public void iterableUndeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Completable>) upstream ->
-            Completable.mergeDelayError(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide())));
+            Completable.merge(Arrays.asList(upstream.ignoreElements(), Completable.complete().hide()), CompletableMergeConfig.DELAY_ERRORS));
     }
 
     @Test
     public void iterableCompleteLater() {
         CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Void> to = Completable.mergeDelayError(Arrays.asList(cs, cs, cs))
+        TestObserver<Void> to = Completable.merge(Arrays.asList(cs, cs, cs), CompletableMergeConfig.DELAY_ERRORS)
         .test();
 
         to.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -617,6 +617,8 @@ public class ParamValidationCheckerTest {
 
         defaultValues.put(FlatMapConfig.class, new FlatMapConfig());
         defaultValues.put(GenericConfig.class, new GenericConfig());
+        defaultValues.put(CompletableConcatConfig.class, CompletableConcatConfig.DEFAULT);
+        defaultValues.put(CompletableMergeConfig.class, CompletableMergeConfig.DEFAULT);
 
         @SuppressWarnings("rawtypes")
         class MixedConverters implements FlowableConverter, ObservableConverter, SingleConverter,
@@ -686,7 +688,7 @@ public class ParamValidationCheckerTest {
         addDefaultInstance(Maybe.class, Maybe.just(1).hide(), "Just(1).Hide()");
 
         addDefaultInstance(ParallelFlowable.class, Flowable.just(1).parallel(), "Just(1)");
-}
+    }
 
     static void addIgnore(ParamIgnore ignore) {
         String key = ignore.toString();


### PR DESCRIPTION
Simplify API by changing the number of overloads of various operators.

# Completable

- `concat` and `concatDelayError` -> `concat` with `CompletableConcatConfig` configuration record.
- `concatArray` and `concatArrayDelayError` -> `concatArray` with `CompletableConcatConfig` configuration record.
- `merge` and `mergeDelayError` -> `merge` with `CompletableMergeConfig` configuration record.
- `mergeArray` and `mergeArrayDelayError` -> `mergeArray` with `CompletableMergeConfig` configuration record.

Related: #8173