### PR TITLE
4.x: Observable.merge API reduction

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -10271,7 +10271,7 @@ FlowableDocBasic<T>
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Flowable<R> flatMap(@NonNull Function<? super T, @NonNull ? extends Publisher<? extends R>> mapper) {
-        return flatMap(mapper, new FlatMapConfig());
+        return flatMap(mapper, FlatMapConfig.DEFAULT);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -883,7 +883,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -990,7 +989,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -20,8 +20,7 @@ import java.util.stream.*;
 import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.*;
-import io.reactivex.rxjava4.core.config.ObservableCombineLatestConfig;
-import io.reactivex.rxjava4.core.config.ObservableConcatConfig;
+import io.reactivex.rxjava4.core.config.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -273,6 +272,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @throws NullPointerException if {@code sources}, {@code combiner} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
@@ -370,6 +370,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @throws NullPointerException if {@code sources}, {@code combiner} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
@@ -906,6 +907,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param config the configuration record for this operator
      * @return the new {@code Observable} with the concatenating behavior
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @NonNull
@@ -959,6 +961,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/concat.html">ReactiveX operators documentation: Concat</a>
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
@@ -967,6 +970,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     public static <@NonNull T> Observable<T> concat(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources,
                                                     @NonNull ObservableConcatConfig config) {
         Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(config, "config is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(
                 sources, Functions.identity(), config.bufferSize(), config.errorMode()));
     }
@@ -1011,6 +1015,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param <T> the common base value type
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
@@ -1027,6 +1032,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         if (sources.length == 1) {
             return wrap((ObservableSource<T>)sources[0]);
         }
+        Objects.requireNonNull(config, "config is null");
         return RxJavaPlugins.onAssembly(new ObservableConcatMap(
                 fromArray(sources), Functions.identity(), bufferSize(), config.errorMode()));
     }
