### PR TITLE
4.x: Maybe API reduction: concat, concatEager, merge

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -15,11 +15,11 @@ package io.reactivex.rxjava4.core;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.*;
 import java.util.stream.*;
 
-import static java.util.concurrent.Flow.*;
-
 import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.core.config.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -193,108 +193,6 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     }
 
     /**
-     * Returns a {@link Flowable} that emits the items emitted by two {@link MaybeSource}s, one after the other.
-     * <p>
-     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be concatenated
-     * @param source2
-     *            a {@code MaybeSource} to be concatenated
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> concat(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        return concatArray(source1, source2);
-    }
-
-    /**
-     * Returns a {@link Flowable} that emits the items emitted by three {@link MaybeSource}s, one after the other.
-     * <p>
-     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be concatenated
-     * @param source2
-     *            a {@code MaybeSource} to be concatenated
-     * @param source3
-     *            a {@code MaybeSource} to be concatenated
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> concat(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        return concatArray(source1, source2, source3);
-    }
-
-    /**
-     * Returns a {@link Flowable} that emits the items emitted by four {@link MaybeSource}s, one after the other.
-     * <p>
-     * <img width="640" height="423" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concat.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The returned {@code Flowable} honors the backpressure of the downstream consumer.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be concatenated
-     * @param source2
-     *            a {@code MaybeSource} to be concatenated
-     * @param source3
-     *            a {@code MaybeSource} to be concatenated
-     * @param source4
-     *            a {@code MaybeSource} to be concatenated
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> concat(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
-            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        Objects.requireNonNull(source4, "source4 is null");
-        return concatArray(source1, source2, source3, source4);
-    }
-
-    /**
      * Concatenate the single values, in a non-overlapping fashion, of the {@link MaybeSource} sources provided by
      * a {@link Publisher} sequence as a {@link Flowable} sequence.
      * <p>
@@ -317,7 +215,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Flowable<T> concat(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return concat(sources, 2);
+        return concat(sources, MaybeConcatConfig.DEFAULT);
     }
 
     /**
@@ -335,19 +233,21 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources the {@code Publisher} of {@code MaybeSource} instances
-     * @param prefetch the number of {@code MaybeSource}s to prefetch from the {@code Publisher}
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @param config the configuration record for this operator
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code prefetch} is non-positive
      * @return the new {@code Flowable} instance
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> concat(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int prefetch) {
+    public static <@NonNull T> Flowable<T> concat(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeConcatConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybePublisher<>(sources, Functions.identity(), ErrorMode.IMMEDIATE, prefetch));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new FlowableConcatMapMaybePublisher<>(
+                sources, Functions.identity(), config.delayError() ? ErrorMode.END : ErrorMode.IMMEDIATE, config.prefetch()));
     }
 
     /**
@@ -393,20 +293,23 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concatArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param sources the array of sources
      * @param <T> the common base value type
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
     @NonNull
-    public static <@NonNull T> Flowable<T> concatArrayDelayError(@NonNull MaybeSource<? extends T>... sources) {
+    public static <@NonNull T> Flowable<T> concatArray(@NonNull MaybeConcatConfig config, @NonNull MaybeSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(config, "config is null");
         if (sources.length == 0) {
             return Flowable.empty();
         } else
@@ -415,7 +318,10 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
             MaybeSource<T> source = (MaybeSource<T>)sources[0];
             return RxJavaPlugins.onAssembly(new MaybeToFlowable<>(source));
         }
-        return RxJavaPlugins.onAssembly(new MaybeConcatArrayDelayError<>(sources));
+        if (config.delayError()) {
+            return RxJavaPlugins.onAssembly(new MaybeConcatArrayDelayError<>(sources));
+        }
+        return RxJavaPlugins.onAssembly(new MaybeConcatArray<>(sources));
     }
 
     /**
@@ -462,9 +368,10 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
@@ -472,8 +379,11 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     @SafeVarargs
-    public static <@NonNull T> Flowable<T> concatArrayEagerDelayError(@NonNull MaybeSource<? extends T>... sources) {
-        return Flowable.fromArray(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true);
+    public static <@NonNull T> Flowable<T> concatArrayEager(@NonNull MaybeConcatEagerConfig config, @NonNull MaybeSource<? extends T>... sources) {
+        if (config.delayError()) {
+            return Flowable.fromArray(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true, config.maxConcurrency(), config.prefetch());
+        }
+        return Flowable.fromArray(sources).concatMapEager((Function)MaybeToPublisher.instance(), config.maxConcurrency(), config.prefetch());
     }
 
     /**
@@ -486,77 +396,26 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code concat} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources the {@code Iterable} sequence of {@code MaybeSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} with the concatenating behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> concatDelayError(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromIterable(sources).concatMapMaybeDelayError(Functions.identity());
-    }
-
-    /**
-     * Concatenates the {@link Publisher} sequence of {@link MaybeSource}s into a single sequence by subscribing to each inner {@code MaybeSource},
-     * one after the other, one at a time and delays any errors till the all inner and the outer {@code Publisher} terminate
-     * as a {@link Flowable} sequence.
-     * <p>
-     * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatDelayError.p.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>{@code concatDelayError} fully supports backpressure.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources the {@code Publisher} sequence of {@code MaybeSource}s
-     * @return the new {@code Flowable} with the concatenating behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromPublisher(sources).concatMapMaybeDelayError(Functions.identity());
-    }
-    /**
-     * Concatenates the {@link Publisher} sequence of {@link MaybeSource}s into a single sequence by subscribing to each inner {@code MaybeSource},
-     * one after the other, one at a time and delays any errors till the all inner and the outer {@code Publisher} terminate
-     * as a {@link Flowable} sequence.
-     * <p>
-     * <img width="640" height="299" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatDelayError.pn.png" alt="">
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>{@code concatDelayError} fully supports backpressure.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources the {@code Publisher} sequence of {@code MaybeSource}s
-     * @param prefetch The number of upstream items to prefetch so that fresh items are
-     *                 ready to be mapped when a previous {@code MaybeSource} terminates.
-     *                 The operator replenishes after half of the prefetch amount has been consumed
-     *                 and turned into {@code MaybeSource}s.
-     * @return the new {@code Flowable} with the concatenating behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code prefetch} is non-positive
-     * @since 3.0.0
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int prefetch) {
-        return Flowable.fromPublisher(sources).concatMapMaybeDelayError(Functions.identity(), true, prefetch);
+    public static <@NonNull T> Flowable<T> concat(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeConcatConfig config) {
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayError()) {
+            return Flowable.fromIterable(sources).concatMapMaybeDelayError(Functions.identity(), true, config.prefetch());
+        }
+        return Flowable.fromIterable(sources).concatMapMaybe(Functions.identity(), config.prefetch());
     }
 
     /**
@@ -604,20 +463,22 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of {@code MaybeSource} that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner {@code MaybeSource}s; {@link Integer#MAX_VALUE}
-     *                       is interpreted as all inner {@code MaybeSource}s can be active at the same time
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @since 3.0.0
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Flowable<T> concatEager(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return Flowable.fromIterable(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), false, maxConcurrency, 1);
+    public static <@NonNull T> Flowable<T> concatEager(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeConcatEagerConfig config) {
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayError()) {
+            return Flowable.fromIterable(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true, config.maxConcurrency(), config.prefetch());
+        }
+        return Flowable.fromIterable(sources).concatMapEager((Function)MaybeToPublisher.instance(), config.maxConcurrency(), config.prefetch());
     }
 
     /**
@@ -669,152 +530,23 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * </dl>
      * @param <T> the value type
      * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner {@code MaybeSource}s; {@link Integer#MAX_VALUE}
-     *                       is interpreted as all inner {@code MaybeSource}s can be active at the same time
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @since 3.0.0
+     * @since 4.0.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Flowable<T> concatEager(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return Flowable.fromPublisher(sources).concatMapEager((Function)MaybeToPublisher.instance(), maxConcurrency, 1);
-    }
-
-    /**
-     * Concatenates a sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence,
-     * delaying errors until all inner {@code MaybeSource}s terminate.
-     * <p>
-     * <img width="640" height="428" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEagerDelayError.i.png" alt="">
-     * <p>
-     * Eager concatenation means that once an observer subscribes, this operator subscribes to all of the
-     * source {@code MaybeSource}s. The operator buffers the values emitted by these {@code MaybeSource}s and then drains them
-     * in order, each one after the previous one completes.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <T> the value type
-     * @param sources a sequence of {@code MaybeSource} that need to be eagerly concatenated
-     * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatEagerDelayError(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromIterable(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true);
-    }
-
-    /**
-     * Concatenates a sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence,
-     * delaying errors until all inner {@code MaybeSource}s terminate and
-     * runs a limited number of inner {@code MaybeSource}s at once.
-     * <p>
-     * <img width="640" height="379" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEagerDelayError.in.png" alt="">
-     * <p>
-     * Eager concatenation means that once an observer subscribes, this operator subscribes to all of the
-     * source {@code MaybeSource}s. The operator buffers the values emitted by these {@code MaybeSource}s and then drains them
-     * in order, each one after the previous one completes.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <T> the value type
-     * @param sources a sequence of {@code MaybeSource} that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner {@code MaybeSource}s; {@link Integer#MAX_VALUE}
-     *                       is interpreted as all inner {@code MaybeSource}s can be active at the same time
-     * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @since 3.0.0
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatEagerDelayError(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return Flowable.fromIterable(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true, maxConcurrency, 1);
-    }
-
-    /**
-     * Concatenates a {@link Publisher} sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence,
-     * delaying errors until all the inner and the outer sequence terminate.
-     * <p>
-     * <img width="640" height="495" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEagerDelayError.p.png" alt="">
-     * <p>
-     * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * emitted source {@code MaybeSource}s as they are observed. The operator buffers the values emitted by these
-     * {@code MaybeSource}s and then drains them in order, each one after the previous one completes.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream and the outer {@code Publisher} is
-     *  expected to support backpressure. Violating this assumption, the operator will
-     *  signal {@link io.reactivex.rxjava4.exceptions.MissingBackpressureException}.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <T> the value type
-     * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
-     * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @since 3.0.0
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatEagerDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromPublisher(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true);
-    }
-
-    /**
-     * Concatenates a {@link Publisher} sequence of {@link MaybeSource}s eagerly into a {@link Flowable} sequence,
-     * delaying errors until all the inner and the outer sequence terminate and
-     * runs a limited number of the inner {@code MaybeSource}s at once.
-     * <p>
-     * <img width="640" height="421" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.concatEagerDelayError.pn.png" alt="">
-     * <p>
-     * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * emitted source {@code MaybeSource}s as they are observed. The operator buffers the values emitted by these
-     * {@code MaybeSource}s and then drains them in order, each one after the previous one completes.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>Backpressure is honored towards the downstream and the outer {@code Publisher} is
-     *  expected to support backpressure. Violating this assumption, the operator will
-     *  signal {@link io.reactivex.rxjava4.exceptions.MissingBackpressureException}.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <T> the value type
-     * @param sources a sequence of {@code MaybeSource}s that need to be eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrently running inner {@code MaybeSource}s; {@link Integer#MAX_VALUE}
-     *                       is interpreted as all inner {@code MaybeSource}s can be active at the same time
-     * @return the new {@code Flowable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @since 3.0.0
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> concatEagerDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        return Flowable.fromPublisher(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true, maxConcurrency, 1);
+    public static <@NonNull T> Flowable<T> concatEager(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeConcatEagerConfig config) {
+        Objects.requireNonNull(config, "config is null");
+        if (config.delayError()) {
+            return Flowable.fromPublisher(sources).concatMapEagerDelayError((Function)MaybeToPublisher.instance(), true, config.maxConcurrency(), config.prefetch());
+        }
+        return Flowable.fromPublisher(sources).concatMapEager((Function)MaybeToPublisher.instance(), config.maxConcurrency(), config.prefetch());
     }
 
     /**
@@ -1341,15 +1073,12 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
      * @param sources the {@code Iterable} sequence of {@code MaybeSource} sources
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeDelayError(Iterable)
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -1379,22 +1108,19 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
      * @param sources the {@code Flowable} sequence of {@code MaybeSource} sources
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeDelayError(Publisher)
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Flowable<T> merge(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return merge(sources, Integer.MAX_VALUE);
+        return merge(sources, MaybeMergeConfig.DEFAULT);
     }
 
     /**
@@ -1417,26 +1143,24 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
      * @param sources the {@code Flowable} sequence of {@code MaybeSource} sources
-     * @param maxConcurrency the maximum number of concurrently running {@code MaybeSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see #mergeDelayError(Publisher, int)
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> merge(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
+    public static <@NonNull T> Flowable<T> merge(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeMergeConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapMaybePublisher<>(sources, Functions.identity(), false, maxConcurrency));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new FlowableFlatMapMaybePublisher<>(sources, Functions.identity(), config.delayErrors(), config.maxConcurrency()));
     }
 
     /**
@@ -1472,164 +1196,6 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     }
 
     /**
-     * Flattens two {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
-     * <p>
-     * <img width="640" height="279" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.2.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
-     *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(MaybeSource, MaybeSource)
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> merge(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2
-    ) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        return mergeArray(source1, source2);
-    }
-
-    /**
-     * Flattens three {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
-     * <p>
-     * <img width="640" height="301" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.3.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by using
-     * the {@code merge} method.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
-     *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(MaybeSource, MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @param source3
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(MaybeSource, MaybeSource, MaybeSource)
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> merge(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
-            @NonNull MaybeSource<? extends T> source3
-    ) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        return mergeArray(source1, source2, source3);
-    }
-
-    /**
-     * Flattens four {@link MaybeSource}s into a single {@link Flowable}, without any transformation.
-     * <p>
-     * <img width="640" height="289" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.merge.4.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code MaybeSource}s so that they appear as a single {@code Flowable}, by using
-     * the {@code merge} method.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     * <dt><b>Scheduler:</b></dt>
-     * <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the source {@code MaybeSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code MaybeSource}s are disposed.
-     *  If more than one {@code MaybeSource} signals an error, the resulting {@code Flowable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(MaybeSource, MaybeSource, MaybeSource, MaybeSource)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common value type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @param source3
-     *            a {@code MaybeSource} to be merged
-     * @param source4
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(MaybeSource, MaybeSource, MaybeSource, MaybeSource)
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> merge(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
-            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4
-    ) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        Objects.requireNonNull(source4, "source4 is null");
-        return mergeArray(source1, source2, source3, source4);
-    }
-
-    /**
      * Merges an array of {@link MaybeSource} instances into a single {@link Flowable} sequence,
      * running all {@code MaybeSource}s at once.
      * <p>
@@ -1649,15 +1215,12 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeArrayDelayError(MaybeSource...)} to merge sources and terminate only when all source {@code MaybeSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      * @param <T> the common and resulting value type
      * @param sources the array sequence of {@code MaybeSource} sources
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeArrayDelayError(MaybeSource...)
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
@@ -1694,24 +1257,27 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources
      *            the array of {@code MaybeSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @SafeVarargs
     @NonNull
-    public static <@NonNull T> Flowable<T> mergeArrayDelayError(@NonNull MaybeSource<? extends T>... sources) {
+    public static <@NonNull T> Flowable<T> mergeArray(@NonNull MaybeMergeConfig config, @NonNull MaybeSource<? extends T>... sources) {
         Objects.requireNonNull(sources, "sources is null");
-        return Flowable.fromArray(sources).flatMapMaybe(Functions.identity(), true, Math.max(1, sources.length));
+        Objects.requireNonNull(config, "config is null");
+        return Flowable.fromArray(sources).flatMapMaybe(Functions.identity(), config.delayErrors(), config.maxConcurrency());
     }
 
     /**
@@ -1733,230 +1299,25 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream.</dd>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources
      *            the {@code Iterable} of {@code MaybeSource}s
+     * @param config the configuration record for this operator
      * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @since 4.0.0
      */
     @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return Flowable.fromIterable(sources).flatMapMaybe(Functions.identity(), true, Integer.MAX_VALUE);
