### PR TITLE
cleanup: convert anonymous inner classes to lambdas in test files

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
@@ -34,31 +34,25 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class BlockingObservableNextTest extends RxJavaTest {
 
     private void fireOnNextInNewThread(final Subject<String> o, final String value) {
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                o.onNext(value);
+        new Thread(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
             }
-        }.start();
+            o.onNext(value);
+        }).start();
     }
 
     private void fireOnErrorInNewThread(final Subject<String> o) {
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                o.onError(new TestException());
+        new Thread(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
             }
-        }.start();
+            o.onError(new TestException());
+        }).start();
     }
 
     static <T> Iterable<T> next(ObservableSource<T> source) {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -285,36 +285,33 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
-                @Override
-                public void subscribe(final Subscriber<? super Integer> subscriber) {
-                    inner.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            subscriber.onNext(42);
-                            latch.countDown();
+            Flowable<Integer> obs = Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
+                inner.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        subscriber.onNext(42);
+                        latch.countDown();
 
-                            // this will recursively schedule this task for execution again
-                            inner.schedule(this);
-                        }
-                    });
+                        // this will recursively schedule this task for execution again
+                        inner.schedule(this);
+                    }
+                });
 
-                    subscriber.onSubscribe(new Subscription() {
+                subscriber.onSubscribe(new Subscription() {
 
-                        @Override
-                        public void cancel() {
-                            inner.dispose();
-                            subscriber.onComplete();
-                            completionLatch.countDown();
-                        }
+                    @Override
+                    public void cancel() {
+                        inner.dispose();
+                        subscriber.onComplete();
+                        completionLatch.countDown();
+                    }
 
-                        @Override
-                        public void request(long n) {
+                    @Override
+                    public void request(long n) {
 
-                        }
-                    });
+                    }
+                });
 
-                }
             });
 
             final AtomicInteger count = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
@@ -277,35 +277,32 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
     @Test
     public final void recursiveSchedulerInObservable() {
-        Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                final Scheduler.Worker inner = getScheduler().createWorker();
+        Flowable<Integer> obs = Flowable.unsafeCreate((Publisher<Integer>) subscriber -> {
+            final Scheduler.Worker inner = getScheduler().createWorker();
 
-                AsyncSubscription as = new AsyncSubscription();
-                subscriber.onSubscribe(as);
-                as.setResource(inner);
+            AsyncSubscription as = new AsyncSubscription();
+            subscriber.onSubscribe(as);
+            as.setResource(inner);
 
-                inner.schedule(new Runnable() {
-                    int i;
+            inner.schedule(new Runnable() {
+                int i;
 
-                    @Override
-                    public void run() {
-                        if (i > 42) {
-                            try {
-                                subscriber.onComplete();
-                            } finally {
-                                inner.dispose();
-                            }
-                            return;
+                @Override
+                public void run() {
+                    if (i > 42) {
+                        try {
+                            subscriber.onComplete();
+                        } finally {
+                            inner.dispose();
                         }
-
-                        subscriber.onNext(i++);
-
-                        inner.schedule(this);
+                        return;
                     }
-                });
-            }
+
+                    subscriber.onNext(i++);
+
+                    inner.schedule(this);
+                }
+            });
         });
 
         final AtomicInteger lastValue = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
@@ -186,21 +186,18 @@ public class TestSchedulerTest extends RxJavaTest {
             final Runnable calledOp = mock(Runnable.class);
 
             Flowable<Object> poller;
-            poller = Flowable.unsafeCreate(new Publisher<Object>() {
-                @Override
-                public void subscribe(final Subscriber<? super Object> aSubscriber) {
-                    final BooleanSubscription bs = new BooleanSubscription();
-                    aSubscriber.onSubscribe(bs);
-                    inner.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!bs.isCancelled()) {
-                                calledOp.run();
-                                inner.schedule(this, 5, TimeUnit.SECONDS);
-                            }
+            poller = Flowable.unsafeCreate((Publisher<Object>) aSubscriber -> {
+                final BooleanSubscription bs = new BooleanSubscription();
+                aSubscriber.onSubscribe(bs);
+                inner.schedule(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (!bs.isCancelled()) {
+                            calledOp.run();
+                            inner.schedule(this, 5, TimeUnit.SECONDS);
                         }
-                    });
-                }
+                    }
+                });
             });
 
             InOrder inOrder = Mockito.inOrder(calledOp);


### PR DESCRIPTION
Converts anonymous inner classes to lambdas in test files where the anonymous class implements a functional interface (single abstract method) and has no instance fields or self-references.

Changes in 4 files:
- `BlockingObservableNextTest`: `new Thread()` subclass to `new Thread(() -> ...)`
- `TestSchedulerTest`: `new Publisher<Object>()` to lambda
- `AbstractSchedulerConcurrencyTests`: `new Publisher<Integer>()` to lambda
- `AbstractSchedulerTests`: `new Publisher<Integer>()` to lambda

Inner classes that use `this` for recursive scheduling or have instance fields are intentionally kept as-is since lambdas cannot replace those.

Ref: #8080