@@ -2709,103 +2715,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
-     * Flattens an {@link Iterable} of {@link ObservableSource}s into one {@code Observable}, without any transformation, while limiting the
-     * number of concurrent subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
-     * <p>
-     * You can combine the items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the returned {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
-     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Iterable, int, int)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the {@code Iterable} of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param bufferSize
-     *            the number of items expected from each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException
-     *             if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(Iterable, int, int)
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> merge(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
-        return fromIterable(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
-    }
-
-    /**
-     * Flattens an array of {@link ObservableSource}s into one {@code Observable}, without any transformation, while limiting the
-     * number of concurrent subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
-     * <p>
-     * You can combine the items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
-     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeArrayDelayError(int, int, ObservableSource...)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the array of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param bufferSize
-     *            the number of items expected from each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException
-     *             if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeArrayDelayError(int, int, ObservableSource...)
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    @SafeVarargs
-    public static <@NonNull T> Observable<T> mergeArray(int maxConcurrency, int bufferSize, @NonNull ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function)Functions.identity(), false, maxConcurrency, bufferSize);
-    }
-
-    /**
      * Flattens an {@link Iterable} of {@link ObservableSource}s into one {@code Observable}, without any transformation.
      * <p>
      * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
@@ -2825,8 +2734,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      *
@@ -2836,7 +2743,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(Iterable)
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
@@ -2867,29 +2773,26 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(Iterable, int)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources
      *            the {@code Iterable} of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException
-     *             if {@code maxConcurrency} is less than or equal to 0
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(Iterable, int)
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Observable<T> merge(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return fromIterable(sources).flatMap((Function)Functions.identity(), maxConcurrency);
+    public static <@NonNull T> Observable<T> merge(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, @NonNull ObservableMergeConfig config) {
+        Objects.requireNonNull(config, "config is null");
+        return fromIterable(sources).flatMap((Function)Functions.identity(), config.delayErrors(), config.maxConcurrency(), config.bufferSize());
     }
 
     /**
@@ -2913,8 +2816,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      *
@@ -2924,7 +2825,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
      * @throws NullPointerException if {@code sources} is {@code null}
-     * @see #mergeDelayError(ObservableSource)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -2957,181 +2857,27 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource, int)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources
      *            an {@code ObservableSource} that emits {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
+     * @param config
+     *            the configuration record of this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException
-     *             if {@code maxConcurrency} is non-positive
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since 1.1.0
-     * @see #mergeDelayError(ObservableSource, int)
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Observable<T> merge(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
+    public static <@NonNull T> Observable<T> merge(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), false, maxConcurrency, bufferSize()));
-    }
-
-    /**
-     * Flattens two {@link ObservableSource}s into a single {@code Observable}, without any transformation.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
-     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(ObservableSource, ObservableSource)
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> merge(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        return fromArray(source1, source2).flatMap((Function)Functions.identity(), false, 2);
-    }
-
-    /**
-     * Flattens three {@link ObservableSource}s into a single {@code Observable}, without any transformation.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
-     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @param source3
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(ObservableSource, ObservableSource, ObservableSource)
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> merge(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull ObservableSource<? extends T> source3) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        return fromArray(source1, source2, source3).flatMap((Function)Functions.identity(), false, 3);
-    }
-
-    /**
-     * Flattens four {@link ObservableSource}s into a single {@code Observable}, without any transformation.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
-     * <p>
-     * You can combine items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
-     * using the {@code merge} method.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
-     *  <dt><b>Error handling:</b></dt>
-     *  <dd>If any of the {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
-     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
-     *  first one's error or, depending on the concurrency of the sources, may terminate with a
-     *  {@link CompositeException} containing two or more of the various error signals.
-     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
-     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
-     *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeDelayError(ObservableSource, ObservableSource, ObservableSource, ObservableSource)} to merge sources
-     *  and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
-     *  </dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @param source3
-     *            an {@code ObservableSource} to be merged
-     * @param source4
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeDelayError(ObservableSource, ObservableSource, ObservableSource, ObservableSource)
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> merge(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull ObservableSource<? extends T> source3, @NonNull ObservableSource<? extends T> source4) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        Objects.requireNonNull(source4, "source4 is null");
-        return fromArray(source1, source2, source3, source4).flatMap((Function)Functions.identity(), false, 4);
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), config.delayErrors(), config.maxConcurrency(), config.bufferSize()));
     }
 
     /**
@@ -3154,8 +2900,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
      *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
      *  (composite) error will be sent to the same global error handler.
-     *  Use {@link #mergeArrayDelayError(ObservableSource...)} to merge sources and terminate only when all source {@code ObservableSource}s
-     *  have completed or failed with an error.
      *  </dd>
      * </dl>
      *
@@ -3165,7 +2909,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @see #mergeArrayDelayError(ObservableSource...)
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
@@ -3177,384 +2920,47 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     }
 
     /**
-     * Flattens an {@link Iterable} of {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the returned {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the {@code Iterable} of {@code ObservableSource}s
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources) {
-        return fromIterable(sources).flatMap((Function)Functions.identity(), true);
-    }
-
-    /**
-     * Flattens an {@link Iterable} of {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the returned {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them, while limiting the number of concurrent subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the {@code Iterable} of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param bufferSize
-     *            the number of items expected from each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency, int bufferSize) {
-        return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
-    }
-
-    /**
-     * Flattens an array of {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them, while limiting the number of concurrent subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the array of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param bufferSize
-     *            the number of items expected from each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    @SafeVarargs
-    public static <@NonNull T> Observable<T> mergeArrayDelayError(int maxConcurrency, int bufferSize, @NonNull ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function)Functions.identity(), true, maxConcurrency, bufferSize);
-    }
-
-    /**
-     * Flattens an {@link Iterable} of {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the returned {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them, while limiting the number of concurrent subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            the {@code Iterable} of {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        return fromIterable(sources).flatMap((Function)Functions.identity(), true, maxConcurrency);
-    }
-
-    /**
-     * Flattens an {@link ObservableSource} that emits {@code ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to
-     * receive all successfully emitted items from all of the emitted {@code ObservableSource}s without being interrupted by
-     * an error notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            an {@code ObservableSource} that emits {@code ObservableSource}s
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
-        Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, Integer.MAX_VALUE, bufferSize()));
-    }
-
-    /**
-     * Flattens an {@link ObservableSource} that emits {@code ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to
-     * receive all successfully emitted items from all of the emitted {@code ObservableSource}s without being interrupted by
-     * an error notification from one of them, while limiting the
+     * Flattens an array of {@link ObservableSource}s into one {@code Observable}, without any transformation, while limiting the
      * number of concurrent subscriptions to these {@code ObservableSource}s.
      * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
+     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/merge.v3.png" alt="">
      * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
+     * You can combine the items emitted by multiple {@code ObservableSource}s so that they appear as a single {@code ObservableSource}, by
+     * using the {@code merge} method.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param sources
-     *            an {@code ObservableSource} that emits {@code ObservableSource}s
-     * @param maxConcurrency
-     *            the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     * @since 2.0
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int maxConcurrency) {
-        Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMap(sources, Functions.identity(), true, maxConcurrency, bufferSize()));
-    }
-
-    /**
-     * Flattens two {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource, ObservableSource)} except that if any of the merged {@code ObservableSource}s
-     * notify of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from
-     * propagating that error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if both merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        return fromArray(source1, source2).flatMap((Function)Functions.identity(), true, 2);
-    }
-
-    /**
-     * Flattens three {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from all of the {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource, ObservableSource, ObservableSource)} except that if any of the merged
-     * {@code ObservableSource}s notify of an error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain
-     * from propagating that error notification until all of the merged {@code ObservableSource}s have finished emitting
-     * items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @param source3
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code source3} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull ObservableSource<? extends T> source3) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        return fromArray(source1, source2, source3).flatMap((Function)Functions.identity(), true, 3);
-    }
-
-    /**
-     * Flattens four {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from all of the {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource, ObservableSource, ObservableSource, ObservableSource)} except that if any of
-     * the merged {@code ObservableSource}s notify of an error via {@link Observer#onError onError}, {@code mergeDelayError}
-     * will refrain from propagating that error notification until all of the merged {@code ObservableSource}s have finished
-     * emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the common element base type
-     * @param source1
-     *            an {@code ObservableSource} to be merged
-     * @param source2
-     *            an {@code ObservableSource} to be merged
-     * @param source3
-     *            an {@code ObservableSource} to be merged
-     * @param source4
-     *            an {@code ObservableSource} to be merged
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2}, {@code source3} or {@code source4} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> mergeDelayError(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull ObservableSource<? extends T> source3, @NonNull ObservableSource<? extends T> source4) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(source3, "source3 is null");
-        Objects.requireNonNull(source4, "source4 is null");
-        return fromArray(source1, source2, source3, source4).flatMap((Function)Functions.identity(), true, 4);
-    }
-
-    /**
-     * Flattens an array of {@link ObservableSource}s into one {@code Observable}, in a way that allows an {@link Observer} to receive all
-     * successfully emitted items from each of the {@code ObservableSource}s without being interrupted by an error
-     * notification from one of them.
-     * <p>
-     * This behaves like {@link #merge(ObservableSource)} except that if any of the merged {@code ObservableSource}s notify of an
-     * error via {@link Observer#onError onError}, {@code mergeDelayError} will refrain from propagating that
-     * error notification until all of the merged {@code ObservableSource}s have finished emitting items.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeDelayError.v3.png" alt="">
-     * <p>
-     * Even if multiple merged {@code ObservableSource}s send {@code onError} notifications, {@code mergeDelayError} will only
-     * invoke the {@code onError} method of its {@code Observer}s once.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code mergeArrayDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dt><b>Error handling:</b></dt>
+     *  <dd>If any of the {@code ObservableSource}s signal a {@link Throwable} via {@code onError}, the resulting
+     *  {@code Observable} terminates with that {@code Throwable} and all other source {@code ObservableSource}s are disposed.
+     *  If more than one {@code ObservableSource} signals an error, the resulting {@code Observable} may terminate with the
+     *  first one's error or, depending on the concurrency of the sources, may terminate with a
+     *  {@link CompositeException} containing two or more of the various error signals.
+     *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
+     *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
+     *  signaled by source(s) after the returned {@code Observable} has been disposed or terminated with a
+     *  (composite) error will be sent to the same global error handler.
+     *  </dd>
      * </dl>
      *
      * @param <T> the common element base type
      * @param sources
      *            the array of {@code ObservableSource}s
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/merge.html">ReactiveX operators documentation: Merge</a>
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     @SafeVarargs
-    public static <@NonNull T> Observable<T> mergeArrayDelayError(@NonNull ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function)Functions.identity(), true, sources.length);
+    public static <@NonNull T> Observable<T> mergeArray(@NonNull ObservableMergeConfig config, @NonNull ObservableSource<? extends T>... sources) {
+        Objects.requireNonNull(config, "config is null");
+        return fromArray(sources).flatMap((Function) Functions.identity(), config.delayErrors(), config.maxConcurrency(), config.bufferSize());
     }
 
     /**
@@ -8922,13 +8328,12 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param onCompleteSupplier
      *            a function that returns an {@code ObservableSource} to merge for an {@code onComplete} notification from the current
      *            {@code Observable}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
+     * @param config
+     *         the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code onNextMapper} or {@code onErrorMapper} or {@code onCompleteSupplier} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
+     * @throws NullPointerException if {@code onNextMapper} or {@code onErrorMapper} or {@code onCompleteSupplier} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
@@ -8937,11 +8342,12 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             @NonNull Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             @NonNull Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
             @NonNull Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier,
-            int maxConcurrency) {
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
         Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier), maxConcurrency);
+        Objects.requireNonNull(config, "config is null");
+        return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier), config);
     }
 
     /**
@@ -10155,7 +9561,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public final Observable<T> mergeWith(@NonNull ObservableSource<? extends T> other) {
         Objects.requireNonNull(other, "other is null");
-        return merge(this, other);
+        return mergeArray(this, other);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/CompletableConcatConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/CompletableConcatConfig.java
@@ -54,9 +54,7 @@ public record CompletableConcatConfig(boolean delayError, int prefetch) {
      * @param delayError should the error propagation be delayed?
      * @param prefetch the number of source sequences to request from a backpressured source
      */
-    public CompletableConcatConfig(boolean delayError, int prefetch) {
+    public CompletableConcatConfig {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayError = delayError;
-        this.prefetch = prefetch;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
@@ -55,9 +55,7 @@ public record CompletableMergeConfig(boolean delayErrors, int maxConcurrency) {
      * @param delayErrors should the error propagation be delayed?
      * @param maxConcurrency the number of source sequences run concurrently
      */
-    public CompletableMergeConfig(boolean delayErrors, int maxConcurrency) {
+    public CompletableMergeConfig {
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        this.delayErrors = delayErrors;
-        this.maxConcurrency = maxConcurrency;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
@@ -28,11 +28,14 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
 
     /**
-     * Default config: no error delay, {@link Flowable#bufferSize()} sizes.
+     * The default config with no error delay and Flowable#bufferSize() as the maximum concurrency setting.
      */
-    public FlatMapConfig() {
-        this(false, Flowable.bufferSize(), Flowable.bufferSize());
-    }
+    public static final FlatMapConfig DEFAULT = new FlatMapConfig(false, Flowable.bufferSize());
+
+    /**
+     * The default config with error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     */
+    public static final FlatMapConfig DELAY_ERRORS = new FlatMapConfig(true, Flowable.bufferSize());
 
     /**
      * Optionally delay error, {@link Flowable#bufferSize()} sizes

--- a/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
@@ -65,11 +65,8 @@ public record GenericConfig(boolean delayErrors, int bufferSize, int prefetch) {
      * @param bufferSize what would be the buffer size
      * @param prefetch what would be the prefetch amount
      */
-    public GenericConfig(boolean delayErrors, int bufferSize, int prefetch) {
+    public GenericConfig {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayErrors = delayErrors;
-        this.bufferSize = bufferSize;
-        this.prefetch = prefetch;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/GenericConfig.java
@@ -28,11 +28,14 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 public record GenericConfig(boolean delayErrors, int bufferSize, int prefetch) {
 
     /**
-     * Default config: no error delay, {@link Flowable#bufferSize()} sizes.
+     * The default config with no error delay and Flowable#bufferSize() as the maximum concurrency setting.
      */
-    public GenericConfig() {
-        this(false, Flowable.bufferSize(), Flowable.bufferSize());
-    }
+    public static final GenericConfig DEFAULT = new GenericConfig(false, Flowable.bufferSize());
+
+    /**
+     * The default config with error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     */
+    public static final GenericConfig DELAY_ERRORS = new GenericConfig(true, Flowable.bufferSize());
 
     /**
      * Optionally delay error, {@link Flowable#bufferSize()} sizes.

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
@@ -66,10 +66,7 @@ public record MaybeConcatEagerConfig(boolean delayError, int maxConcurrency, int
      * @param maxConcurrency the maximum number of concurrent sources running
      * @param prefetch the number of items to request from each source
      */
-    public MaybeConcatEagerConfig(boolean delayError, int maxConcurrency, int prefetch) {
+    public MaybeConcatEagerConfig {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayError = delayError;
-        this.maxConcurrency = maxConcurrency;
-        this.prefetch = prefetch;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeMergeConfig.java
@@ -54,9 +54,7 @@ public record MaybeMergeConfig(boolean delayErrors, int maxConcurrency) {
      * @param delayErrors should the error propagation be delayed?
      * @param maxConcurrency the number of source sequences run concurrently
      */
-    public MaybeMergeConfig(boolean delayErrors, int maxConcurrency) {
+    public MaybeMergeConfig {
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        this.delayErrors = delayErrors;
-        this.maxConcurrency = maxConcurrency;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableCombineLatestConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableCombineLatestConfig.java
@@ -55,9 +55,7 @@ public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) 
      * @param delayError should the error propagation be delayed?
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
-    public ObservableCombineLatestConfig(boolean delayError, int bufferSize) {
+    public ObservableCombineLatestConfig {
         ObjectHelper.verifyPositive(bufferSize, "prefetch");
-        this.delayError = delayError;
-        this.bufferSize = bufferSize;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
@@ -37,13 +37,6 @@ public record ObservableMergeConfig(boolean delayErrors, int maxConcurrency, int
     public static final ObservableMergeConfig DELAY_ERROR = new ObservableMergeConfig(true, Observable.bufferSize());
 
     /**
-     * Default config: no error delay, {@link Flowable#bufferSize()} sizes.
-     */
-    public ObservableMergeConfig() {
-        this(false, Flowable.bufferSize(), Flowable.bufferSize());
-    }
-
-    /**
      * Optionally delay error, {@link Flowable#bufferSize()} sizes
      * @param delayErrors should the error be delayed?
      */

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
@@ -14,23 +14,32 @@
 package io.reactivex.rxjava4.core.config;
 
 import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Generic configuration block with option to delay errors, change max concurrency
- * amounts and buffer sizes.
- * TODO once value classes are available, make this a record class.
+ * Configuration record for Observable.merge() operators.
  * @param delayErrors should the error be delayed?
  * @param maxConcurrency the maximum number of concurrent flows?
  * @param bufferSize what would be the buffer size?
  * @since 4.0.0
  */
-public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
+public record ObservableMergeConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
+
+    /**
+     * The default configuration with no error delays and bufferSize of {@link Observable#bufferSize()}.
+     */
+    public static final ObservableMergeConfig DEFAULT = new ObservableMergeConfig(false, Observable.bufferSize());
+
+    /**
+     * The default configuration with error delays and bufferSize of {@link Observable#bufferSize()}.
+     */
+    public static final ObservableMergeConfig DELAY_ERROR = new ObservableMergeConfig(true, Observable.bufferSize());
 
     /**
      * Default config: no error delay, {@link Flowable#bufferSize()} sizes.
      */
-    public FlatMapConfig() {
+    public ObservableMergeConfig() {
         this(false, Flowable.bufferSize(), Flowable.bufferSize());
     }
 
@@ -38,7 +47,7 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
      * Optionally delay error, {@link Flowable#bufferSize()} sizes
      * @param delayErrors should the error be delayed?
      */
-    public FlatMapConfig(boolean delayErrors) {
+    public ObservableMergeConfig(boolean delayErrors) {
         this(delayErrors, Flowable.bufferSize(), Flowable.bufferSize());
     }
 
@@ -46,7 +55,7 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
      * Optionally set the buffer size, no delay errors.
      * @param maxConcurrency the maximum number of concurrent flows
      */
-    public FlatMapConfig(int maxConcurrency) {
+    public ObservableMergeConfig(int maxConcurrency) {
         this(false, maxConcurrency, Flowable.bufferSize());
     }
 
@@ -55,7 +64,7 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
      * @param delayErrors should the errors be delayed?
      * @param maxConcurrency the maximum number of concurrent flows
      */
-    public FlatMapConfig(boolean delayErrors, int maxConcurrency) {
+    public ObservableMergeConfig(boolean delayErrors, int maxConcurrency) {
         this(delayErrors, maxConcurrency, Flowable.bufferSize());
     }
 
@@ -65,7 +74,7 @@ public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferS
      * @param maxConcurrency the maximum number of concurrent flows?
      * @param bufferSize what would be the buffer size
      */
-    public FlatMapConfig {
+    public ObservableMergeConfig {
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ParallelSchedulerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ParallelSchedulerConfig.java
@@ -36,12 +36,12 @@ public record ParallelSchedulerConfig(
         @Nullable ThreadFactory factory) {
 
     /**
-     * Creates a default config with available CPUs parallelism,
-     * normal priority, tracking and RxParallelScheduler thread name prefix.
+     * Default configuration: Available CPU parallelism, tracking on, normal thread priority
+     * {@code RxParallelScheduler} naming and no custom {@link ThreadFactory}.
      */
-    public ParallelSchedulerConfig() {
-        this(Runtime.getRuntime().availableProcessors(), true, Thread.NORM_PRIORITY, "RxParallelScheduler", null);
-    }
+    public static final ParallelSchedulerConfig DEFAULT = new ParallelSchedulerConfig(
+            Runtime.getRuntime().availableProcessors(), true, Thread.NORM_PRIORITY,
+            "RxParallelScheduler", null);
 
     /**
      * Creates a default config with the given parallelism,

--- a/src/main/java/io/reactivex/rxjava4/core/config/ParallelSchedulerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ParallelSchedulerConfig.java
@@ -16,13 +16,14 @@ package io.reactivex.rxjava4.core.config;
 import java.util.concurrent.ThreadFactory;
 
 import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
 /**
  * Configuration record for {@link Schedulers#createParallel(ParallelSchedulerConfig)}.
  * @param parallelism the number of concurrent threads, default the number of CPUs.
  * @param tracking if true, tasks submitted to it will be tracked and can be en-masse disposed
- * @param priority the thread priority of the created platform threads.
+ * @param priority the thread priority of the created platform threads. See {@link Thread#NORM_PRIORITY}.
  * @param threadNamePrefix the prefix to name the scheduler's threads
  * @param factory the customizable factory for the underlying Executor, if non-null, the priority and threadNamePrefix
  *                are ignored
@@ -97,21 +98,12 @@ public record ParallelSchedulerConfig(
      * Creates a fully configurable ParallelSchedulerConfig object.
      * @param parallelism the number of threads to work with in the scheduler
      * @param tracking if true, tasks submitted to it will be tracked and can be en-masse disposed
-     * @param priority
+     * @param priority the thread priority of the created platform threads. See {@link Thread#NORM_PRIORITY}.
      * @param threadNamePrefix the prefix to name the scheduler's threads
      * @param factory the customizable factory for the underlying Executor, if non-null, the priority
      *                and threadNamePrefix are ignored
      */
-    public ParallelSchedulerConfig(
-            int parallelism,
-            boolean tracking,
-            int priority,
-            @NonNull String threadNamePrefix,
-            @Nullable ThreadFactory factory) {
-        this.parallelism = parallelism;
-        this.tracking = tracking;
-        this.priority = priority;
-        this.threadNamePrefix = threadNamePrefix;
-        this.factory = factory;
+    public ParallelSchedulerConfig {
+        ObjectHelper.verifyPositive(parallelism, "parallelism");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatConfig.java
@@ -54,9 +54,7 @@ public record SingleConcatConfig(boolean delayError, int prefetch) {
      * @param delayError should the error propagation be delayed?
      * @param prefetch the number of source sequences to request from a backpressured source
      */
-    public SingleConcatConfig(boolean delayError, int prefetch) {
+    public SingleConcatConfig {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayError = delayError;
-        this.prefetch = prefetch;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatEagerConfig.java
@@ -66,10 +66,8 @@ public record SingleConcatEagerConfig(boolean delayError, int maxConcurrency, in
      * @param maxConcurrency the maximum number of concurrent sources running
      * @param prefetch the number of items to request from each source
      */
-    public SingleConcatEagerConfig(boolean delayError, int maxConcurrency, int prefetch) {
+    public SingleConcatEagerConfig {
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        this.delayError = delayError;
-        this.maxConcurrency = maxConcurrency;
-        this.prefetch = prefetch;
+        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/SingleMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/SingleMergeConfig.java
@@ -54,9 +54,7 @@ public record SingleMergeConfig(boolean delayErrors, int maxConcurrency) {
      * @param delayErrors should the error propagation be delayed?
      * @param maxConcurrency the number of source sequences run concurrently
      */
-    public SingleMergeConfig(boolean delayErrors, int maxConcurrency) {
+    public SingleMergeConfig {
         ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        this.delayErrors = delayErrors;
-        this.maxConcurrency = maxConcurrency;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
@@ -175,6 +175,7 @@ implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver
     /**
      * Expose this {@code TestObserver} as a {@link Disposable} object.
      * @return the {@code Disposable} view of this {@code TestObserver}
+     * @since 4.0.0
      */
     public final Disposable asDisposable() {
         return new TestObserverDisposable(this);

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
@@ -660,7 +660,7 @@ public final class Schedulers {
      */
     @NonNull
     public static Scheduler createParallel() {
-        return createParallel(new ParallelSchedulerConfig());
+        return createParallel(ParallelSchedulerConfig.DEFAULT);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
@@ -287,6 +287,7 @@ implements FlowableSubscriber<T>, Subscription {
     /**
      * Expose this {@code TestSubscriber} as a {@link Disposable} object.
      * @return the {@code Disposable} view of this {@code TestSubscriber}
+     * @since 4.0.0
      */
     public final Disposable asDisposable() {
         return new TestSubscriberDisposable(this);

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableMergeConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableMergeConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObservableMergeConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new ObservableMergeConfig(true).delayErrors(), "delayErrors - true");
+        assertFalse(new ObservableMergeConfig(false).delayErrors(), "delayErrors - false");
+        assertEquals(5, new ObservableMergeConfig(5).maxConcurrency(), "maxConcurrency - 5");
+        assertEquals(5, new ObservableMergeConfig(true, 5).maxConcurrency(), "maxConcurrency both - true, 5");
+        assertEquals(5, new ObservableMergeConfig(false, 5).maxConcurrency(), "maxConcurrency both - false, 5");
+        assertTrue(new ObservableMergeConfig(true, 5).delayErrors(), "delayErrors both - true, 5");
+        assertFalse(new ObservableMergeConfig(false, 5).delayErrors(), "delayErrors both - false, 5");
+
+        assertTrue(new ObservableMergeConfig(true, 5, 10).delayErrors(), "delayErrors both - true, 5");
+        assertFalse(new ObservableMergeConfig(false, 5, 10).delayErrors(), "delayErrors both - false, 5");
+        assertEquals(5, new ObservableMergeConfig(true, 5, 10).maxConcurrency(), "maxConcurrency both - true, 5");
+        assertEquals(10, new ObservableMergeConfig(false, 5, 10).bufferSize(), "bufferSize both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
@@ -307,7 +307,7 @@ public class ObservableDebounceTest extends RxJavaTest {
         TestScheduler scheduler = new TestScheduler();
         TestObserverEx<Integer> observer = new TestObserverEx<>();
 
-        Observable.merge(
+        Observable.mergeArray(
                 Observable.just(1),
                 Observable.just(2).delay(10, TimeUnit.MILLISECONDS, scheduler)
         ).debounce(20, TimeUnit.MILLISECONDS, scheduler).take(1).subscribe(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -22,6 +22,7 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import org.junit.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
@@ -341,7 +342,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         TestObserverEx<Object> to = new TestObserverEx<>(o);
 
         Function<Throwable, Observable<Integer>> just = just(onError);
-        source.flatMap(just(onNext), just, just0(onComplete), m).subscribe(to);
+        source.flatMap(just(onNext), just, just0(onComplete), new ObservableMergeConfig(m)).subscribe(to);
 
         to.awaitDone(1, TimeUnit.SECONDS);
         to.assertNoErrors();
@@ -522,7 +523,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
             }
         };
 
-        Observable.merge(ps, 2)
+        Observable.merge(ps, new ObservableMergeConfig(2))
         .subscribe(to);
 
         ps.onNext(Observable.just(1));
@@ -575,7 +576,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void noCrossBoundaryFusion() {
         for (int i = 0; i < 500; i++) {
-            TestObserver<Object> to = Observable.merge(
+            TestObserver<Object> to = Observable.mergeArray(
                     Observable.just(1).observeOn(Schedulers.single()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4)),
                     Observable.just(1).observeOn(Schedulers.computation()).map((Function<Integer, Object>) _ -> Thread.currentThread().getName().substring(0, 4))
             )

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.*;
 
@@ -45,7 +46,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(NullPointerException.class));
@@ -69,7 +70,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
         final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2, o3, o4);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(CompositeException.class));
@@ -94,7 +95,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight", null));
         final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2, o3, o4);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(NullPointerException.class));
@@ -117,7 +118,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o3 = Observable.unsafeCreate(new TestErrorObservable("seven", "eight"));
         final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine", null));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2, o3, o4);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2, o3, o4);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(NullPointerException.class));
@@ -141,7 +142,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         // throw the error at the very end so no onComplete will be called after it
         final TestAsyncErrorObservable o4 = new TestAsyncErrorObservable("nine", null);
 
-        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2), Observable.unsafeCreate(o3), Observable.unsafeCreate(o4));
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR,
+                Observable.unsafeCreate(o1), Observable.unsafeCreate(o2), Observable.unsafeCreate(o3), Observable.unsafeCreate(o4));
         m.subscribe(stringObserver);
 
         try {
@@ -172,7 +174,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(Throwable.class));
@@ -193,7 +195,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o1 = Observable.unsafeCreate(new TestErrorObservable("four", null, "six"));
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", null));
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2);
         CaptureObserver w = new CaptureObserver();
         m.subscribe(w);
 
@@ -226,7 +228,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
             observer.onNext(o2);
             observer.onComplete();
         });
-        Observable<String> m = Observable.mergeDelayError(observableOfObservables);
+        Observable<String> m = Observable.merge(observableOfObservables, ObservableMergeConfig.DELAY_ERROR);
         m.subscribe(stringObserver);
 
         verify(stringObserver, never()).onError(any(Throwable.class));
@@ -239,7 +241,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
         final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<String> m = Observable.mergeDelayError(o1, o2);
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, o1, o2);
         m.subscribe(stringObserver);
 
         verify(stringObserver, never()).onError(any(Throwable.class));
@@ -255,7 +257,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         listOfObservables.add(o1);
         listOfObservables.add(o2);
 
-        Observable<String> m = Observable.mergeDelayError(Observable.fromIterable(listOfObservables));
+        Observable<String> m = Observable.merge(Observable.fromIterable(listOfObservables), ObservableMergeConfig.DELAY_ERROR);
         m.subscribe(stringObserver);
 
         verify(stringObserver, never()).onError(any(Throwable.class));
@@ -268,7 +270,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.mergeDelayError(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
+        Observable<String> m = Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(stringObserver);
 
         try {
@@ -288,7 +290,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<Observable<String>> o1 = Observable.error(new RuntimeException("unit test"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        Observable.mergeDelayError(o1).subscribe(new DefaultObserver<String>() {
+        Observable.merge(o1, ObservableMergeConfig.DELAY_ERROR).subscribe(new DefaultObserver<String>() {
             @Override
             public void onComplete() {
                 fail("Expected onError path");
@@ -423,10 +425,10 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
     @Test
     public void errorInParentObservable() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
-        Observable.mergeDelayError(
+        Observable.merge(
                 Observable.just(Observable.just(1), Observable.just(2))
                         .startWithItem(Observable.<Integer> error(new RuntimeException()))
-                ).subscribe(to);
+                , ObservableMergeConfig.DELAY_ERROR).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertTerminated();
         to.assertValues(1, 2);
@@ -449,7 +451,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
             Observer<String> stringObserver = TestHelper.mockObserver();
 
             TestObserverEx<String> to = new TestObserverEx<>(stringObserver);
-            Observable<String> m = Observable.mergeDelayError(parentObservable);
+            Observable<String> m = Observable.merge(parentObservable, ObservableMergeConfig.DELAY_ERROR);
             m.subscribe(to);
             System.out.println("testErrorInParentObservableDelayed | " + i);
             to.awaitDone(2000, TimeUnit.MILLISECONDS);
@@ -482,84 +484,85 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void mergeIterableDelayError() {
-        Observable.mergeDelayError(Arrays.asList(Observable.just(1), Observable.just(2)))
+        Observable.merge(Arrays.asList(Observable.just(1), Observable.just(2)), ObservableMergeConfig.DELAY_ERROR)
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void mergeArrayDelayError() {
-        Observable.mergeArrayDelayError(Observable.just(1), Observable.just(2))
+        Observable.mergeArray(ObservableMergeConfig.DELAY_ERROR, Observable.just(1), Observable.just(2))
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void mergeIterableDelayErrorWithError() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Arrays.asList(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
-                Observable.just(2)))
+                Observable.just(2)), ObservableMergeConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void mergeDelayError() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Observable.just(Observable.just(1),
-                Observable.just(2)))
+                Observable.just(2)), ObservableMergeConfig.DELAY_ERROR)
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void mergeDelayErrorWithError() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Observable.just(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
-                Observable.just(2)))
+                Observable.just(2)), ObservableMergeConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void mergeDelayErrorMaxConcurrency() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Observable.just(Observable.just(1),
-                Observable.just(2)), 1)
+                Observable.just(2)), new ObservableMergeConfig(1))
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void mergeDelayErrorWithErrorMaxConcurrency() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Observable.just(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
-                Observable.just(2)), 1)
+                Observable.just(2)), new ObservableMergeConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void mergeIterableDelayErrorMaxConcurrency() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Arrays.asList(Observable.just(1),
-                Observable.just(2)), 1)
+                Observable.just(2)), new ObservableMergeConfig(1))
         .test()
         .assertResult(1, 2);
     }
 
     @Test
     public void mergeIterableDelayErrorWithErrorMaxConcurrency() {
-        Observable.mergeDelayError(
+        Observable.merge(
                 Arrays.asList(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
-                Observable.just(2)), 1)
+                Observable.just(2)), new ObservableMergeConfig(true, 1))
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
 
     @Test
     public void mergeDelayError3() {
-        Observable.mergeDelayError(
+        Observable.mergeArray(
+                ObservableMergeConfig.DELAY_ERROR,
                 Observable.just(1),
                 Observable.just(2),
                 Observable.just(3)
@@ -570,7 +573,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
     @Test
     public void mergeDelayError3WithError() {
-        Observable.mergeDelayError(
+        Observable.mergeArray(
+                ObservableMergeConfig.DELAY_ERROR,
                 Observable.just(1),
                 Observable.just(2).concatWith(Observable.<Integer>error(new TestException())),
                 Observable.just(3)

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeMaxConcurrentTest.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -48,7 +49,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
             os.add(Observable.just("one", "two", "three", "four", "five").subscribeOn(Schedulers.newThread()));
 
             List<String> expected = Arrays.asList("one", "two", "three", "four", "five", "one", "two", "three", "four", "five", "one", "two", "three", "four", "five");
-            Iterator<String> iter = Observable.merge(os, 1).blockingIterable().iterator();
+            Iterator<String> iter = Observable.merge(os, new ObservableMergeConfig(1)).blockingIterable().iterator();
             List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
@@ -73,7 +74,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
                 os.add(Observable.unsafeCreate(sco));
             }
 
-            Iterator<String> iter = Observable.merge(os, maxConcurrent).blockingIterable().iterator();
+            Iterator<String> iter = Observable.merge(os, new ObservableMergeConfig(maxConcurrent)).blockingIterable().iterator();
             List<String> actual = new ArrayList<>();
             while (iter.hasNext()) {
                 actual.add(iter.next());
@@ -125,13 +126,13 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
-        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), 1).blockingIterable().iterator();
+        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), new ObservableMergeConfig(1)).blockingIterable().iterator();
         int j = 0;
         while (it.hasNext()) {
             assertEquals((Integer)j, it.next());
             j++;
         }
-        assertEquals(j, n);
+        assertEquals(n, j);
     }
 
     @Test
@@ -141,13 +142,13 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
         for (int i = 0; i < n; i++) {
             sourceList.add(Observable.just(i));
         }
-        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), 1).take(n / 2).blockingIterable().iterator();
+        Iterator<Integer> it = Observable.merge(Observable.fromIterable(sourceList), new ObservableMergeConfig(1)).take(n / 2).blockingIterable().iterator();
         int j = 0;
         while (it.hasNext()) {
             assertEquals((Integer)j, it.next());
             j++;
         }
-        assertEquals(j, n / 2);
+        assertEquals(n / 2, j);
     }
 
     @Test
@@ -161,7 +162,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
                 result.add(j);
             }
 
-            Observable.merge(sourceList, i).subscribe(to);
+            Observable.merge(sourceList, new ObservableMergeConfig(i)).subscribe(to);
 
             to.assertNoErrors();
             to.assertTerminated();
@@ -180,7 +181,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
                 result.add(j);
             }
 
-            Observable.merge(sourceList, i - 1).subscribe(to);
+            Observable.merge(sourceList, new ObservableMergeConfig(i - 1)).subscribe(to);
 
             to.assertNoErrors();
             to.assertTerminated();
@@ -212,7 +213,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
                 expected.add(j);
             }
 
-            Observable.merge(sourceList, i).subscribe(to);
+            Observable.merge(sourceList, new ObservableMergeConfig(i)).subscribe(to);
 
             to.awaitDone(1, TimeUnit.SECONDS);
             to.assertNoErrors();
@@ -244,7 +245,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
                 expected.add(j);
             }
 
-            Observable.merge(sourceList, i - 1).subscribe(to);
+            Observable.merge(sourceList, new ObservableMergeConfig(i - 1)).subscribe(to);
 
             to.awaitDone(1, TimeUnit.SECONDS);
             to.assertNoErrors();
@@ -264,7 +265,7 @@ public class ObservableMergeMaxConcurrentTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.merge(sourceList, 2).take(5).subscribe(to);
+        Observable.merge(sourceList, new ObservableMergeConfig(2)).take(5).subscribe(to);
 
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -95,7 +95,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final Observable<String> o1 = Observable.unsafeCreate(new TestSynchronousObservable());
         final Observable<String> o2 = Observable.unsafeCreate(new TestSynchronousObservable());
 
-        Observable<String> m = Observable.merge(o1, o2);
+        Observable<String> m = Observable.mergeArray(o1, o2);
         m.subscribe(stringObserver);
 
         verify(stringObserver, never()).onError(any(Throwable.class));
@@ -169,7 +169,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final TestASynchronousObservable o1 = new TestASynchronousObservable();
         final TestASynchronousObservable o2 = new TestASynchronousObservable();
 
-        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
+        Observable<String> m = Observable.mergeArray(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         TestObserver<String> to = new TestObserver<>(stringObserver);
         m.subscribe(to);
 
@@ -200,7 +200,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger concurrentCounter = new AtomicInteger();
         final AtomicInteger totalCounter = new AtomicInteger();
 
-        Observable<String> m = Observable.merge(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
+        Observable<String> m = Observable.mergeArray(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
         m.subscribe(new DefaultObserver<String>() {
 
             @Override
@@ -279,7 +279,7 @@ public class ObservableMergeTest extends RxJavaTest {
         // we expect to lose all of these since o1 is done first and fails
         final Observable<String> o2 = Observable.unsafeCreate(new TestErrorObservable("one", "two", "three"));
 
-        Observable<String> m = Observable.merge(o1, o2);
+        Observable<String> m = Observable.mergeArray(o1, o2);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(NullPointerException.class));
@@ -306,7 +306,7 @@ public class ObservableMergeTest extends RxJavaTest {
         // we expect to lose all of these since o2 is done first and fails
         final Observable<String> o4 = Observable.unsafeCreate(new TestErrorObservable("nine"));
 
-        Observable<String> m = Observable.merge(o1, o2, o3, o4);
+        Observable<String> m = Observable.mergeArray(o1, o2, o3, o4);
         m.subscribe(stringObserver);
 
         verify(stringObserver, times(1)).onError(any(NullPointerException.class));
@@ -388,7 +388,7 @@ public class ObservableMergeTest extends RxJavaTest {
         Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
         TestObserverEx<Long> to = new TestObserverEx<>();
-        Observable.merge(o1, o2).subscribe(to);
+        Observable.mergeArray(o1, o2).subscribe(to);
 
         // we haven't incremented time so nothing should be received yet
         to.assertNoValues();
@@ -430,7 +430,7 @@ public class ObservableMergeTest extends RxJavaTest {
             Observable<Long> o2 = createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(scheduler2, os2);
 
             TestObserver<Long> to = new TestObserver<>();
-            Observable.merge(o1, o2).subscribe(to);
+            Observable.mergeArray(o1, o2).subscribe(to);
 
             // we haven't incremented time so nothing should be received yet
             to.assertNoValues();
@@ -492,7 +492,7 @@ public class ObservableMergeTest extends RxJavaTest {
         Observable<Integer> o = Observable.range(1, 10000).subscribeOn(Schedulers.newThread());
 
         for (int i = 0; i < 10; i++) {
-            Observable<Integer> merge = Observable.merge(o, o, o);
+            Observable<Integer> merge = Observable.mergeArray(o, o, o);
             TestObserverEx<Integer> to = new TestObserverEx<>();
             merge.subscribe(to);
 
@@ -536,7 +536,7 @@ public class ObservableMergeTest extends RxJavaTest {
         });
 
         for (int i = 0; i < 10; i++) {
-            Observable<Integer> merge = Observable.merge(o, o, o);
+            Observable<Integer> merge = Observable.mergeArray(o, o, o);
             TestObserver<Integer> to = new TestObserver<>();
             merge.subscribe(to);
 
@@ -574,7 +574,7 @@ public class ObservableMergeTest extends RxJavaTest {
         });
 
         for (int i = 0; i < 10; i++) {
-            Observable<Integer> merge = Observable.merge(o, o, o);
+            Observable<Integer> merge = Observable.mergeArray(o, o, o);
             TestObserver<Integer> to = new TestObserver<>();
             merge.subscribe(to);
 
@@ -602,10 +602,12 @@ public class ObservableMergeTest extends RxJavaTest {
             }
         };
 
-        Observable.merge(o1.take(Flowable.bufferSize() * 2), o2.take(Flowable.bufferSize() * 2)).subscribe(testObserver);
+        Observable.mergeArray(o1.take(Flowable.bufferSize() * 2L),
+                o2.take(Flowable.bufferSize() * 2L))
+                .subscribe(testObserver);
         testObserver.awaitDone(5, TimeUnit.SECONDS);
-        if (testObserver.errors().size() > 0) {
-            testObserver.errors().get(0).printStackTrace();
+        if (!testObserver.errors().isEmpty()) {
+            testObserver.errors().getFirst().printStackTrace();
         }
         testObserver.assertNoErrors();
         System.err.println(testObserver.values());
@@ -639,7 +641,9 @@ public class ObservableMergeTest extends RxJavaTest {
             }
         };
 
-        Observable.merge(o1.take(Flowable.bufferSize() * 2), Observable.just(-99)).subscribe(testObserver);
+        Observable.mergeArray(o1.take(Flowable.bufferSize() * 2L),
+                Observable.just(-99))
+                .subscribe(testObserver);
         testObserver.awaitDone(5, TimeUnit.SECONDS);
 
         List<Integer> onNextEvents = testObserver.values();
@@ -685,10 +689,13 @@ public class ObservableMergeTest extends RxJavaTest {
             }
         };
 
-        Observable.merge(o1.take(Flowable.bufferSize() * 2), o2.take(Flowable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(to);
+        Observable.mergeArray(o1.take(Flowable.bufferSize() * 2L),
+                o2.take(Flowable.bufferSize() * 2L))
+                .observeOn(Schedulers.computation())
+                .subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
-        if (to.errors().size() > 0) {
-            to.errors().get(0).printStackTrace();
+        if (!to.errors().isEmpty()) {
+            to.errors().getFirst().printStackTrace();
         }
         to.assertNoErrors();
         System.err.println(to.values());
@@ -983,7 +990,7 @@ public class ObservableMergeTest extends RxJavaTest {
             Observable<Integer> source1 = Observable.error(new TestException("First"));
             Observable<Integer> source2 = Observable.error(new TestException("Second"));
 
-            Observable.merge(source1, source2)
+            Observable.mergeArray(source1, source2)
             .to(TestHelper.<Integer>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
@@ -100,7 +100,7 @@ public class ObservablePublishTest extends RxJavaTest {
         }).doOnComplete(() -> System.out.println("^^^^^^^^^^^^^ completed SLOW"));
 
         TestObserver<Integer> to = new TestObserver<>();
-        Observable.merge(fast, slow).subscribe(to);
+        Observable.mergeArray(fast, slow).subscribe(to);
         is.connect();
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -19,7 +19,6 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithSizeTest.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
@@ -113,7 +114,11 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         final AtomicInteger count = new AtomicInteger();
-        Observable.merge(Observable.range(1, 10000).doOnNext(_ -> count.incrementAndGet()).window(5, 4).take(2))
+        Observable.merge(
+                Observable.range(1, 10000)
+                        .doOnNext(_ -> count.incrementAndGet())
+                        .window(5, 4)
+                        .take(2))
         .subscribe(to);
 
         to.awaitDone(500, TimeUnit.MILLISECONDS);
@@ -132,8 +137,10 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
                 .doOnNext(_ -> count.incrementAndGet())
                 .observeOn(Schedulers.computation())
                 .window(5, 4)
-                .take(2), 128)
-                .subscribe(to);
+                .take(2)
+            )
+            .subscribe(to)
+        ;
 
         to.awaitDone(500, TimeUnit.MILLISECONDS);
         to.assertTerminated();
@@ -143,7 +150,7 @@ public class ObservableWindowWithSizeTest extends RxJavaTest {
     }
 
     private List<String> list(String... args) {
-        List<String> list = new ArrayList<>();
+        List<String> list = new ArrayList<>(args.length + 1);
         for (String arg : args) {
             list.add(arg);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
@@ -391,7 +391,7 @@ public class ParallelSchedulerTest implements Runnable {
     @Test
     public void parallelSchedulerConfig() {
         {
-        var psc1 = new ParallelSchedulerConfig();
+        var psc1 = ParallelSchedulerConfig.DEFAULT;
         assertEquals("Parallelism", psc1.parallelism(), Runtime.getRuntime().availableProcessors());
         assertTrue("Tracking", psc1.tracking());
         assertEquals("threadNamePrefix", psc1.threadNamePrefix(), "RxParallelScheduler");

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableGroupByTests.java
@@ -24,7 +24,7 @@ public class ObservableGroupByTests extends RxJavaTest {
 
     @Test
     public void takeUnsubscribesOnGroupBy() throws Exception {
-        Observable.merge(
+        Observable.mergeArray(
             ObservableEventStream.getEventStream("HTTP-ClusterA", 50),
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
@@ -43,7 +43,7 @@ public class ObservableGroupByTests extends RxJavaTest {
 
     @Test
     public void takeUnsubscribesOnFlatMapOfGroupBy() throws Exception {
-        Observable.merge(
+        Observable.mergeArray(
             ObservableEventStream.getEventStream("HTTP-ClusterA", 50),
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         )

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableMergeTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableMergeTests.java
@@ -64,7 +64,7 @@ public class ObservableMergeTests extends RxJavaTest {
         Observable<Movie> o1 = Observable.just(new HorrorMovie(), new Movie());
         Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().blockingGet();
+        List<Media> values = Observable.mergeArray(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);
@@ -82,7 +82,7 @@ public class ObservableMergeTests extends RxJavaTest {
 
         Observable<Media> o2 = Observable.just(new Media(), new HorrorMovie());
 
-        List<Media> values = Observable.merge(o1, o2).toList().blockingGet();
+        List<Media> values = Observable.mergeArray(o1, o2).toList().blockingGet();
 
         assertTrue(values.get(0) instanceof HorrorMovie);
         assertTrue(values.get(1) instanceof Movie);

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -3554,28 +3554,28 @@ public enum TestHelper {
 
             if (result instanceof MaybeSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((MaybeSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof SingleSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((SingleSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof CompletableSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((CompletableSource)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof ObservableSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((ObservableSource<?>)result)
                 .subscribe(to);
@@ -3620,28 +3620,28 @@ public enum TestHelper {
 
             if (result instanceof MaybeSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((MaybeSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof SingleSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((SingleSource<?>)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof CompletableSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((CompletableSource)result)
                 .subscribe(to);
                 to.assertEmpty();
             } else if (result instanceof ObservableSource) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to);
+                disposable.set(to.asDisposable());
 
                 ((ObservableSource<?>)result)
                 .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
@@ -15,9 +15,11 @@ package io.reactivex.rxjava4.testsupport;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.operators.QueueDisposable;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 
@@ -31,9 +33,9 @@ import io.reactivex.rxjava4.operators.QueueFuseable;
  *
  * @param <T> the value type
  */
-public class TestObserverEx<T>
+public class TestObserverEx<@NonNull T>
 extends BaseTestConsumerEx<T, TestObserverEx<T>>
-implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
+implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver {
     /** The actual observer to forward events to. */
     private final Observer<? super T> downstream;
 
@@ -293,6 +295,28 @@ implements Observer<T>, Disposable, MaybeObserver<T>, SingleObserver<T>, Complet
     public void onSuccess(T value) {
         onNext(value);
         onComplete();
+    }
+
+    /**
+     * Expose this {@code TestObserver} as a {@link Disposable} object.
+     * @return the {@code Disposable} view of this {@code TestObserver}
+     * @since 4.0.0
+     */
+    public final Disposable asDisposable() {
+        return new TestObserverExDisposable(this);
+    }
+
+    record TestObserverExDisposable(TestObserverEx<?> to) implements Disposable {
+
+        @Override
+        public void dispose() {
+            to.dispose();
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return to.isDisposed();
+        }
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
@@ -19,7 +19,6 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
-import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.operators.QueueDisposable;
 import io.reactivex.rxjava4.operators.QueueFuseable;
 

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
@@ -173,7 +173,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void nullExpected() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onNext(1);
 
@@ -188,7 +187,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void nullActual() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onNext(null);
 
@@ -203,7 +201,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalErrorOnce() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onError(new TestException());
         to.onError(new TestException());
@@ -219,7 +216,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalCompletedOnce() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onComplete();
         to.onComplete();
@@ -235,7 +231,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void terminalOneKind() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onError(new TestException());
         to.onComplete();
@@ -253,7 +248,6 @@ public class TestObserverExTest extends RxJavaTest {
     public void createDelegate() {
         TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>(to1);
 
         to.assertNotSubscribed();
@@ -311,7 +305,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertError() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         try {
@@ -432,7 +425,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertFailure() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -454,7 +446,6 @@ public class TestObserverExTest extends RxJavaTest {
         to.assertFailureAndMessage(TestException.class, "Forced failure", 1);
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void assertFuseable() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
@@ -504,7 +495,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertTerminated() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.assertNotTerminated();
@@ -521,7 +511,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertResult() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -559,7 +548,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void await() throws Exception {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -582,7 +570,6 @@ public class TestObserverExTest extends RxJavaTest {
 
         to.assertNoErrors().assertComplete();
 
-        @SuppressWarnings("resource")
         final TestObserverEx<Integer> to1 = new TestObserverEx<>();
 
         to1.onSubscribe(Disposable.empty());
@@ -594,7 +581,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errors() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -610,7 +596,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void onNext() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -642,7 +627,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void multipleTerminals() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -686,7 +670,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValue() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -719,7 +702,6 @@ public class TestObserverExTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void onNextMisbehave() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
@@ -737,7 +719,6 @@ public class TestObserverExTest extends RxJavaTest {
         to.assertFailure(NullPointerException.class, (Integer)null);
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void assertTerminated2() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
@@ -781,7 +762,6 @@ public class TestObserverExTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void onSubscribe() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
@@ -815,7 +795,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValueSequence() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -849,7 +828,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertEmpty() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         try {
@@ -875,7 +853,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void awaitDoneTimed() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         Thread.currentThread().interrupt();
@@ -889,7 +866,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertNotSubscribed() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.assertNotSubscribed();
@@ -906,7 +882,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertErrorMultiple() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         TestException e = new TestException();
@@ -941,7 +916,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorInPredicate() {
-        @SuppressWarnings("resource")
         TestObserverEx<Object> to = new TestObserverEx<>();
         to.onError(new RuntimeException());
         try {
@@ -957,7 +931,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertComplete() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onSubscribe(Disposable.empty());
@@ -985,7 +958,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void completeWithoutOnSubscribe() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
         to.onComplete();
@@ -995,7 +967,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
 
             @Override
@@ -1032,7 +1003,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
 
             @Override
@@ -1280,7 +1250,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnly() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
         to.assertValuesOnly();
@@ -1294,7 +1263,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsOnUnexpectedValue() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
         to.assertValuesOnly();
@@ -1314,7 +1282,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenCompleted() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
 
@@ -1330,7 +1297,6 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void assertValuesOnlyThrowsWhenErrored() {
-        @SuppressWarnings("resource")
         TestObserverEx<Integer> to = new TestObserverEx<>();
         to.onSubscribe(Disposable.empty());
 

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -630,6 +630,7 @@ public class ParamValidationCheckerTest {
 
         defaultValues.put(ObservableCombineLatestConfig.class, ObservableCombineLatestConfig.DEFAULT);
         defaultValues.put(ObservableConcatConfig.class, ObservableConcatConfig.DEFAULT);
+        defaultValues.put(ObservableMergeConfig.class, ObservableMergeConfig.DEFAULT);
 
         @SuppressWarnings("rawtypes")
         class MixedConverters implements FlowableConverter, ObservableConverter, SingleConverter,
@@ -722,11 +723,7 @@ public class ParamValidationCheckerTest {
     }
 
     static void addDefaultInstance(Class<?> clazz, Object o, String tag) {
-        List<Object> list = defaultInstances.get(clazz);
-        if (list == null) {
-            list = new ArrayList<>();
-            defaultInstances.put(clazz, list);
-        }
+        List<Object> list = defaultInstances.computeIfAbsent(clazz, k -> new ArrayList<>());
         list.add(o);
         list.add(tag);
     }

--- a/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/ParamValidationCheckerTest.java
@@ -615,8 +615,8 @@ public class ParamValidationCheckerTest {
         VirtualGenerator<Object> vg = _ -> { };
         defaultValues.put(VirtualGenerator.class, vg);
 
-        defaultValues.put(FlatMapConfig.class, new FlatMapConfig());
-        defaultValues.put(GenericConfig.class, new GenericConfig());
+        defaultValues.put(FlatMapConfig.class, FlatMapConfig.DEFAULT);
+        defaultValues.put(GenericConfig.class, GenericConfig.DEFAULT);
         defaultValues.put(CompletableConcatConfig.class, CompletableConcatConfig.DEFAULT);
         defaultValues.put(CompletableMergeConfig.class, CompletableMergeConfig.DEFAULT);
 
@@ -723,7 +723,7 @@ public class ParamValidationCheckerTest {
     }
 
     static void addDefaultInstance(Class<?> clazz, Object o, String tag) {
-        List<Object> list = defaultInstances.computeIfAbsent(clazz, k -> new ArrayList<>());
+        List<Object> list = defaultInstances.computeIfAbsent(clazz, _ -> new ArrayList<>());
         list.add(o);
         list.add(tag);
     }


### PR DESCRIPTION
Reduce API surface by introducing configuration record to various operators.

# Observable

- `merge` + `mergeDelayError` -> `merge` + `ObservableMergeConfig`
- `mergeArray` + `mergeArrayDelayError` -> `mergeArray` + `ObservableMergeConfig`
- removed the 2, 3 and 4 argument `merge` and `mergeDelayError` methods -> use `mergeArray`
- Adjusted other config records to user better java syntax.
- Minor adjustments as I went along with test corrections based on IntelliJ suggestions.

Related: #8173