-    }
-
-    /**
-     * Flattens a {@link Publisher} that emits {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to
-     * receive all successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by
-     * an error notification from one of them or even the main {@code Publisher}.
-     * <p>
-     * <img width="640" height="456" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeDelayError.p.png" alt="">
-     * <p>
-     * This behaves like {@link #merge(Publisher)} except that if any of the merged {@code MaybeSource}s notify of an
-     * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code MaybeSource}s and the main {@code Publisher} have finished emitting items.
-     * <p>
-     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its subscribers once.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
-     *  in unbounded mode (i.e., no backpressure is applied to it).</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            a {@code Publisher} that emits {@code MaybeSource}s
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources) {
-        return mergeDelayError(sources, Integer.MAX_VALUE);
-    }
-
-    /**
-     * Flattens a {@link Publisher} that emits {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to
-     * receive all successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by
-     * an error notification from one of them or even the main {@code Publisher} as well as limiting the total number of active {@code MaybeSource}s.
-     * <p>
-     * <img width="640" height="429" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeDelayError.pn.png" alt="">
-     * <p>
-     * This behaves like {@link #merge(Publisher, int)} except that if any of the merged {@code MaybeSource}s notify of an
-     * error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code MaybeSource}s and the main {@code Publisher} have finished emitting items.
-     * <p>
-     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its subscribers once.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed
-     *  in unbounded mode (i.e., no backpressure is applied to it).</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.9 - experimental
-     * @param <T> the common element base type
-     * @param sources
-     *            a {@code Publisher} that emits {@code MaybeSource}s
-     * @param maxConcurrency the maximum number of active inner {@code MaybeSource}s to be merged at a time
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since 2.2
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull Publisher<@NonNull ? extends MaybeSource<? extends T>> sources, int maxConcurrency) {
-        Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new FlowableFlatMapMaybePublisher<>(sources, Functions.identity(), true, maxConcurrency));
-    }
-
-    /**
-     * Flattens two {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
-     * successfully emitted items from each of the source {@code MaybeSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * <img width="640" height="414" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeDelayError.2.png" alt="">
-     * <p>
-     * This behaves like {@link #merge(MaybeSource, MaybeSource)} except that if any of the merged {@code MaybeSource}s
-     * notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain from
-     * propagating that error notification until all of the merged {@code MaybeSource}s have finished emitting items.
-     * <p>
-     * Even if both merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its subscribers once.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        return mergeArrayDelayError(source1, source2);
-    }
-
-    /**
-     * Flattens three {@link MaybeSource} into one {@link Flowable}, in a way that allows a subscriber to receive all
-     * successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * <img width="640" height="467" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeDelayError.3.png" alt="">
-     * <p>
-     * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource)} except that if any of the merged
-     * {@code MaybeSource}s notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError} will refrain
-     * from propagating that error notification until all of the merged {@code MaybeSource}s have finished emitting
-     * items.
-     * <p>
-     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its subscribers once.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @param source3
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> mergeDelayError(@NonNull MaybeSource<? extends T> source1,
-            @NonNull MaybeSource<? extends T> source2, @NonNull MaybeSource<? extends T> source3) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        return mergeArrayDelayError(source1, source2, source3);
-    }
-
-    /**
-     * Flattens four {@link MaybeSource}s into one {@link Flowable}, in a way that allows a subscriber to receive all
-     * successfully emitted items from all of the source {@code MaybeSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * <img width="640" height="461" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.mergeDelayError.4.png" alt="">
-     * <p>
-     * This behaves like {@link #merge(MaybeSource, MaybeSource, MaybeSource, MaybeSource)} except that if any of
-     * the merged {@code MaybeSource}s notify of an error via {@link Subscriber#onError onError}, {@code mergeDelayError}
-     * will refrain from propagating that error notification until all of the merged {@code MaybeSource}s have finished
-     * emitting items.
-     * <p>
-     * Even if multiple merged {@code MaybeSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its subscribers once.
-     * <dl>
-     *  <dt><b>Backpressure:</b></dt>
-     *  <dd>The operator honors backpressure from downstream.</dd>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            a {@code MaybeSource} to be merged
-     * @param source2
-     *            a {@code MaybeSource} to be merged
-     * @param source3
-     *            a {@code MaybeSource} to be merged
-     * @param source4
-     *            a {@code MaybeSource} to be merged
-     * @return the new {@code Flowable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @BackpressureSupport(BackpressureKind.FULL)
-    @CheckReturnValue
-    @NonNull
-    @SchedulerSupport(SchedulerSupport.NONE)
-    public static <@NonNull T> Flowable<T> mergeDelayError(
-            @NonNull MaybeSource<? extends T> source1, @NonNull MaybeSource<? extends T> source2,
-            @NonNull MaybeSource<? extends T> source3, @NonNull MaybeSource<? extends T> source4) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        Objects.requireNonNull(source4, "source4 is null");
-        return mergeArrayDelayError(source1, source2, source3, source4);
+    public static <@NonNull T> Flowable<T> merge(@NonNull Iterable<@NonNull ? extends MaybeSource<? extends T>> sources, @NonNull MaybeMergeConfig config) {
+        Objects.requireNonNull(config, "config is null");
+        return Flowable.fromIterable(sources).flatMapMaybe(Functions.identity(), config.delayErrors(), config.maxConcurrency());
     }
 
     /**
@@ -3201,7 +2562,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> concatWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return concat(this, other);
+        return concatArray(this, other);
     }
 
     /**
@@ -4405,7 +3766,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Flowable<T> mergeWith(@NonNull MaybeSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return merge(this, other);
+        return mergeArray(this, other);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Maybe.concat() operators.
+ * @param delayError should the error propagation be delayed?
+ * @param prefetch the number of source sequences to request from a backpressured source
+ * @since 4.0.0
+ */
+public record MaybeConcatConfig(boolean delayError, int prefetch) {
+
+    /**
+     * The default configuration with no error delays and prefetch of 2.
+     */
+    public static final MaybeConcatConfig DEFAULT = new MaybeConcatConfig(false, 2);
+
+    /**
+     * The default configuration with error delays and prefetch of 2.
+     */
+    public static final MaybeConcatConfig DELAY_ERROR = new MaybeConcatConfig(true, 2);
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     */
+    public MaybeConcatConfig(boolean delayError) {
+        this(delayError, 2);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param prefetch the number of source sequences to request from a backpressured source
+     */
+    public MaybeConcatConfig(int prefetch) {
+        this(false, prefetch);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     * @param prefetch the number of source sequences to request from a backpressured source
+     */
+    public MaybeConcatConfig(boolean delayError, int prefetch) {
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        this.delayError = delayError;
+        this.prefetch = prefetch;
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Maybe.concatEager() operators.
+ * @param delayError should the error propagation be delayed?
+ * @param maxConcurrency the maximum number of concurrent sources running
+ * @param prefetch the number of items to request from each source
+ * @since 4.0.0
+ */
+public record MaybeConcatEagerConfig(boolean delayError, int maxConcurrency, int prefetch) {
+
+    /**
+     * The default configuration with no error delays, maxConcurrency and prefetch of Flowable#bufferSize().
+     */
+    public static final MaybeConcatEagerConfig DEFAULT = new MaybeConcatEagerConfig(false, Flowable.bufferSize());
+
+    /**
+     * The default configuration with error delays, maxConcurrency and prefetch of Flowable#bufferSize().
+     */
+    public static final MaybeConcatEagerConfig DELAY_ERROR = new MaybeConcatEagerConfig(true, Flowable.bufferSize());
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     */
+    public MaybeConcatEagerConfig(boolean delayError) {
+        this(delayError, 2, 2);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param maxConcurrency the maximum number of concurrent sources running
+     */
+    public MaybeConcatEagerConfig(int maxConcurrency) {
+        this(false, maxConcurrency, maxConcurrency);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     * @param maxConcurrency the maximum number of concurrent sources running
+     */
+    public MaybeConcatEagerConfig(boolean delayError, int maxConcurrency) {
+        this(delayError, maxConcurrency, maxConcurrency);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayError should the error propagation be delayed?
+     * @param maxConcurrency the maximum number of concurrent sources running
+     * @param prefetch the number of items to request from each source
+     */
+    public MaybeConcatEagerConfig(boolean delayError, int maxConcurrency, int prefetch) {
+        ObjectHelper.verifyPositive(prefetch, "prefetch");
+        this.delayError = delayError;
+        this.maxConcurrency = maxConcurrency;
+        this.prefetch = prefetch;
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeMergeConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Maybe.merge() operators.
+ * @param delayErrors should the error propagation be delayed?
+ * @param maxConcurrency the number of source sequences run concurrently
+ * @since 4.0.0
+ */
+public record MaybeMergeConfig(boolean delayErrors, int maxConcurrency) {
+
+    /**
+     * The default config with no error delay and Integer#MAX_VALUE as the maximum concurrency setting.
+     */
+    public static final MaybeMergeConfig DEFAULT = new MaybeMergeConfig(false, Integer.MAX_VALUE);
+
+    /**
+     * The default config with error delay and Integer#MAX_VALUE as the maximum concurrency setting.
+     */
+    public static final MaybeMergeConfig DELAY_ERRORS = new MaybeMergeConfig(true, Integer.MAX_VALUE);
+
+    /**
+     * Constructs a configuration record.
+     * @param delayErrors should the error propagation be delayed?
+     */
+    public MaybeMergeConfig(boolean delayErrors) {
+        this(delayErrors, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param maxConcurrency the number of source sequences run concurrently
+     */
+    public MaybeMergeConfig(int maxConcurrency) {
+        this(false, maxConcurrency);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param delayErrors should the error propagation be delayed?
+     * @param maxConcurrency the number of source sequences run concurrently
+     */
+    public MaybeMergeConfig(boolean delayErrors, int maxConcurrency) {
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
+        this.delayErrors = delayErrors;
+        this.maxConcurrency = maxConcurrency;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/MaybeConcatConfigEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/MaybeConcatConfigEagerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+
+public class MaybeConcatConfigEagerTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new MaybeConcatEagerConfig(true).delayError(), "delayError - true");
+        assertFalse(new MaybeConcatEagerConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new MaybeConcatEagerConfig(5).prefetch(), "prefetch - 5");
+        assertEquals(5, new MaybeConcatEagerConfig(true, 5).prefetch(), "prefetch both - true, 5");
+        assertEquals(5, new MaybeConcatEagerConfig(false, 5).prefetch(), "prefetch both - false, 5");
+        assertEquals(5, new MaybeConcatEagerConfig(true, 5).maxConcurrency(), "maxConcurrency both - true, 5");
+        assertEquals(5, new MaybeConcatEagerConfig(false, 5).maxConcurrency(), "maxConcurrency both - false, 5");
+        assertTrue(new MaybeConcatEagerConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new MaybeConcatEagerConfig(false, 5).delayError(), "delayError both - false, 5");
+
+        assertEquals(5, new MaybeConcatEagerConfig(true, 5, 10).maxConcurrency(), "maxConcurrency both - true, 5, 10");
+        assertEquals(10, new MaybeConcatEagerConfig(false, 5, 10).prefetch(), "prefetch both - false, 5, 10");
+        assertTrue(new MaybeConcatEagerConfig(true, 5, 10).delayError(), "delayError both - true, 5, 10");
+        assertFalse(new MaybeConcatEagerConfig(false, 5, 10).delayError(), "delayError both - true, 5, 10");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/MaybeConcatConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/MaybeConcatConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+
+public class MaybeConcatConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new MaybeConcatConfig(true).delayError(), "delayError - true");
+        assertFalse(new MaybeConcatConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new MaybeConcatConfig(5).prefetch(), "prefetch - 5");
+        assertEquals(5, new MaybeConcatConfig(true, 5).prefetch(), "prefetch both - true, 5");
+        assertEquals(5, new MaybeConcatConfig(false, 5).prefetch(), "prefetch both - false, 5");
+        assertTrue(new MaybeConcatConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new MaybeConcatConfig(false, 5).delayError(), "delayError both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/MaybeMergeConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/MaybeMergeConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+
+public class MaybeMergeConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new MaybeMergeConfig(true).delayErrors(), "delayErrors - true");
+        assertFalse(new MaybeMergeConfig(false).delayErrors(), "delayErrors - false");
+        assertEquals(5, new MaybeMergeConfig(5).maxConcurrency(), "maxConcurrency - 5");
+        assertEquals(5, new MaybeMergeConfig(true, 5).maxConcurrency(), "maxConcurrency both - true, 5");
+        assertEquals(5, new MaybeMergeConfig(false, 5).maxConcurrency(), "maxConcurrency both - false, 5");
+        assertTrue(new MaybeMergeConfig(true, 5).delayErrors(), "delayErrors both - true, 5");
+        assertFalse(new MaybeMergeConfig(false, 5).delayErrors(), "delayErrors both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayEagerDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayEagerDelayErrorTest.java
@@ -16,13 +16,14 @@ package io.reactivex.rxjava4.internal.operators.maybe;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.Maybe;
+import io.reactivex.rxjava4.core.config.MaybeConcatEagerConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 
 public class MaybeConcatArrayEagerDelayErrorTest {
 
     @Test
     public void normal() {
-        Maybe.concatArrayEagerDelayError(
+        Maybe.concatArrayEager(MaybeConcatEagerConfig.DELAY_ERROR,
                 Maybe.just(1),
                 Maybe.<Integer>error(new TestException()),
                 Maybe.empty(),

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.MaybeConcatConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -40,7 +41,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
 
     @Test
     public void cancelDelayError() {
-        Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
+        Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1), Maybe.just(2))
         .take(1)
         .test()
         .assertResult(1);
@@ -64,7 +65,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
 
     @Test
     public void backpressureDelayError() {
-        TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
+        TestSubscriber<Integer> ts = Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1), Maybe.just(2))
         .test(0L);
 
         ts.assertEmpty();
@@ -95,7 +96,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
     @Test
     public void requestCancelRaceDelayError() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(Maybe.just(1), Maybe.just(2))
+            final TestSubscriber<Integer> ts = Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1), Maybe.just(2))
                     .test(0L);
 
             Runnable r1 = ts::cancel;
@@ -111,7 +112,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final MaybeObserver<?>[] o = { null };
-            Maybe.concatArrayDelayError(Maybe.just(1),
+            Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1),
                     Maybe.error(new IOException()),
             new Maybe<Integer>() {
                 @Override
@@ -157,7 +158,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
             s.onSuccess(1);
         });
 
-        Maybe.concatArrayDelayError(source, source).firstElement()
+        Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, source, source).firstElement()
         .test()
         .assertResult(1);
 
@@ -171,7 +172,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
 
     @Test
     public void badRequestDelayError() {
-        TestHelper.assertBadRequestReported(Maybe.concatArrayDelayError(MaybeSubject.create(), MaybeSubject.create()));
+        TestHelper.assertBadRequestReported(Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, MaybeSubject.create(), MaybeSubject.create()));
     }
 
     @Test
@@ -216,7 +217,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
     @Test
     public void requestBeforeSuccessDelayError() {
         MaybeSubject<Integer> ms = MaybeSubject.create();
-        TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(ms, ms)
+        TestSubscriber<Integer> ts = Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, ms, ms)
         .test();
 
         ts.assertEmpty();
@@ -229,7 +230,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
     @Test
     public void requestBeforeCompleteDelayError() {
         MaybeSubject<Integer> ms = MaybeSubject.create();
-        TestSubscriber<Integer> ts = Maybe.concatArrayDelayError(ms, ms)
+        TestSubscriber<Integer> ts = Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, ms, ms)
         .test();
 
         ts.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatEagerTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.MaybeConcatEagerConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 
 public class MaybeConcatEagerTest {
@@ -39,7 +40,7 @@ public class MaybeConcatEagerTest {
                 Maybe.just(1),
                 Maybe.empty(),
                 Maybe.just(2)
-        ), 1)
+        ), new MaybeConcatEagerConfig(1))
         .test()
         .assertResult(1, 2);
     }
@@ -63,7 +64,7 @@ public class MaybeConcatEagerTest {
                 Maybe.error(new TestException()),
                 Maybe.empty(),
                 Maybe.just(2)
-        ), 1)
+        ), new MaybeConcatEagerConfig(1))
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -85,7 +86,7 @@ public class MaybeConcatEagerTest {
                 Maybe.just(1),
                 Maybe.empty(),
                 Maybe.just(2)
-        ), 1)
+        ), new MaybeConcatEagerConfig(1))
         .test()
         .assertResult(1, 2);
     }
