### PR TITLE
[Banned, AI Slop, Undisclosed AI Use, Had to Manually Correct PR] Fix NullPointerException in AppendOnlyLinkedArrayList.forEachWhile on a full last chunk

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/internal/util/AppendOnlyLinkedArrayList.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/AppendOnlyLinkedArrayList.java
@@ -175,6 +175,9 @@ public class AppendOnlyLinkedArrayList<T> {
                 }
             }
             a = (Object[])a[c];
+            if (a == null) {
+                return;
+            }
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
@@ -235,4 +235,26 @@ public class MiscUtilTest extends RxJavaTest {
     public void queueDrainHelperUtility() {
         TestHelper.checkUtilityClass(QueueDrainHelper.class);
     }
+
+        @Test
+    public void appendOnlyLinkedArrayListForEachWhileBiFullChunkNoNext() throws Throwable {
+        // Fill exactly capacity elements in one chunk; no next chunk exists (a[c] == null).
+        // The predicate returns false for all elements so the loop must traverse past the full chunk.
+        AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
+
+        list.add(1);
+        list.add(2);
+
+        final List<Integer> out = new ArrayList<>();
+
+        list.forEachWhile(null, new BiPredicate<Object, Integer>() {
+            @Override
+            public boolean test(Object state, Integer value) throws Throwable {
+                out.add(value);
+                return false; // never terminate early
+            }
+        });
+
+        assertEquals(Arrays.asList(1, 2), out);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
@@ -236,7 +236,7 @@ public class MiscUtilTest extends RxJavaTest {
         TestHelper.checkUtilityClass(QueueDrainHelper.class);
     }
 
-        @Test
+    @Test
     public void appendOnlyLinkedArrayListForEachWhileBiFullChunkNoNext() throws Throwable {
         // Fill exactly capacity elements in one chunk; no next chunk exists (a[c] == null).
         // The predicate returns false for all elements so the loop must traverse past the full chunk.
@@ -247,12 +247,9 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(null, new BiPredicate<Object, Integer>() {
-            @Override
-            public boolean test(Object state, Integer value) throws Throwable {
-                out.add(value);
-                return false; // never terminate early
-            }
+        list.forEachWhile(null, (state, value) -> {
+            out.add(value);
+            return false; // never terminate early
         });
 
         assertEquals(Arrays.asList(1, 2), out);


### PR DESCRIPTION
When `forEachWhile(S, BiPredicate)` is called on an `AppendOnlyLinkedArrayList` whose last chunk is exactly full — i.e. the number of elements is a multiple of the chunk capacity — the next-chunk pointer stored at `a[capacity]` is still `null` (a new chunk is only allocated on the next `add`). After traversing the full chunk, `a` becomes `null` and the next loop iteration throws `NullPointerException` when reading `a[0]`.

This only affects the `BiPredicate` overload; it stops the traversal when the next chunk is `null`.

Reproducer (capacity 2, two elements, predicate never terminates):

```java
AppendOnlyLinkedArrayList<Integer> list = new AppendOnlyLinkedArrayList<>(2);
list.add(1);
list.add(2);
list.forEachWhile(null, (state, value) -> false); // NPE before this change
```

A regression test is added (`MiscUtilTest.appendOnlyLinkedArrayListForEachWhileBiFullChunkNoNext`) that fails before the change with `NullPointerException` and passes after it.