@@ -104,48 +105,48 @@ public class MaybeConcatEagerTest {
 
     @Test
     public void iterableDelayError() {
-        Maybe.concatEagerDelayError(Arrays.asList(
+        Maybe.concatEager(Arrays.asList(
                 Maybe.just(1),
                 Maybe.error(new TestException()),
                 Maybe.empty(),
                 Maybe.just(2)
-        ))
+        ), MaybeConcatEagerConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void iterableDelayErrorMaxConcurrency() {
-        Maybe.concatEagerDelayError(Arrays.asList(
+        Maybe.concatEager(Arrays.asList(
                 Maybe.just(1),
                 Maybe.error(new TestException()),
                 Maybe.empty(),
                 Maybe.just(2)
-        ), 1)
+        ), new MaybeConcatEagerConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void publisherDelayError() {
-        Maybe.concatEagerDelayError(Flowable.fromArray(
+        Maybe.concatEager(Flowable.fromArray(
                 Maybe.just(1),
                 Maybe.error(new TestException()),
                 Maybe.empty(),
                 Maybe.just(2)
-        ))
+        ), MaybeConcatEagerConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void publisherDelayErrorMaxConcurrency() {
-        Maybe.concatEagerDelayError(Flowable.fromArray(
+        Maybe.concatEager(Flowable.fromArray(
                 Maybe.just(1),
                 Maybe.error(new TestException()),
                 Maybe.empty(),
                 Maybe.just(2)
-        ), 1)
+        ), new MaybeConcatEagerConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1, 2);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterableTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.MaybeConcatConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.util.CrashingMappedIterable;
@@ -119,7 +120,7 @@ public class MaybeConcatIterableTest extends RxJavaTest {
             s.onSuccess(1);
         });
 
-        Maybe.concatDelayError(Arrays.asList(source, source)).firstElement()
+        Maybe.concat(Arrays.asList(source, source), MaybeConcatConfig.DELAY_ERROR).firstElement()
         .test()
         .assertResult(1);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.MaybeMergeConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
@@ -27,16 +28,16 @@ public class MaybeMergeTest extends RxJavaTest {
 
     @Test
     public void delayErrorWithMaxConcurrency() {
-        Maybe.mergeDelayError(
-                Flowable.just(Maybe.just(1), Maybe.just(2), Maybe.just(3)), 1)
+        Maybe.merge(
+                Flowable.just(Maybe.just(1), Maybe.just(2), Maybe.just(3)), new MaybeMergeConfig(true, 1))
         .test()
         .assertResult(1, 2, 3);
     }
 
     @Test
     public void delayErrorWithMaxConcurrencyError() {
-        Maybe.mergeDelayError(
-                Flowable.just(Maybe.just(1), Maybe.<Integer>error(new TestException()), Maybe.just(3)), 1)
+        Maybe.merge(
+                Flowable.just(Maybe.just(1), Maybe.<Integer>error(new TestException()), Maybe.just(3)), new MaybeMergeConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1, 3);
     }
@@ -54,8 +55,8 @@ public class MaybeMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 1000; i++) {
             count.set(0);
-            Maybe.mergeDelayError(
-                    Flowable.fromArray(sources), 1)
+            Maybe.merge(
+                    Flowable.fromArray(sources), new MaybeMergeConfig(1))
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(0, 0, 0);
@@ -79,8 +80,8 @@ public class MaybeMergeTest extends RxJavaTest {
 
         for (int i = 0; i < 1000; i++) {
             count.set(0);
-            Maybe.mergeDelayError(
-                    Flowable.fromArray(sources), 1)
+            Maybe.merge(
+                    Flowable.fromArray(sources), new MaybeMergeConfig(true, 1))
             .to(TestHelper.<Integer>testConsumer())
             .awaitDone(5, TimeUnit.SECONDS)
             .assertFailureAndMessage(TestException.class, "2", 0, 0);
@@ -89,8 +90,8 @@ public class MaybeMergeTest extends RxJavaTest {
 
     @Test
     public void scalar() {
-        Maybe.mergeDelayError(
-                Flowable.just(Maybe.just(1)))
+        Maybe.merge(
+                Flowable.just(Maybe.just(1)), new MaybeMergeConfig(true))
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -735,16 +735,16 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         .assertFailure(TestException.class, "[1, 2]");
     }
 
-    // @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void combineLatestArrayEmpty() {
-        assertSame(Observable.empty(), Observable.combineLatestArray(new ObservableSource[0], Functions.<Object[]>identity(), 16));
+        assertSame(Observable.empty(), Observable.combineLatestArray(new ObservableSource[0], (Function)Functions.identity(), 16));
     }
 
-    // @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void combineLatestDelayErrorEmpty() {
-        assertSame(Observable.empty(), Observable.combineLatestArrayDelayError(new ObservableSource[0], Functions.<Object[]>identity(), 16));
+        assertSame(Observable.empty(), Observable.combineLatestArrayDelayError(new ObservableSource[0], (Function)Functions.identity(), 16));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -19,14 +19,15 @@ import java.io.IOException;
 import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.core.config.*;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
@@ -936,21 +937,21 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void concat2() {
-        Maybe.concat(Maybe.just(1), Maybe.just(2))
+        Maybe.concatArray(Maybe.just(1), Maybe.just(2))
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void concat2Empty() {
-        Maybe.concat(Maybe.empty(), Maybe.empty())
+        Maybe.concatArray(Maybe.empty(), Maybe.empty())
         .test()
         .assertResult();
     }
 
     @Test
     public void concat2Backpressured() {
-        TestSubscriber<Integer> ts = Maybe.concat(Maybe.just(1), Maybe.just(2))
+        TestSubscriber<Integer> ts = Maybe.concatArray(Maybe.just(1), Maybe.just(2))
         .test(0L);
 
         ts.assertEmpty();
@@ -969,7 +970,7 @@ public class MaybeTest extends RxJavaTest {
         PublishProcessor<Integer> pp1 = PublishProcessor.create();
         PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.concat(pp1.singleElement(), pp2.singleElement())
+        TestSubscriber<Integer> ts = Maybe.concatArray(pp1.singleElement(), pp2.singleElement())
         .test(0L);
 
         assertTrue(pp1.hasSubscribers());
@@ -1005,35 +1006,35 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void concat3() {
-        Maybe.concat(Maybe.just(1), Maybe.just(2), Maybe.just(3))
+        Maybe.concatArray(Maybe.just(1), Maybe.just(2), Maybe.just(3))
         .test()
         .assertResult(1, 2, 3);
     }
 
     @Test
     public void concat3Empty() {
-        Maybe.concat(Maybe.empty(), Maybe.empty(), Maybe.empty())
+        Maybe.concatArray(Maybe.empty(), Maybe.empty(), Maybe.empty())
         .test()
         .assertResult();
     }
 
     @Test
     public void concat3Mixed1() {
-        Maybe.concat(Maybe.just(1), Maybe.empty(), Maybe.just(3))
+        Maybe.concatArray(Maybe.just(1), Maybe.empty(), Maybe.just(3))
         .test()
         .assertResult(1, 3);
     }
 
     @Test
     public void concat3Mixed2() {
-        Maybe.concat(Maybe.just(1), Maybe.just(2), Maybe.empty())
+        Maybe.concatArray(Maybe.just(1), Maybe.just(2), Maybe.empty())
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void concat3Backpressured() {
-        TestSubscriber<Integer> ts = Maybe.concat(Maybe.just(1), Maybe.just(2), Maybe.just(3))
+        TestSubscriber<Integer> ts = Maybe.concatArray(Maybe.just(1), Maybe.just(2), Maybe.just(3))
         .test(0L);
 
         ts.assertEmpty();
@@ -1059,7 +1060,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void concat4() {
-        Maybe.concat(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
+        Maybe.concatArray(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
         .test()
         .assertResult(1, 2, 3, 4);
     }
@@ -1150,7 +1151,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void concatPublisherPrefetch() {
-        Maybe.concat(Flowable.just(Maybe.just(1), Maybe.just(2)), 1).test().assertResult(1, 2);
+        Maybe.concat(Flowable.just(Maybe.just(1), Maybe.just(2)), new MaybeConcatConfig(1)).test().assertResult(1, 2);
     }
 
     @Test
@@ -1610,28 +1611,28 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void merge2() {
-        Maybe.merge(Maybe.just(1), Maybe.just(2))
+        Maybe.mergeArray(Maybe.just(1), Maybe.just(2))
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void merge3() {
-        Maybe.merge(Maybe.just(1), Maybe.just(2), Maybe.just(3))
+        Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3))
         .test()
         .assertResult(1, 2, 3);
     }
 
     @Test
     public void merge4() {
-        Maybe.merge(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
+        Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
         .test()
         .assertResult(1, 2, 3, 4);
     }
 
     @Test
     public void merge4Take2() {
-        Maybe.merge(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
+        Maybe.mergeArray(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.just(4))
         .take(2)
         .test()
         .assertResult(1, 2);
@@ -1767,7 +1768,7 @@ public class MaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = Maybe.merge(Flowable.just(pp1.singleElement(), pp2.singleElement()), 1).test(0L);
+        TestSubscriber<Integer> ts = Maybe.merge(Flowable.just(pp1.singleElement(), pp2.singleElement()), new MaybeMergeConfig(1)).test(0L);
 
         assertTrue(pp1.hasSubscribers());
         assertFalse(pp2.hasSubscribers());
@@ -1845,14 +1846,14 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void mergeErrorSuccess() {
-        Maybe.merge(Maybe.error(new TestException()), Maybe.just(1))
+        Maybe.mergeArray(Maybe.error(new TestException()), Maybe.just(1))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void mergeSuccessError() {
-        Maybe.merge(Maybe.just(1), Maybe.error(new TestException()))
+        Maybe.mergeArray(Maybe.just(1), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -2040,48 +2041,48 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void concatArrayDelayError() {
-        Maybe.concatArrayDelayError(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))
+        Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.concatArrayDelayError(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1))
+        Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1))
         .test()
         .assertFailure(TestException.class, 1);
 
-        assertSame(Flowable.empty(), Maybe.concatArrayDelayError());
+        assertSame(Flowable.empty(), Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR));
 
-        assertFalse(Maybe.concatArrayDelayError(Maybe.never()) instanceof MaybeConcatArrayDelayError);
+        assertFalse(Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.never()) instanceof MaybeConcatArrayDelayError);
     }
 
     @Test
     public void concatIterableDelayError() {
-        Maybe.concatDelayError(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
+        Maybe.concat(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), MaybeConcatConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.concatDelayError(Arrays.asList(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)))
+        Maybe.concat(Arrays.asList(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), MaybeConcatConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void concatPublisherDelayError() {
-        Maybe.concatDelayError(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
+        Maybe.concat(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), MaybeConcatConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.concatDelayError(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)))
+        Maybe.concat(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), MaybeConcatConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void concatPublisherDelayErrorPrefetch() {
-        Maybe.concatDelayError(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), 1)
+        Maybe.concat(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), new MaybeConcatConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.concatDelayError(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), 1)
+        Maybe.concat(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), new MaybeConcatConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1);
     }
@@ -2190,74 +2191,74 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void mergeArrayDelayError() {
-        Maybe.mergeArrayDelayError(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.empty(), Maybe.just(1), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.mergeArrayDelayError(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1))
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void mergeIterableDelayError() {
-        Maybe.mergeDelayError(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
+        Maybe.merge(Arrays.asList(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), MaybeMergeConfig.DELAY_ERRORS)
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.mergeDelayError(Arrays.asList(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)))
+        Maybe.merge(Arrays.asList(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), MaybeMergeConfig.DELAY_ERRORS)
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void mergePublisherDelayError() {
-        Maybe.mergeDelayError(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())))
+        Maybe.merge(Flowable.just(Maybe.empty(), Maybe.just(1), Maybe.error(new TestException())), MaybeMergeConfig.DELAY_ERRORS)
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.mergeDelayError(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)))
+        Maybe.merge(Flowable.just(Maybe.error(new TestException()), Maybe.empty(), Maybe.just(1)), MaybeMergeConfig.DELAY_ERRORS)
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void mergeDelayError2() {
-        Maybe.mergeDelayError(Maybe.just(1), Maybe.error(new TestException()))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.just(1), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1);
 
-        Maybe.mergeDelayError(Maybe.error(new TestException()), Maybe.just(1))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.error(new TestException()), Maybe.just(1))
         .test()
         .assertFailure(TestException.class, 1);
     }
 
     @Test
     public void mergeDelayError3() {
-        Maybe.mergeDelayError(Maybe.just(1), Maybe.error(new TestException()), Maybe.just(2))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.just(1), Maybe.error(new TestException()), Maybe.just(2))
         .test()
         .assertFailure(TestException.class, 1, 2);
 
-        Maybe.mergeDelayError(Maybe.error(new TestException()), Maybe.just(1), Maybe.just(2))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.error(new TestException()), Maybe.just(1), Maybe.just(2))
         .test()
         .assertFailure(TestException.class, 1, 2);
 
-        Maybe.mergeDelayError(Maybe.just(1), Maybe.just(2), Maybe.error(new TestException()))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.just(1), Maybe.just(2), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void mergeDelayError4() {
-        Maybe.mergeDelayError(Maybe.just(1), Maybe.error(new TestException()), Maybe.just(2), Maybe.just(3))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.just(1), Maybe.error(new TestException()), Maybe.just(2), Maybe.just(3))
         .test()
         .assertFailure(TestException.class, 1, 2, 3);
 
-        Maybe.mergeDelayError(Maybe.error(new TestException()), Maybe.just(1), Maybe.just(2), Maybe.just(3))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.error(new TestException()), Maybe.just(1), Maybe.just(2), Maybe.just(3))
         .test()
         .assertFailure(TestException.class, 1, 2, 3);
 
-        Maybe.mergeDelayError(Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.error(new TestException()))
+        Maybe.mergeArray(MaybeMergeConfig.DELAY_ERRORS, Maybe.just(1), Maybe.just(2), Maybe.just(3), Maybe.error(new TestException()))
         .test()
         .assertFailure(TestException.class, 1, 2, 3);
     }

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -624,6 +624,10 @@ public class ParamValidationCheckerTest {
         defaultValues.put(SingleConcatEagerConfig.class, SingleConcatEagerConfig.DEFAULT);
         defaultValues.put(SingleMergeConfig.class, SingleMergeConfig.DEFAULT);
 
+        defaultValues.put(MaybeConcatConfig.class, MaybeConcatConfig.DEFAULT);
+        defaultValues.put(MaybeConcatEagerConfig.class, MaybeConcatEagerConfig.DEFAULT);
+        defaultValues.put(MaybeMergeConfig.class, MaybeMergeConfig.DEFAULT);
+
         @SuppressWarnings("rawtypes")
         class MixedConverters implements FlowableConverter, ObservableConverter, SingleConverter,
         MaybeConverter, CompletableConverter, ParallelFlowableConverter {


### PR DESCRIPTION
Simplify API by changing the number of overloads of various operators.

# Maybe

- `concat` and `concatDelayError` -> `concat` with `MaybeConcatConfig` configuration record.
- `concatArray` and `concatArrayDelayError` -> `concatArray` with `MaybeConcatConfig` configuration record.
- `concatEager` and `concatEagerDelayError` -> `concatEager` with `MaybeConcatEagerConfig` configuration record.
- `concatArrayEager` and `concatArrayEagerDelayError` -> `concatArrayEager` with `MaybeConcatEagerConfig` configuration record.
- `merge` and `mergeDelayError` -> `merge` with `MaybeMergeConfig` configuration record.
- `mergeArray` and `mergeArrayDelayError` -> `mergeArray` with `MaybeMergeConfig` configuration record.
- Removed the 2, 3 and 4 argument `merge`|`mergeDelayError` variants, use `mergeArray`

Related: #8173