### PR TITLE
4.x: Cleanup + lambda instead of inner class check

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/core/SchedulerMainTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/SchedulerMainTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
-public class SchedulerTest {
+public class SchedulerMainTest {
     private static final String DRIFT_USE_NANOTIME = "rxjava4.scheduler.use-nanotime";
 
     @After

--- a/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
@@ -56,17 +56,14 @@ public class CompositeDisposableTest extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        cd.dispose();
-                    } catch (final InterruptedException e) {
-                        fail(e.getMessage());
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    cd.dispose();
+                } catch (final InterruptedException e) {
+                    fail(e.getMessage());
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }
@@ -201,17 +198,14 @@ public class CompositeDisposableTest extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        cd.dispose();
-                    } catch (final InterruptedException e) {
-                        fail(e.getMessage());
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    cd.dispose();
+                } catch (final InterruptedException e) {
+                    fail(e.getMessage());
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }

--- a/src/test/java/io/reactivex/rxjava4/disposables/SequentialDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/SequentialDisposableTest.java
@@ -131,19 +131,16 @@ public class SequentialDisposableTest extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        serialDisposable.dispose();
-                    } catch (InterruptedException e) {
-                        fail(e.getMessage());
-                    } finally {
-                        end.countDown();
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    serialDisposable.dispose();
+                } catch (InterruptedException e) {
+                    fail(e.getMessage());
+                } finally {
+                    end.countDown();
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }
@@ -174,19 +171,16 @@ public class SequentialDisposableTest extends RxJavaTest {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);
 
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        serialDisposable.update(subscription);
-                    } catch (InterruptedException e) {
-                        fail(e.getMessage());
-                    } finally {
-                        end.countDown();
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    serialDisposable.update(subscription);
+                } catch (InterruptedException e) {
+                    fail(e.getMessage());
+                } finally {
+                    end.countDown();
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }

--- a/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
@@ -131,19 +131,16 @@ public class SerialDisposableTests extends RxJavaTest {
 
         final List<Thread> threads = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        serialDisposable.dispose();
-                    } catch (InterruptedException e) {
-                        fail(e.getMessage());
-                    } finally {
-                        end.countDown();
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    serialDisposable.dispose();
+                } catch (InterruptedException e) {
+                    fail(e.getMessage());
+                } finally {
+                    end.countDown();
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }
@@ -174,19 +171,16 @@ public class SerialDisposableTests extends RxJavaTest {
             final Disposable subscription = mock(Disposable.class);
             subscriptions.add(subscription);
 
-            final Thread t = new Thread() /* NFI */ {
-                @Override
-                public void run() {
-                    try {
-                        start.await();
-                        serialDisposable.set(subscription);
-                    } catch (InterruptedException e) {
-                        fail(e.getMessage());
-                    } finally {
-                        end.countDown();
-                    }
+            final Thread t = new Thread(() -> {
+                try {
+                    start.await();
+                    serialDisposable.set(subscription);
+                } catch (InterruptedException e) {
+                    fail(e.getMessage());
+                } finally {
+                    end.countDown();
                 }
-            };
+            });
             t.start();
             threads.add(t);
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -34,31 +34,25 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class BlockingFlowableNextTest extends RxJavaTest {
 
     private void fireOnNextInNewThread(final FlowableProcessor<String> o, final String value) {
-        new Thread() /* NFI */ {
-            @Override
-            public void run() {
+        new Thread(() -> {
                 try {
                     Thread.sleep(500);
                 } catch (InterruptedException e) {
                     // ignore
                 }
                 o.onNext(value);
-            }
-        }.start();
+        }).start();
     }
 
     private void fireOnErrorInNewThread(final FlowableProcessor<String> o) {
-        new Thread() /* NFI */ {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                o.onError(new TestException());
+        new Thread(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
             }
-        }.start();
+            o.onError(new TestException());
+        }).start();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -528,7 +528,7 @@ public class FlowableRefCountTest extends RxJavaTest {
     @Test
     public void noOpConnect() {
         final int[] calls = { 0 };
-        Flowable<Integer> f = new ConnectableFlowable<Integer>() {
+        Flowable<Integer> f = new ConnectableFlowable<Integer>() /* NFI */ {
             @Override
             public void connect(Consumer<? super Disposable> connection) {
                 calls[0]++;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -664,7 +664,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(true) {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(true) /* NFI */ {
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override
@@ -995,7 +995,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1257,7 +1257,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -1342,7 +1342,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1364,7 +1364,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1386,7 +1386,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1408,7 +1408,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1517,7 +1517,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Subscriber<?>[] sub = { null };
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 sub[0] = s;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -667,7 +667,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override
@@ -704,7 +704,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test(expected = IllegalStateException.class)
     public void boundedRemoveFirstOneItemOnly() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override
@@ -1014,7 +1014,7 @@ public class FlowableReplayTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1037,7 +1037,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay()
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onError(Throwable t) {
                             super.onError(t);
@@ -1060,7 +1060,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay()
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onComplete() {
                             super.onComplete();
@@ -1322,7 +1322,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -1407,7 +1407,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1429,7 +1429,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1451,7 +1451,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1473,7 +1473,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1582,9 +1582,9 @@ public class FlowableReplayTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Subscriber<?>[] sub = { null };
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
-            protected void subscribeActual(Subscriber<? super Integer> s) {
+            protected void subscribeActual(Subscriber<? super Integer> s) /* NFI */ {
                 sub[0] = s;
             }
         }
@@ -1871,7 +1871,7 @@ public class FlowableReplayTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay(1000).autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1894,7 +1894,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay(1000)
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onError(Throwable t) {
                             super.onError(t);
@@ -1917,7 +1917,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay(1000)
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onComplete() {
                             super.onComplete();
@@ -1969,7 +1969,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
         AtomicLong requested = new AtomicLong();
 
-        ref.get().onSubscribe(new Subscription() {
+        ref.get().onSubscribe(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 BackpressureHelper.add(requested, n);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -45,7 +45,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void iterativeBackoff() {
         Subscriber<String> consumer = TestHelper.mockSubscriber();
 
-        Flowable<String> producer = Flowable.unsafeCreate(new Publisher<String>() {
+        Flowable<String> producer = Flowable.unsafeCreate(new Publisher<String>() /* NFI */ {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();
@@ -338,7 +338,7 @@ public class FlowableRetryTest extends RxJavaTest {
 
         @Override
         public void subscribe(final Subscriber<? super String> subscriber) {
-            subscriber.onSubscribe(new Subscription() {
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
                 final AtomicLong req = new AtomicLong();
                 // 0 = not set, 1 = fast path, 2 = backpressure
                 final AtomicInteger path = new AtomicInteger(0);
@@ -405,7 +405,7 @@ public class FlowableRetryTest extends RxJavaTest {
         final AtomicInteger subsCount = new AtomicInteger(0);
         Publisher<String> onSubscribe = s -> {
             subsCount.incrementAndGet();
-            s.onSubscribe(new Subscription() {
+            s.onSubscribe(new Subscription() /* NFI */ {
 
                 @Override
                 public void request(long n) {
@@ -508,7 +508,7 @@ public class FlowableRetryTest extends RxJavaTest {
         @Override
         public void subscribe(final Subscriber<? super Long> subscriber) {
             final AtomicBoolean terminate = new AtomicBoolean(false);
-            subscriber.onSubscribe(new Subscription() {
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
                 @Override
                 public void request(long n) {
                     // TODO Auto-generated method stub
@@ -524,25 +524,22 @@ public class FlowableRetryTest extends RxJavaTest {
             efforts.getAndIncrement();
             active.getAndIncrement();
             maxActive.set(Math.max(active.get(), maxActive.get()));
-            final Thread thread = new Thread(context) {
-                @Override
-                public void run() {
-                    long nr = 0;
-                    try {
-                        while (!terminate.get()) {
-                            Thread.sleep(emitDelay);
-                            if (nextBeforeFailure.getAndDecrement() > 0) {
-                                subscriber.onNext(nr++);
-                            } else {
-                                active.decrementAndGet();
-                                subscriber.onError(new RuntimeException("expected-failed"));
-                                break;
-                            }
+            final Thread thread = new Thread(() -> {
+                long nr = 0;
+                try {
+                    while (!terminate.get()) {
+                        Thread.sleep(emitDelay);
+                        if (nextBeforeFailure.getAndDecrement() > 0) {
+                            subscriber.onNext(nr++);
+                        } else {
+                            active.decrementAndGet();
+                            subscriber.onError(new RuntimeException("expected-failed"));
+                            break;
                         }
-                    } catch (InterruptedException t) {
                     }
+                } catch (InterruptedException t) {
                 }
-            };
+            }, context);
             thread.start();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -59,7 +59,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryTwice() {
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
@@ -120,7 +120,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryOnSpecificException() {
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
@@ -157,7 +157,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void retryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -108,7 +108,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -142,7 +142,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -176,7 +176,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -302,7 +302,7 @@ public class FlowableScanTest extends RxJavaTest {
             subscriber.onSubscribe(p);
         }).scan(100, Integer::sum);
 
-        f.subscribe(new TestSubscriber<Integer>(1L) {
+        f.subscribe(new TestSubscriber<Integer>(1L) /* NFI */ {
 
             @Override
             public void onNext(Integer integer) {
@@ -511,7 +511,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanTake() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -347,7 +347,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void cancelAndDrainRaceFlowable() {
-        Flowable<Object> neverNever = new Flowable<Object>() {
+        Flowable<Object> neverNever = new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
             }
@@ -376,7 +376,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void sourceOverflowsFlowable() {
-        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() {
+        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -394,7 +394,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void doubleErrorFlowable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() {
+            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -437,7 +437,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void cancelAndDrainRace() {
-        Flowable<Object> neverNever = new Flowable<Object>() {
+        Flowable<Object> neverNever = new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
             }
@@ -465,7 +465,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void sourceOverflows() {
-        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() {
+        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -482,7 +482,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void doubleError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() {
+            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
@@ -82,7 +82,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -118,7 +118,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -153,7 +153,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() {
+                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -314,7 +314,7 @@ public class FlowableSingleTest extends RxJavaTest {
     public void singleWithBackpressureFlowable() {
         Flowable<Integer> flowable = Flowable.just(1, 2).singleElement().toFlowable();
 
-        Subscriber<Integer> subscriber = spy(new DefaultSubscriber<Integer>() {
+        Subscriber<Integer> subscriber = spy(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -38,7 +38,7 @@ public class FlowableSkipWhileTest extends RxJavaTest {
         return v < 5;
     };
 
-    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() {
+    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() /* NFI */ {
         int index;
         @Override
         public boolean test(Integer value) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -165,7 +165,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     @Test
     public void backpressureReschedulesCorrectly() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(10);
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -198,7 +198,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         Flowable.just(1, 2, 3).lift((FlowableOperator<Integer, Integer>) child -> {
             final AtomicLong requested = new AtomicLong();
-            child.onSubscribe(new Subscription() {
+            child.onSubscribe(new Subscription() /* NFI */ {
 
                 @Override
                 public void request(long n) {
@@ -213,7 +213,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
                 }
 
             });
-            Subscriber<Integer> parent = new DefaultSubscriber<Integer>() {
+            Subscriber<Integer> parent = new DefaultSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -52,7 +52,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void switchWithProducer() throws Exception {
         final AtomicBoolean emitted = new AtomicBoolean(false);
-        Flowable<Long> withProducer = Flowable.unsafeCreate(subscriber -> subscriber.onSubscribe(new Subscription() {
+        Flowable<Long> withProducer = Flowable.unsafeCreate(subscriber -> subscriber.onSubscribe(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 if (n > 0 && emitted.compareAndSet(false, true)) {
@@ -84,7 +84,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
         Flowable.<Long>empty()
                 .switchIfEmpty(withProducer)
-                .lift((FlowableOperator<Long, Long>) _ -> new DefaultSubscriber<Long>() {
+                .lift((FlowableOperator<Long, Long>) _ -> new DefaultSubscriber<Long>() /* NFI */ {
                     @Override
                     public void onComplete() {
 
@@ -153,7 +153,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
     @Test
     public void requestsNotLost() throws InterruptedException {
         final TestSubscriber<Long> ts = new TestSubscriber<>(0L);
-        Flowable.unsafeCreate((Publisher<Long>) subscriber -> subscriber.onSubscribe(new Subscription() {
+        Flowable.unsafeCreate((Publisher<Long>) subscriber -> subscriber.onSubscribe(new Subscription() /* NFI */ {
             final AtomicBoolean completed = new AtomicBoolean(false);
             @Override
             public void request(long n) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -370,7 +370,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         publishCompleted(o3, 55);
 
         final TestSubscriberEx<String> testSubscriber = new TestSubscriberEx<>();
-        Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<String>() {
+        Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             private int requested;
 
@@ -431,7 +431,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         .share()
         ;
 
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>() {
+        TestSubscriberEx<String> ts = new TestSubscriberEx<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 super.onNext(t);
@@ -742,7 +742,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void badMainSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -782,7 +782,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1).hide()
-            .switchMap(Functions.justFunction(new Flowable<Integer>() {
+            .switchMap(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -805,7 +805,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void innerCompletesReentrant() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -826,7 +826,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void innerErrorsReentrant() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -873,7 +873,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     @Test
     public void innerOverflow() {
         Flowable.just(1).hide()
-        .switchMap(Functions.justFunction(new Flowable<Integer>() {
+        .switchMap(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
@@ -117,7 +117,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     }
 
     private Function<Integer, Integer> newSlowProcessor() {
-        return new Function<Integer, Integer>() {
+        return new Function<Integer, Integer>() /* NFI */ {
             int c;
 
             @Override
@@ -149,7 +149,8 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest1() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000)
+        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -175,7 +176,8 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest2() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000)
+        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -200,7 +202,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest3() {
         // If `takeLast` does not ignore `request` properly, it will enter an infinite loop.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -226,7 +228,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest4() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -252,7 +254,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void unsubscribeTakesEffectEarlyOnFastPath() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -280,7 +282,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void requestOverflow() {
         final List<Integer> list = new ArrayList<>();
-        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() {
+        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -340,7 +342,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void cancelThenRequest() {
         Flowable.never().takeLast(2)
-        .subscribe(new FlowableSubscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Object t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
@@ -265,7 +265,7 @@ public class FlowableTakeTest extends RxJavaTest {
     public void producerRequestThroughTake() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() {
+        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -284,7 +284,7 @@ public class FlowableTakeTest extends RxJavaTest {
     public void producerRequestThroughTakeIsModified() {
         TestSubscriber<Integer> ts = new TestSubscriber<>(3);
         final AtomicLong requested = new AtomicLong();
-        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() {
+        Flowable.unsafeCreate((Publisher<Integer>) s -> s.onSubscribe(new Subscription() /* NFI */ {
 
             @Override
             public void request(long n) {
@@ -348,7 +348,7 @@ public class FlowableTakeTest extends RxJavaTest {
     public void takeFinalValueThrows() {
         Flowable<Integer> source = Flowable.just(1).take(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
@@ -159,7 +159,7 @@ public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Actio
     public void cancelIgnored() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     BooleanSubscription bs = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntilPredicateTest.java
@@ -153,7 +153,7 @@ public class FlowableTakeUntilPredicateTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -76,7 +76,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhile2() {
         Flowable<String> w = Flowable.just("one", "two", "three");
-        Flowable<String> take = w.takeWhile(new Predicate<String>() {
+        Flowable<String> take = w.takeWhile(new Predicate<String>() /* NFI */ {
             int index;
 
             @Override
@@ -144,7 +144,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> take = Flowable.unsafeCreate(w)
-                .takeWhile(new Predicate<String>() {
+                .takeWhile(new Predicate<String>() /* NFI */ {
             int index;
 
             @Override
@@ -257,7 +257,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTest.java
@@ -216,7 +216,7 @@ public class FlowableThrottleFirstTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -251,7 +251,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
         TestScheduler sch = new TestScheduler();
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTests.java
@@ -344,7 +344,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -370,7 +370,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
     public void badSourceOther() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -363,7 +363,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriberEx<Integer> ts = pp
-            .timeout(Functions.justFunction(new Flowable<Integer>() {
+            .timeout(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -392,7 +392,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriberEx<Integer> ts = pp
-            .timeout(Functions.justFunction(new Flowable<Integer>() {
+            .timeout(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -426,7 +426,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
     public void badSourceTimeout() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -495,7 +495,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() {
+                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -539,7 +539,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() {
+                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -584,7 +584,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() {
+                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -629,7 +629,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() {
+                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -672,7 +672,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() {
+                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -741,7 +741,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorProcessor.createDefault(1)
-            .timeout(Functions.justFunction(new Flowable<Integer>() {
+            .timeout(Functions.justFunction(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     BooleanSubscription bs1 = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
@@ -232,7 +232,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void onceObserverThrows() {
         Flowable<Long> source = Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler);
 
-        source.safeSubscribe(new DefaultSubscriber<Long>() {
+        source.safeSubscribe(new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {
@@ -263,7 +263,7 @@ public class FlowableTimerTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(subscriber);
 
-        source.safeSubscribe(new DefaultSubscriber<Long>() {
+        source.safeSubscribe(new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
@@ -112,7 +112,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void cancellationDuringFutureGet() throws Exception {
-        Future<Object> future = new Future<Object>() {
+        Future<Object> future = new Future<Object>() /* NFI */ {
             private AtomicBoolean isCancelled = new AtomicBoolean(false);
             private AtomicBoolean isDone = new AtomicBoolean(false);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
@@ -133,7 +133,7 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
             private static final long serialVersionUID = -3296811238780863394L;
 
@@ -272,7 +272,7 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
             private static final long serialVersionUID = -3296811238780863394L;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
@@ -77,7 +77,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
             private static final long serialVersionUID = -2084477070717362859L;
 
@@ -268,7 +268,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
             private static final long serialVersionUID = -2084477070717362859L;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOnTest.java
@@ -231,7 +231,7 @@ public class FlowableUnsubscribeOnTest extends RxJavaTest {
     public void signalAfterDispose() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
@@ -98,7 +98,7 @@ public class FlowableUsingTest extends RxJavaTest {
 
     private void performTestUsingWithSubscribingTwice(boolean disposeEagerly) {
         // When subscribe is called, a new resource should be created.
-        Supplier<Resource> resourceFactory = () -> new Resource() {
+        Supplier<Resource> resourceFactory = () -> new Resource() /* NFI */ {
 
             boolean first = true;
 
@@ -286,7 +286,7 @@ public class FlowableUsingTest extends RxJavaTest {
     }
 
     private static Supplier<Resource> createResourceFactory(final List<String> events) {
-        return () -> new Resource() {
+        return () -> new Resource() /* NFI */ {
 
             @Override
             public String getTextFromWeb() {
@@ -437,7 +437,7 @@ public class FlowableUsingTest extends RxJavaTest {
     public void eagerDisposedOnComplete() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
+        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -452,7 +452,7 @@ public class FlowableUsingTest extends RxJavaTest {
     public void eagerDisposedOnError() {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() {
+        Flowable.using(Functions.justSupplier(1), Functions.justFunction(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -46,7 +46,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -103,7 +103,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -159,7 +159,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -209,7 +209,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() {
+        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -279,7 +279,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     public void reentrant() {
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -377,7 +377,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             TestSubscriberEx<Flowable<Object>> ts = Flowable.error(new TestException("main"))
-            .window(new Flowable<Object>() {
+            .window(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -413,14 +413,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
                 final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
                 final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-                TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() {
+                TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> subscriber) {
                         subscriber.onSubscribe(new BooleanSubscription());
                         refMain.set(subscriber);
                     }
                 }
-                .window(new Flowable<Object>() {
+                .window(new Flowable<Object>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> subscriber) {
                         subscriber.onSubscribe(new BooleanSubscription());
@@ -453,14 +453,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
+            TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() {
+            .window(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -486,14 +486,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
         final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-        TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() {
+        TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
                 refMain.set(subscriber);
             }
         }
-        .window(new Flowable<Object>() {
+        .window(new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -518,18 +518,18 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() {
+            .window(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     final AtomicInteger counter = new AtomicInteger();
-                    subscriber.onSubscribe(new Subscription() {
+                    subscriber.onSubscribe(new Subscription() /* NFI */ {
 
                         @Override
                         public void cancel() {
@@ -568,18 +568,18 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() {
+            .window(new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     final AtomicInteger counter = new AtomicInteger();
-                    subscriber.onSubscribe(new Subscription() {
+                    subscriber.onSubscribe(new Subscription() /* NFI */ {
 
                         @Override
                         public void cancel() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -170,7 +170,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(new DefaultSubscriber<Flowable<Integer>>() {
+        source.subscribe(new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onStart() {
                 request(1);
@@ -178,7 +178,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
             @Override
             public void onNext(Flowable<Integer> t) {
-                t.subscribe(new DefaultSubscriber<Integer>() {
+                t.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
                     @Override
                     public void onNext(Integer t) {
                         list.add(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -99,7 +99,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     private Consumer<Flowable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
-        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<String>() {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<String>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -191,7 +191,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     public void reentrant() {
         final FlowableProcessor<Integer> pp = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -298,7 +298,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorProcessor.createDefault(1)
-            .window(BehaviorProcessor.createDefault(1), _ -> new Flowable<Integer>() {
+            .window(BehaviorProcessor.createDefault(1), _ -> new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -122,7 +122,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     private <T> Consumer<Flowable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
-        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<T>() {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<T>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -549,7 +549,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -577,7 +577,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -605,7 +605,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -633,7 +633,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -817,7 +817,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
         TestSubscriber<Flowable<Integer>> ts = pp.window(1, TimeUnit.MINUTES, 1)
-        .subscribeWith(new TestSubscriber<Flowable<Integer>>(2) {
+        .subscribeWith(new TestSubscriber<Flowable<Integer>>(2) /* NFI */ {
             int calls;
             @Override
             public void onNext(Flowable<Integer> t) {
@@ -861,7 +861,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
@@ -902,7 +902,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
@@ -942,7 +942,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
@@ -983,7 +983,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
@@ -1023,7 +1023,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
@@ -1064,7 +1064,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() {
+        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Flowable<Integer> v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -589,7 +589,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
     public void manyErrors() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -613,7 +613,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .withLatestFrom(new Flowable<Integer>() {
+            .withLatestFrom(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
@@ -227,7 +227,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = () -> new Iterator<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
             int count;
 
             @Override
@@ -270,7 +270,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = () -> new Iterator<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -346,7 +346,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -679,7 +679,7 @@ public class FlowableZipTest extends RxJavaTest {
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable.zip(Flowable.just(1),
-                Flowable.just(1), Integer::sum).subscribe(new DefaultSubscriber<Integer>() {
+                Flowable.just(1), Integer::sum).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -746,7 +746,7 @@ public class FlowableZipTest extends RxJavaTest {
                 .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteFlowable), (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
-        os.subscribe(new DefaultSubscriber<String>() {
+        os.subscribe(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -953,7 +953,7 @@ public class FlowableZipTest extends RxJavaTest {
     }
 
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() {
+        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -1029,7 +1029,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void unboundedDownstreamOverrequesting() {
         Flowable<Integer> source = Flowable.range(1, 2).zipWith(Flowable.range(1, 2), (t1, t2) -> t1 + 10 * t2);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1350,7 +1350,7 @@ public class FlowableZipTest extends RxJavaTest {
 
             @SuppressWarnings("rawtypes")
             final Subscriber[] sub = { null };
-            TestSubscriberEx<Object> ts = Flowable.zip(pp, new Flowable<Object>() {
+            TestSubscriberEx<Object> ts = Flowable.zip(pp, new Flowable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     sub[0] = s;
@@ -1517,7 +1517,7 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void cancelOnBackpressureBoundary() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
@@ -106,7 +106,7 @@ public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void disposeNoFurtherSignals() {
-        TestObserver<Integer> to = Maybe.ambArray(new Maybe<Integer>() {
+        TestObserver<Integer> to = Maybe.ambArray(new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(
                     MaybeObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
@@ -245,7 +245,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
         final Disposable[] dout = { null };
 
-        source.subscribe(new MaybeObserver<Integer>() {
+        source.subscribe(new MaybeObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -114,7 +114,7 @@ public class MaybeConcatArrayTest extends RxJavaTest {
             final MaybeObserver<?>[] o = { null };
             Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1),
                     Maybe.error(new IOException()),
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
@@ -71,7 +71,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -110,7 +110,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -149,7 +149,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -184,7 +184,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -219,7 +219,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -254,7 +254,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() {
+        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -220,7 +220,7 @@ public class MaybeDelayOtherTest extends RxJavaTest {
 
     @Test
     public void otherPublisherNextSlipsThrough() {
-        Maybe.just(1).delay(new Flowable<Integer>() {
+        Maybe.just(1).delay(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -115,7 +115,7 @@ public class MaybeDelaySubscriptionTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable<Integer> f = new Flowable<Integer>() {
+            Flowable<Integer> f = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
@@ -61,7 +61,7 @@ public class MaybeDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Object> to = new Maybe<Object>() {
+        TestObserver<Object> to = new Maybe<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Object> observer) {
                 observer.onSubscribe(wr.get());
@@ -87,7 +87,7 @@ public class MaybeDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
@@ -113,7 +113,7 @@ public class MaybeDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
@@ -139,7 +139,7 @@ public class MaybeDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -34,7 +34,7 @@ public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
     final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnEventTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnEventTest.java
@@ -49,7 +49,7 @@ public class MaybeDoOnEventTest extends RxJavaTest {
         try {
             final Disposable bs = Disposable.empty();
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(bs);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnLifecycleTest.java
@@ -84,7 +84,7 @@ public class MaybeDoOnLifecycleTest extends RxJavaTest {
 
             Disposable bs = Disposable.empty();
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(bs);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -231,7 +231,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.just(1)
-        .flattenAsFlowable(_ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() {
+        .flattenAsFlowable(_ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             QueueSubscription<Integer> qs;
             @SuppressWarnings("unchecked")
             @Override
@@ -364,7 +364,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {
@@ -398,7 +398,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -215,7 +215,8 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.just(1)
-        .flattenAsObservable(_ -> Arrays.asList(1, 2, 3)).subscribe(new Observer<Integer>() {
+        .flattenAsObservable(_ -> Arrays.asList(1, 2, 3))
+        .subscribe(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -61,7 +61,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(2))
-        .subscribe(new FlowableSubscriber<Integer>() {
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             QueueSubscription<Integer> qs;
             @Override
             public void onSubscribe(Subscription s) {
@@ -159,7 +159,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
 
     @Test
     public void mergeBadSource() {
-        Maybe.mergeArray(new Maybe<Integer>() {
+        Maybe.mergeArray(new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -176,7 +176,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @Test
     public void smallOffer2Throws() {
         Maybe.mergeArray(Maybe.never(), Maybe.never())
-        .subscribe(new FlowableSubscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @SuppressWarnings("rawtypes")
             @Override
@@ -211,7 +211,7 @@ public class MaybeMergeArrayTest extends RxJavaTest {
         Maybe<Integer>[] a = new Maybe[1024];
         Arrays.fill(a, Maybe.never());
         Maybe.mergeArray(a)
-        .subscribe(new FlowableSubscriber<Object>() {
+        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
             @SuppressWarnings("rawtypes")
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
@@ -48,7 +48,7 @@ public class MaybePeekTest extends RxJavaTest {
         final Throwable[] err = { null };
 
         try {
-            TestObserverEx<Integer> to = new Maybe<Integer>() {
+            TestObserverEx<Integer> to = new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -74,7 +74,7 @@ public class MaybePeekTest extends RxJavaTest {
     public void doubleComplete() {
         final int[] compl = { 0 };
 
-        TestObserver<Integer> to = new Maybe<Integer>() {
+        TestObserver<Integer> to = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
@@ -91,7 +91,7 @@ public class MaybeSafeSubscribeTest {
 
             Disposable d = Disposable.empty();
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(d);
@@ -121,7 +121,7 @@ public class MaybeSafeSubscribeTest {
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onSuccess(any());
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -146,7 +146,7 @@ public class MaybeSafeSubscribeTest {
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -176,7 +176,7 @@ public class MaybeSafeSubscribeTest {
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onComplete();
 
-            new Maybe<Integer>() {
+            new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
@@ -212,7 +212,7 @@ public class MaybeTimeoutPublisherTest extends RxJavaTest {
     public void mainSuccessAfterOtherSignal() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        new Maybe<Integer>() {
+        new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
@@ -329,7 +329,7 @@ public class MaybeTimeoutTest extends RxJavaTest {
     public void mainSuccessAfterOtherSignal() {
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        new Maybe<Integer>() {
+        new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -100,7 +100,7 @@ public class MaybeUnsubscribeOnTest extends RxJavaTest {
 
             final Disposable[] ds = { null };
             pp.singleElement().unsubscribeOn(Schedulers.computation())
-            .subscribe(new MaybeObserver<Integer>() {
+            .subscribe(new MaybeObserver<Integer>() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     ds[0] = d;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
@@ -150,13 +150,13 @@ public class MaybeZipArrayTest extends RxJavaTest {
         AtomicReference<MaybeObserver<? super Integer>> ref1 = new AtomicReference<>();
         AtomicReference<MaybeObserver<? super Integer>> ref2 = new AtomicReference<>();
 
-        Maybe<Integer> m1 = new Maybe<Integer>() {
+        Maybe<Integer> m1 = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 ref1.set(observer);
             }
         };
-        Maybe<Integer> m2 = new Maybe<Integer>() {
+        Maybe<Integer> m2 = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 ref2.set(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -249,7 +249,7 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
     public void queueOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -203,7 +203,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
     public void queueOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -254,7 +254,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapMaybe(
-                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
                             @Override
                             protected void subscribeActual(
                                     MaybeObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -135,7 +135,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
     public void queueOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -186,7 +186,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapSingle(
-                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
                             @Override
                             protected void subscribeActual(
                                     SingleObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletableTest.java
@@ -247,7 +247,7 @@ public class FlowableSwitchMapCompletableTest extends RxJavaTest {
     public void innerErrorThenMainError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -306,7 +306,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
     public void mainErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -330,7 +330,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
         try {
             final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<>();
 
-            TestSubscriberEx<Integer> ts = new Flowable<Integer>() {
+            TestSubscriberEx<Integer> ts = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -338,7 +338,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         MaybeObserver<? super Integer> observer) {
@@ -488,7 +488,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void requestMoreOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -268,7 +268,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
     public void mainErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Integer>() {
+            new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -292,7 +292,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
         try {
             final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<>();
 
-            TestSubscriberEx<Integer> ts = new Flowable<Integer>() {
+            TestSubscriberEx<Integer> ts = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -300,7 +300,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         SingleObserver<? super Integer> observer) {
@@ -449,7 +449,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void requestMoreOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -192,7 +192,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     public void mainErrorAfterInnerError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -221,7 +221,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapMaybe(
-                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
                             @Override
                             protected void subscribeActual(
                                     MaybeObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -124,7 +124,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     public void mainErrorAfterInnerError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -153,7 +153,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapSingle(
-                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
                             @Override
                             protected void subscribeActual(
                                     SingleObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -246,7 +246,7 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
     public void innerErrorThenMainError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -286,7 +286,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
     public void mainErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -310,7 +310,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
         try {
             final AtomicReference<MaybeObserver<? super Integer>> moRef = new AtomicReference<>();
 
-            TestObserverEx<Integer> to = new Observable<Integer>() {
+            TestObserverEx<Integer> to = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -318,7 +318,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
                     observer.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() {
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         MaybeObserver<? super Integer> observer) {
@@ -478,7 +478,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
     public void drainReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -265,7 +265,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
     public void mainErrorAfterTermination() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -289,7 +289,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
         try {
             final AtomicReference<SingleObserver<? super Integer>> moRef = new AtomicReference<>();
 
-            TestObserverEx<Integer> to = new Observable<Integer>() {
+            TestObserverEx<Integer> to = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -297,7 +297,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
                     observer.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         SingleObserver<? super Integer> observer) {
@@ -456,7 +456,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
     public void drainReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
@@ -34,31 +34,25 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class BlockingObservableNextTest extends RxJavaTest {
 
     private void fireOnNextInNewThread(final Subject<String> o, final String value) {
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                o.onNext(value);
+        new Thread(() ->  {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
             }
-        }.start();
+            o.onNext(value);
+        }).start();
     }
 
     private void fireOnErrorInNewThread(final Subject<String> o) {
-        new Thread() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(500);
-                } catch (InterruptedException e) {
-                    // ignore
-                }
-                o.onError(new TestException());
+        new Thread(() -> {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
             }
-        }.start();
+            o.onError(new TestException());
+        }).start();
     }
 
     static <T> Iterable<T> next(ObservableSource<T> source) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAllTest.java
@@ -232,7 +232,7 @@ public class ObservableAllTest extends RxJavaTest {
     public void predicateThrowsObservable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -260,7 +260,7 @@ public class ObservableAllTest extends RxJavaTest {
     public void predicateThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAnyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAnyTest.java
@@ -408,7 +408,7 @@ public class ObservableAnyTest extends RxJavaTest {
     public void predicateThrowsSuppressOthers() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -436,7 +436,7 @@ public class ObservableAnyTest extends RxJavaTest {
     public void badSourceSingle() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
@@ -103,7 +103,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
         Observable.range(1, 5)
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Observer<Object>() {
+        .blockingSubscribe(new Observer<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -138,7 +138,7 @@ public class ObservableBlockingTest extends RxJavaTest {
 
         Observable.range(1, 5).concatWith(Observable.<Integer>error(ex))
         .subscribeOn(Schedulers.computation())
-        .blockingSubscribe(new Observer<Object>() {
+        .blockingSubscribe(new Observer<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -222,7 +222,7 @@ public class ObservableBlockingTest extends RxJavaTest {
             obsRef.get().onNext(1);
         }, 200, TimeUnit.MILLISECONDS);
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -673,7 +673,7 @@ public class ObservableBufferTest extends RxJavaTest {
         final Observer<Object> o = TestHelper.mockObserver();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        DisposableObserver<Object> observer = new DisposableObserver<Object>() {
+        DisposableObserver<Object> observer = new DisposableObserver<Object>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);
@@ -770,7 +770,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows4() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -789,7 +789,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows5() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -808,7 +808,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierThrows6() {
         Observable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -827,7 +827,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), Integer.MAX_VALUE, new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -846,7 +846,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull2() {
         Observable.<Integer>never()
-        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, Schedulers.single(), 10, new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -865,7 +865,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void supplierReturnsNull3() {
         Observable.<Integer>never()
-        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() {
+        .buffer(2, 1, TimeUnit.MILLISECONDS, Schedulers.single(), new Supplier<Collection<Integer>>() /* NFI */ {
             int count;
             @Override
             public Collection<Integer> get() throws Exception {
@@ -914,7 +914,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferSupplierCrash2() {
         Observable.range(1, 2)
-        .buffer(1, new Supplier<List<Integer>>() {
+        .buffer(1, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -931,7 +931,7 @@ public class ObservableBufferTest extends RxJavaTest {
     @Test
     public void bufferSkipSupplierCrash2() {
         Observable.range(1, 2)
-        .buffer(2, 1, new Supplier<List<Integer>>() {
+        .buffer(2, 1, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1022,7 +1022,7 @@ public class ObservableBufferTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<List<Integer>> to = ps
-        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Supplier<List<Integer>>() {
+        .buffer(1, TimeUnit.MILLISECONDS, scheduler, 1, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1200,7 +1200,7 @@ public class ObservableBufferTest extends RxJavaTest {
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Object>() {
+            new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     Disposable bs1 = Disposable.empty();
@@ -1317,7 +1317,7 @@ public class ObservableBufferTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.never()
-            .buffer(new Observable<Object>() {
+            .buffer(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
 
@@ -1361,7 +1361,7 @@ public class ObservableBufferTest extends RxJavaTest {
         try {
             Observable.never()
             .buffer(Observable.just(1).concatWith(Observable.<Integer>never()),
-                    Functions.justFunction(new Observable<Object>() {
+                    Functions.justFunction(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
 
@@ -1411,7 +1411,7 @@ public class ObservableBufferTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         PublishSubject<Integer> b = PublishSubject.create();
 
-        TestObserver<List<Integer>> to = ps.buffer(b, new Supplier<List<Integer>>() {
+        TestObserver<List<Integer>> to = ps.buffer(b, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
             @Override
             public List<Integer> get() throws Exception {
@@ -1429,7 +1429,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryBadSource() {
-        Observable<Integer> ps = new Observable<Integer>() {
+        Observable<Integer> ps = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -1440,7 +1440,7 @@ public class ObservableBufferTest extends RxJavaTest {
         };
 
         final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
-        Observable<Integer> b = new Observable<Integer>() {
+        Observable<Integer> b = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -1540,7 +1540,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         @SuppressWarnings("resource")
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
-                to, new Supplier<List<Integer>>() {
+                to, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -100,7 +100,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissionsObservable() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 
@@ -199,7 +199,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissions() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() {
+        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -449,7 +449,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observer<List<Object>> observer = new DefaultObserver<List<Object>>() {
+            Observer<List<Object>> observer = new DefaultObserver<List<Object>>() /* NFI */ {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -943,7 +943,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1015,7 +1015,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
                 TestObserverEx<Object[]> to = new TestObserverEx<>();
                 AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
-                Observable<Object> o = new Observable<Object>() {
+                Observable<Object> o = new Observable<Object>() /* NFI */ {
                     @Override
                     public void subscribeActual(Observer<? super Object> observer) {
                         ref.set(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -83,7 +83,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -160,7 +160,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         Observable.just(1)
         .hide()
         .concatMapCompletable(completableComplete())
-        .subscribe(new CompletableObserver() {
+        .subscribe(new CompletableObserver() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -186,7 +186,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         Observable.just(1)
         .hide()
         .concatMapCompletable(completableError())
-        .subscribe(new CompletableObserver() {
+        .subscribe(new CompletableObserver() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -585,7 +585,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final UnicastSubject<Integer> us = UnicastSubject.create();
         us.onNext(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -235,7 +235,8 @@ public class ObservableConcatMapSchedulerTest {
         int n = 5000;
         final AtomicInteger counter = new AtomicInteger();
 
-        Observable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultObserver<Integer>() {
+        Observable.range(1, n)
+        .concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -470,7 +471,7 @@ public class ObservableConcatMapSchedulerTest {
     public void immediateInnerNextOuterError() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -494,7 +495,7 @@ public class ObservableConcatMapSchedulerTest {
     public void immediateInnerNextOuterError2() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -539,7 +540,8 @@ public class ObservableConcatMapSchedulerTest {
     public void badInnerSource() {
         @SuppressWarnings("rawtypes")
         final Observer[] ts0 = { null };
-        TestObserverEx<Integer> to = Observable.just(1).hide().concatMap(Functions.justFunction(new Observable<Integer>() {
+        TestObserverEx<Integer> to = Observable.just(1).hide()
+                .concatMap(Functions.justFunction(new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> o) {
                 ts0[0] = o;
@@ -565,7 +567,8 @@ public class ObservableConcatMapSchedulerTest {
     public void badInnerSourceDelayError() {
         @SuppressWarnings("rawtypes")
         final Observer[] ts0 = { null };
-        TestObserverEx<Integer> to = Observable.just(1).hide().concatMapDelayError(Functions.justFunction(new Observable<Integer>() {
+        TestObserverEx<Integer> to = Observable.just(1).hide()
+                .concatMapDelayError(Functions.justFunction(new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> o) {
                 ts0[0] = o;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
@@ -105,7 +105,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -131,7 +131,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void badSourceDelayError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -249,7 +249,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         try {
             Observable.just(1).hide()
-            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<Integer>() {
+            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     o[0] = observer;
@@ -275,7 +275,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         Observable.fromArray(Observable.just(1), Observable.just(2))
         .hide()
         .concatMap(Functions.<Observable<Integer>>identity())
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -305,7 +305,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         Observable.fromArray(Observable.just(1), Observable.<Integer>error(new TestException()))
         .hide()
         .concatMap(Functions.<Observable<Integer>>identity())
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -335,7 +335,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
-            .subscribeWith(new TestObserver<Integer>() {
+            .subscribeWith(new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer t) {
                     super.onNext(t);
@@ -365,7 +365,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
-        .subscribeWith(new TestObserver<Integer>() {
+        .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
@@ -453,7 +453,7 @@ public class ObservableConcatTest extends RxJavaTest {
 
     static class TestObservable<T> implements ObservableSource<T> {
 
-        private final Disposable upstream = new Disposable() {
+        private final Disposable upstream = new Disposable() /* NFI */ {
             @Override
             public void dispose() {
                     subscribed = false;
@@ -663,7 +663,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, n)
-        .concatMap(func).subscribe(new DefaultObserver<Integer>() {
+        .concatMap(func).subscribe(new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -975,7 +975,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final Disposable[] disposable = { null };
 
         Observable.concatArray(Observable.just(1), Observable.just(2))
-        .subscribe(new Observer<>() {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1005,7 +1005,7 @@ public class ObservableConcatTest extends RxJavaTest {
         Observable.concatArray(
                 ObservableConcatConfig.DELAY_ERROR,
                 Observable.just(1), Observable.just(2))
-        .subscribe(new Observer<>() {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1033,7 +1033,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final Disposable[] disposable = { null };
 
         Observable.concatArray(Observable.just(1), Observable.<Integer>error(new TestException()))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1063,7 +1063,7 @@ public class ObservableConcatTest extends RxJavaTest {
         Observable.concatArray(
                 ObservableConcatConfig.DELAY_ERROR,
                 Observable.just(1), Observable.<Integer>error(new TestException()))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletableTest.java
@@ -87,7 +87,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();
@@ -108,7 +108,7 @@ public class ObservableConcatWithCompletableTest extends RxJavaTest {
 
     @Test
     public void consumerDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybeTest.java
@@ -98,7 +98,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void consumerDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();
@@ -119,7 +119,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();
@@ -140,7 +140,7 @@ public class ObservableConcatWithMaybeTest extends RxJavaTest {
 
     @Test
     public void badSource2() {
-        Flowable.empty().concatWith(new Maybe<Integer>() {
+        Flowable.empty().concatWith(new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithSingleTest.java
@@ -87,7 +87,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void consumerDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();
@@ -108,7 +108,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();
@@ -129,7 +129,7 @@ public class ObservableConcatWithSingleTest extends RxJavaTest {
 
     @Test
     public void badSource2() {
-        Flowable.empty().concatWith(new Single<Integer>() {
+        Flowable.empty().concatWith(new Single<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 Disposable bs1 = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
@@ -279,7 +279,7 @@ public class ObservableCreateTest extends RxJavaTest {
             }
             assertTrue(d.isDisposed());
         })
-        .subscribe(new Observer<Object>() {
+        .subscribe(new Observer<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }
@@ -312,7 +312,7 @@ public class ObservableCreateTest extends RxJavaTest {
             }
             assertTrue(d.isDisposed());
         })
-        .subscribe(new Observer<Object>() {
+        .subscribe(new Observer<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
@@ -347,7 +347,7 @@ public class ObservableDebounceTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -405,7 +405,7 @@ public class ObservableDebounceTest extends RxJavaTest {
     public void disposedInOnComplete() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -427,7 +427,7 @@ public class ObservableDebounceTest extends RxJavaTest {
             if (o != 1) {
                 return Observable.never();
             }
-            return new Observable<Integer>() {
+            return new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -452,7 +452,7 @@ public class ObservableDebounceTest extends RxJavaTest {
     public void timedDisposedIgnoredBySource() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(
                     Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
@@ -551,7 +551,7 @@ public class ObservableDelayTest extends RxJavaTest {
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -580,7 +580,7 @@ public class ObservableDelayTest extends RxJavaTest {
                 .delaySubscription(100, TimeUnit.MILLISECONDS)
                 .delay(100, TimeUnit.MILLISECONDS)
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -608,7 +608,7 @@ public class ObservableDelayTest extends RxJavaTest {
         Observable.range(1, Flowable.bufferSize() * 2)
                 .delay((Function<Integer, Observable<Long>>) _ -> Observable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -637,7 +637,7 @@ public class ObservableDelayTest extends RxJavaTest {
                 .delay(Observable.timer(500, TimeUnit.MILLISECONDS)
                 , (Function<Integer, Observable<Long>>) _ -> Observable.timer(100, TimeUnit.MILLISECONDS))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
 
                     int c;
 
@@ -794,7 +794,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable.empty()
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableObserver<Object>() {
+        .subscribe(new DisposableObserver<Object>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }
@@ -823,7 +823,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable.error(new TestException())
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableObserver<Object>() {
+        .subscribe(new DisposableObserver<Object>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
@@ -187,7 +187,7 @@ public class ObservableDematerializeTest extends RxJavaTest {
     public void eventsAfterDematerializedTerminal() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Notification<Object>>() {
+            new Observable<Notification<Object>>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Notification<Object>> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -211,7 +211,7 @@ public class ObservableDematerializeTest extends RxJavaTest {
     @Test
     @SuppressWarnings("unchecked")
     public void nonNotificationInstanceAfterDispose() {
-        new Observable<Object>() {
+        new Observable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
@@ -143,7 +143,7 @@ public class ObservableDistinctTest extends RxJavaTest {
     public void fusedClear() {
         Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 QueueDisposable<?> qd = (QueueDisposable<?>)d;
@@ -192,7 +192,7 @@ public class ObservableDistinctTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -35,7 +35,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     final Consumer<Integer> afterNext = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
@@ -333,7 +333,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void clearIsEmpty() {
         Observable.range(1, 5)
         .doFinally(this)
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -380,7 +380,7 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         Observable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
@@ -142,37 +142,6 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         assertEquals(expectedCount, count.get());
     }
 
-    // FIXME crashing ObservableSource can't propagate to an Observer
-//    @Test
-//    public void testFatalError() {
-//        try {
-//            Observable.just(1, 2, 3)
-//                    .flatMap(new Function<Integer, Observable<?>>() {
-//                        @Override
-//                        public Observable<?> apply(Integer integer) {
-//                            return Observable.create(new ObservableSource<Object>() {
-//                                @Override
-//                                public void accept(Observer<Object> o) {
-//                                    throw new NullPointerException("Test NPE");
-//                                }
-//                            });
-//                        }
-//                    })
-//                    .doOnNext(new Consumer<Object>() {
-//                        @Override
-//                        public void accept(Object o) {
-//                            System.out.println("Won't come here");
-//                        }
-//                    })
-//                    .subscribe();
-//            fail("should have thrown an exception");
-//        } catch (OnErrorNotImplementedException e) {
-//            assertTrue(e.getCause() instanceof NullPointerException);
-//            assertEquals(e.getCause().getMessage(), "Test NPE");
-//            System.out.println("Received exception: " + e);
-//        }
-//    }
-
     @Test
     public void onErrorThrows() {
         TestObserverEx<Object> to = new TestObserverEx<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnSubscribeTest.java
@@ -82,7 +82,7 @@ public class ObservableDoOnSubscribeTest extends RxJavaTest {
         try {
             final Disposable bs = Disposable.empty();
 
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(bs);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableElementAtTest.java
@@ -214,7 +214,7 @@ public class ObservableElementAtTest extends RxJavaTest {
     public void badSourceObservable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -240,7 +240,7 @@ public class ObservableElementAtTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -265,7 +265,7 @@ public class ObservableElementAtTest extends RxJavaTest {
     public void badSource2() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -271,7 +271,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void innerObserver() {
         Observable.range(1, 3)
-        .flatMapCompletable(_ -> new Completable() {
+        .flatMapCompletable(_ -> new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -296,7 +296,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         Observable.range(1, 10)
         .flatMapCompletable(_ -> Completable.complete())
         .toObservable()
-        .subscribe(new Observer<Object>() {
+        .subscribe(new Observer<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 QueueDisposable<?> qd = (QueueDisposable<?>)d;
@@ -326,7 +326,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void innerObserverObservable() {
         Observable.range(1, 3)
-        .flatMapCompletable(_ -> new Completable() {
+        .flatMapCompletable(_ -> new Completable() /* NFI */ {
             @Override
             protected void subscribeActual(CompletableObserver observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -245,7 +245,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -268,7 +268,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1)
-            .flatMapMaybe(Functions.justFunction(new Maybe<Integer>() {
+            .flatMapMaybe(Functions.justFunction(new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -290,7 +290,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -317,7 +317,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps2 = PublishSubject.create();
         final PublishSubject<Integer> ps3 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -344,7 +344,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() {
+        Observable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -207,7 +207,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -230,7 +230,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1)
-            .flatMapSingle(Functions.justFunction(new Single<Integer>() {
+            .flatMapSingle(Functions.justFunction(new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -252,7 +252,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -277,7 +277,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() {
+        Observable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -366,7 +366,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
             }
             TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.range(0, 1000)
-            .flatMap(new Function<Integer, Observable<Integer>>() {
+            .flatMap(new Function<Integer, Observable<Integer>>() /* NFI */ {
                 final Random rnd = new Random();
                 @Override
                 public Observable<Integer> apply(Integer t) {
@@ -490,7 +490,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarReentrant() {
         final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -513,7 +513,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarReentrant2() {
         final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -666,7 +666,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
-        .flatMap((Function<Integer, Observable<Integer>>) _ -> Observable.<Integer>fromIterable(() -> new Iterator<Integer>() {
+        .flatMap((Function<Integer, Observable<Integer>>) _ ->
+        Observable.<Integer>fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -695,7 +696,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
-            .subscribeWith(new TestObserver<Integer>() {
+            .subscribeWith(new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer t) {
                     super.onNext(t);
@@ -725,7 +726,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
-        .subscribeWith(new TestObserver<Integer>() {
+        .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -858,7 +859,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void signalsAfterMapperCrash() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
@@ -44,7 +44,7 @@ public class ObservableFlattenIterableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
-        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
@@ -57,7 +57,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
      */
     @Test
     public void rawIterable() {
-        Iterable<String> it = () -> new Iterator<String>() {
+        Iterable<String> it = () -> new Iterator<String>() /* NFI */ {
 
             int i;
 
@@ -134,7 +134,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredWithBackpressure() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
 
             int count = 1;
 
@@ -165,7 +165,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredFastPath() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() {
+        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -189,7 +189,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
             }
 
         };
-        Observable.fromIterable(iterable).subscribe(new DefaultObserver<Integer>() {
+        Observable.fromIterable(iterable).subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -240,7 +240,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     public void hasNextCancels() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.fromIterable(() -> new Iterator<Integer>() {
+        Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             int count;
 
             @Override
@@ -282,7 +282,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void fusionClear() {
         Observable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 @SuppressWarnings("unchecked")
@@ -322,7 +322,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     public void disposeAfterHasNext() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.fromIterable(() -> new Iterator<Integer>() {
+        Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
@@ -106,7 +106,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         grouped.flatMap((Function<GroupedObservable<Integer, String>, Observable<String>>) o -> {
             groupCounter.incrementAndGet();
             return o.map(v -> "Event => key: " + o.getKey() + " value: " + v);
-        }).subscribe(new DefaultObserver<String>() {
+        }).subscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -180,7 +180,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
             return eventGroupedObservable.map(event -> "Source: " + event.source + "  Message: " + event.message);
 
-        }).subscribe(new DefaultObserver<String>() {
+        }).subscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -246,7 +246,7 @@ public class ObservableGroupByTest extends RxJavaTest {
                             .take(20) // limit to only 20 events on this group
                             .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
 
-                }).subscribe(new DefaultObserver<String>() {
+                }).subscribe(new DefaultObserver<String>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -344,7 +344,7 @@ public class ObservableGroupByTest extends RxJavaTest {
                         return group;
                     }
                 })
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -378,7 +378,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         Observable.range(0, 100)
                 .groupBy(i -> i % 2)
-                .subscribe(new DefaultObserver<GroupedObservable<Integer, Integer>>() {
+                .subscribe(new DefaultObserver<GroupedObservable<Integer, Integer>>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -705,7 +705,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         Observable<String> m = source.groupBy(keysel, valuesel)
         .flatMap((Function<GroupedObservable<String, String>, Observable<String>>) g -> {
             System.out.println("-----------> NEXT: " + g.getKey());
-            return g.take(2).map(new Function<String, String>() {
+            return g.take(2).map(new Function<String, String>() /* NFI */ {
 
                 int count;
 
@@ -813,7 +813,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
         Observable.range(1, 4000).groupBy(IS_EVEN2)
         .flatMap(g -> g.doOnComplete(() -> System.out.println("//////////////////// COMPLETED-A"))
-                .observeOn(Schedulers.computation()).map(new Function<Integer, String>() {
+                .observeOn(Schedulers.computation()).map(new Function<Integer, String>() /* NFI */ {
 
             int c;
 
@@ -896,7 +896,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         final TestObserverEx<Integer> inner2 = new TestObserverEx<>();
 
         final TestObserverEx<GroupedObservable<Integer, Integer>> outer
-                = new TestObserverEx<>(new DefaultObserver<GroupedObservable<Integer, Integer>>() {
+                = new TestObserverEx<>(new DefaultObserver<GroupedObservable<Integer, Integer>>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -962,7 +962,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void reentrantComplete() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -984,7 +984,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void reentrantCompleteCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
@@ -143,7 +143,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
                 PPF::new);
 
         q.subscribe(
-                new Observer<PPF>() {
+                new Observer<PPF>() /* NFI */ {
                     @Override
                     public void onNext(final PPF ppf) {
                         ppf.fruits.filter(t1 -> ppf.person.id == t1.personId).subscribe(t1 -> observer.onNext(Arrays.asList(ppf.person.name, t1.fruit)));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableJoinTest.java
@@ -345,7 +345,7 @@ public class ObservableJoinTest extends RxJavaTest {
     public void badOuterSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -376,7 +376,7 @@ public class ObservableJoinTest extends RxJavaTest {
             TestObserverEx<Integer> to = Observable.just(1)
             .join(Observable.just(2),
                     Functions.justFunction(Observable.never()),
-                    Functions.justFunction(new Observable<Integer>() {
+                    Functions.justFunction(new Observable<Integer>() /* NFI */ {
                         @Override
                         protected void subscribeActual(Observer<? super Integer> observer) {
                             o[0] = observer;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
@@ -42,7 +42,7 @@ public class ObservableMapNotificationTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(new Observable<Integer>() {
+        TestHelper.checkDisposed(new Observable<Integer>() /* NFI */ {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapTest.java
@@ -182,86 +182,12 @@ public class ObservableMapTest extends RxJavaTest {
         Observable.range(1, 1).lastElement().map(i -> i / 0).blockingGet();
     }
 
-    // FIXME RS subscribers can't throw
-//    @Test(expected = OnErrorNotImplementedException.class)
-//    public void verifyExceptionIsThrownIfThereIsNoExceptionHandler() {
-//
-//        ObservableSource<Object> creator = new ObservableSource<Object>() {
-//
-//            @Override
-//            public void subscribeActual(Observer<? super Object> observer) {
-//                observer.onSubscribe(EmptyDisposable.INSTANCE);
-//                observer.onNext("a");
-//                observer.onNext("b");
-//                observer.onNext("c");
-//                observer.onComplete();
-//            }
-//        };
-//
-//        Function<Object, Observable<Object>> manyMapper = new Function<Object, Observable<Object>>() {
-//
-//            @Override
-//            public Observable<Object> apply(Object object) {
-//                return Observable.just(object);
-//            }
-//        };
-//
-//        Function<Object, Object> mapper = new Function<Object, Object>() {
-//            private int count = 0;
-//
-//            @Override
-//            public Object apply(Object object) {
-//                ++count;
-//                if (count > 2) {
-//                    throw new RuntimeException();
-//                }
-//                return object;
-//            }
-//        };
-//
-//        Consumer<Object> onNext = new Consumer<Object>() {
-//
-//            @Override
-//            public void accept(Object object) {
-//                System.out.println(object.toString());
-//            }
-//        };
-//
-//        try {
-//            Observable.unsafeCreate(creator).flatMap(manyMapper).map(mapper).subscribe(onNext);
-//        } catch (RuntimeException e) {
-//            e.printStackTrace();
-//            throw e;
-//        }
-//    }
-
     private static Map<String, String> getMap(String prefix) {
         Map<String, String> m = new HashMap<>();
         m.put("firstName", prefix + "First");
         m.put("lastName", prefix + "Last");
         return m;
     }
-
-    // FIXME RS subscribers can't throw
-//    @Test(expected = OnErrorNotImplementedException.class)
-//    public void testShouldNotSwallowOnErrorNotImplementedException() {
-//        Observable.just("a", "b").flatMap(new Function<String, Observable<String>>() {
-//            @Override
-//            public Observable<String> apply(String s) {
-//                return Observable.just(s + "1", s + "2");
-//            }
-//        }).flatMap(new Function<String, Observable<String>>() {
-//            @Override
-//            public Observable<String> apply(String s) {
-//                return Observable.error(new Exception("test"));
-//            }
-//        }).forEach(new Consumer<String>() {
-//            @Override
-//            public void accept(String s) {
-//                System.out.println(s);
-//            }
-//        });
-//    }
 
     @Test
     public void dispose() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -290,7 +290,8 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
         final Observable<Observable<String>> o1 = Observable.error(new RuntimeException("unit test"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        Observable.merge(o1, ObservableMergeConfig.DELAY_ERROR).subscribe(new DefaultObserver<String>() {
+        Observable.merge(o1, ObservableMergeConfig.DELAY_ERROR)
+        .subscribe(new DefaultObserver<String>() /* NFI */ {
             @Override
             public void onComplete() {
                 fail("Expected onError path");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -203,7 +203,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger totalCounter = new AtomicInteger();
 
         Observable<String> m = Observable.mergeArray(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
-        m.subscribe(new DefaultObserver<String>() {
+        m.subscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -460,7 +460,7 @@ public class ObservableMergeTest extends RxJavaTest {
     private Observable<Long> createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
         return Observable.unsafeCreate(child -> Observable.interval(1, TimeUnit.SECONDS, scheduler)
         .take(5)
-        .subscribe(new Observer<Long>() {
+        .subscribe(new Observer<Long>() /* NFI */ {
             @Override
             public void onSubscribe(final Disposable d) {
                 child.onSubscribe(Disposable.fromRunnable(() -> {
@@ -596,7 +596,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 System.err.println("TestObserver received => " + t + "  on thread " + Thread.currentThread());
@@ -636,7 +636,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Observable<Integer> o1 = createInfiniteObservable(generated1).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -675,7 +675,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t < 100) {
@@ -725,7 +725,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Observable<Observable<Integer>> o1 = createInfiniteObservable(generated1).map(_ -> Observable.just(1, 2, 3));
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             int i;
 
             @Override
@@ -870,7 +870,7 @@ public class ObservableMergeTest extends RxJavaTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() {
+        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -946,7 +946,7 @@ public class ObservableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+            TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
                 int remaining = req;
 
                 @Override
@@ -964,7 +964,7 @@ public class ObservableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+            TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
                 int remaining = req;
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -106,7 +106,7 @@ public class ObservableMergeWithCompletableTest extends RxJavaTest {
 
     @Test
     public void isDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -124,7 +124,7 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final MaybeSubject<Integer> cs = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -148,7 +148,8 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final MaybeSubject<Integer> cs = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs)
+                .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -171,7 +172,7 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final AtomicReference<Observer<?>> observerRef = new AtomicReference<>();
-            TestObserver<Integer> to = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -217,7 +218,7 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
 
     @Test
     public void isDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -239,7 +240,8 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final MaybeSubject<Integer> cs = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs)
+                .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -116,7 +116,8 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs)
+                .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -140,7 +141,8 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs)
+                .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -163,7 +165,7 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             final AtomicReference<Observer<?>> observerRef = new AtomicReference<>();
-            TestObserver<Integer> to = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -209,7 +211,7 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
 
     @Test
     public void isDisposed() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -231,7 +233,8 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.mergeWith(cs).subscribeWith(new TestObserver<Integer>() {
+        TestObserver<Integer> to = ps.mergeWith(cs)
+                .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
@@ -267,7 +267,9 @@ public class ObservableObserveOnTest extends RxJavaTest {
         final CountDownLatch nextLatch = new CountDownLatch(1);
         final AtomicLong completeTime = new AtomicLong();
         // use subscribeOn to make async, observeOn to move
-        Observable.range(1, 2).subscribeOn(Schedulers.newThread()).observeOn(Schedulers.newThread()).subscribe(new DefaultObserver<Integer>() {
+        Observable.range(1, 2).subscribeOn(Schedulers.newThread())
+        .observeOn(Schedulers.newThread())
+        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -357,7 +359,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
     @Test
     public void backpressureWithTakeBefore() {
         final AtomicInteger generated = new AtomicInteger();
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() {
+        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -430,7 +432,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             TestScheduler scheduler = new TestScheduler();
-            TestObserver<Integer> to = new Observable<Integer>() {
+            TestObserver<Integer> to = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -574,7 +576,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         final CountDownLatch cdl = new CountDownLatch(1);
 
         us.observeOn(Schedulers.single())
-        .subscribe(new Observer<Integer>() {
+        .subscribe(new Observer<Integer>() /* NFI */ {
             Disposable upstream;
             int count;
             @Override
@@ -610,7 +612,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
     @Test
     public void nonFusedPollThrows() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -618,7 +620,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
                 @SuppressWarnings("unchecked")
                 ObserveOnObserver<Integer> oo = (ObserveOnObserver<Integer>)observer;
 
-                oo.queue = new SimpleQueue<Integer>() {
+                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {
@@ -663,7 +665,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
         bs.observeOn(ImmediateThinScheduler.INSTANCE)
         .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v + 1))
-        .subscribeWith(new TestObserver<Integer>() {
+        .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorResumeNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorResumeNextTest.java
@@ -197,7 +197,7 @@ public class ObservableOnErrorResumeNextTest extends RxJavaTest {
         Observable.range(0, 100000)
                 .onErrorResumeNext((Function<Throwable, Observable<Integer>>) _ -> Observable.just(1))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
                     int c;
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorResumeWithTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorResumeWithTest.java
@@ -142,7 +142,7 @@ public class ObservableOnErrorResumeWithTest extends RxJavaTest {
         Observable.range(0, 100000)
                 .onErrorResumeWith(Observable.just(1))
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
                     int c;
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorReturnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorReturnTest.java
@@ -128,7 +128,7 @@ public class ObservableOnErrorReturnTest extends RxJavaTest {
         Observable.range(0, 100000)
                 .onErrorReturn(_ -> 1)
                 .observeOn(Schedulers.computation())
-                .map(new Function<Integer, Integer>() {
+                .map(new Function<Integer, Integer>() /* NFI */ {
                     int c;
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
@@ -82,7 +82,8 @@ public class ObservablePublishTest extends RxJavaTest {
         Observable<Integer> fast = is.observeOn(Schedulers.computation())
         .doOnComplete(() -> System.out.println("^^^^^^^^^^^^^ completed FAST"));
 
-        Observable<Integer> slow = is.observeOn(Schedulers.computation()).map(new Function<Integer, Integer>() {
+        Observable<Integer> slow = is.observeOn(Schedulers.computation())
+                .map(new Function<Integer, Integer>() /* NFI */ {
             int c;
 
             @Override
@@ -146,7 +147,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         final TestObserver<Integer> to2 = new TestObserver<>();
 
-        final TestObserver<Integer> to1 = new TestObserver<Integer>() {
+        final TestObserver<Integer> to1 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (values().size() == 2) {
@@ -433,7 +434,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         ConnectableObservable<Integer> co = ps.publish();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -471,7 +472,7 @@ public class ObservablePublishTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -565,7 +566,7 @@ public class ObservablePublishTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Observer<?>[] sub = { null };
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 sub[0] = observer;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLongTest.java
@@ -105,7 +105,7 @@ public class ObservableRangeLongTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Observable.rangeLong(1L, 0L).subscribe(new DefaultObserver<Long>() {
+        Observable.rangeLong(1L, 0L).subscribe(new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeTest.java
@@ -106,7 +106,7 @@ public class ObservableRangeTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Observable.range(1, 0).subscribe(new DefaultObserver<Integer>() {
+        Observable.range(1, 0).subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRedoTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRedoTest.java
@@ -27,7 +27,8 @@ public class ObservableRedoTest extends RxJavaTest {
         final TestObserver<Integer> to = new TestObserver<>();
 
         Observable.just(1)
-        .repeatWhen((Function<Observable<Object>, ObservableSource<Object>>) o -> o.map(new Function<Object, Object>() {
+        .repeatWhen((Function<Observable<Object>, ObservableSource<Object>>) o ->
+        o.map(new Function<Object, Object>() /* NFI */ {
             int count;
             @Override
             public Object apply(Object v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReduceTest.java
@@ -215,7 +215,7 @@ public class ObservableReduceTest extends RxJavaTest {
     public void reduceMaybeBadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Object>() {
+            new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -248,7 +248,7 @@ public class ObservableReduceTest extends RxJavaTest {
     public void seedBadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -497,7 +497,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     @Test
     public void noOpConnect() {
         final int[] calls = { 0 };
-        Observable<Integer> o = new ConnectableObservable<Integer>() {
+        Observable<Integer> o = new ConnectableObservable<Integer>() /* NFI */ {
             @Override
             public void connect(Consumer<? super Disposable> connection) {
                 calls[0]++;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -648,7 +648,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             private static final long serialVersionUID = -5182053207244406872L;
 
             @Override
@@ -1114,7 +1114,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -1199,7 +1199,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1221,7 +1221,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1243,7 +1243,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1265,7 +1265,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1287,7 +1287,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Observer<?>[] sub = { null };
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 sub[0] = observer;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -648,7 +648,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) {
+        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             private static final long serialVersionUID = -5182053207244406872L;
 
             @Override
@@ -1114,7 +1114,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -1199,7 +1199,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1221,7 +1221,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1243,7 +1243,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1265,7 +1265,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1287,7 +1287,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void delayedUpstreamOnSubscribe() {
         final Observer<?>[] sub = { null };
 
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 sub[0] = observer;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
@@ -45,7 +45,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void iterativeBackoff() {
         Observer<String> consumer = TestHelper.mockObserver();
 
-        Observable<String> producer = Observable.unsafeCreate(new ObservableSource<String>() {
+        Observable<String> producer = Observable.unsafeCreate(new ObservableSource<String>() /* NFI */ {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();
@@ -463,25 +463,22 @@ public class ObservableRetryTest extends RxJavaTest {
             efforts.getAndIncrement();
             active.getAndIncrement();
             maxActive.set(Math.max(active.get(), maxActive.get()));
-            final Thread thread = new Thread(context) {
-                @Override
-                public void run() {
-                    long nr = 0;
-                    try {
-                        while (!terminate.get()) {
-                            Thread.sleep(emitDelay);
-                            if (nextBeforeFailure.getAndDecrement() > 0) {
-                                observer.onNext(nr++);
-                            } else {
-                                active.decrementAndGet();
-                                observer.onError(new RuntimeException("expected-failed"));
-                                break;
-                            }
+            final Thread thread = new Thread(() -> {
+                long nr = 0;
+                try {
+                    while (!terminate.get()) {
+                        Thread.sleep(emitDelay);
+                        if (nextBeforeFailure.getAndDecrement() > 0) {
+                            observer.onNext(nr++);
+                        } else {
+                            active.decrementAndGet();
+                            observer.onError(new RuntimeException("expected-failed"));
+                            break;
                         }
-                    } catch (InterruptedException t) {
                     }
+                } catch (InterruptedException t) {
                 }
-            };
+            }, context);
             thread.start();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -59,7 +59,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryTwice() {
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -120,7 +120,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryOnSpecificException() {
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -157,7 +157,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
     public void retryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() {
+        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScanTest.java
@@ -107,7 +107,7 @@ public class ObservableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Observable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultObserver<Integer>() {
+                .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipWhileTest.java
@@ -37,7 +37,7 @@ public class ObservableSkipWhileTest extends RxJavaTest {
         return v < 5;
     };
 
-    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() {
+    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() /* NFI */ {
         int index;
         @Override
         public boolean test(Integer value) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
@@ -57,7 +57,7 @@ public class ObservableSwitchIfEmptyTest extends RxJavaTest {
 
         Observable.<Long>empty()
                 .switchIfEmpty(withProducer)
-                .lift((ObservableOperator<Long, Long>) _ -> new DefaultObserver<Long>() {
+                .lift((ObservableOperator<Long, Long>) _ -> new DefaultObserver<Long>() /* NFI */ {
                     @Override
                     public void onComplete() {
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -372,7 +372,7 @@ public class ObservableSwitchTest extends RxJavaTest {
         .share()
         ;
 
-        TestObserverEx<String> to = new TestObserverEx<String>() {
+        TestObserverEx<String> to = new TestObserverEx<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 super.onNext(t);
@@ -678,7 +678,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void badMainSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -718,7 +718,7 @@ public class ObservableSwitchTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.just(1).hide()
-            .switchMap(Functions.justFunction(new Observable<Integer>() {
+            .switchMap(Functions.justFunction(new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -741,7 +741,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void innerCompletesReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -762,7 +762,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void innerErrorsReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -807,7 +807,7 @@ public class ObservableSwitchTest extends RxJavaTest {
             try {
 
                 final AtomicReference<Observer<? super Integer>> obs1 = new AtomicReference<>();
-                final Observable<Integer> ps1 = new Observable<Integer>() {
+                final Observable<Integer> ps1 = new Observable<Integer>() /* NFI */ {
                     @Override
                     protected void subscribeActual(
                             Observer<? super Integer> observer) {
@@ -815,7 +815,7 @@ public class ObservableSwitchTest extends RxJavaTest {
                     }
                 };
                 final AtomicReference<Observer<? super Integer>> obs2 = new AtomicReference<>();
-                final Observable<Integer> ps2 = new Observable<Integer>() {
+                final Observable<Integer> ps2 = new Observable<Integer>() /* NFI */ {
                     @Override
                     protected void subscribeActual(
                             Observer<? super Integer> observer) {
@@ -1027,7 +1027,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void mainCompleteCancelRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
-            Observable<Integer> o = new Observable<Integer>() {
+            Observable<Integer> o = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref.set(observer);
@@ -1052,14 +1052,14 @@ public class ObservableSwitchTest extends RxJavaTest {
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             AtomicReference<Observer<? super Integer>> ref1 = new AtomicReference<>();
-            Observable<Integer> o1 = new Observable<Integer>() {
+            Observable<Integer> o1 = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref1.set(observer);
                 }
             };
             AtomicReference<Observer<? super Integer>> ref2 = new AtomicReference<>();
-            Observable<Integer> o2 = new Observable<Integer>() {
+            Observable<Integer> o2 = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref2.set(observer);
@@ -1083,14 +1083,14 @@ public class ObservableSwitchTest extends RxJavaTest {
     @Test
     public void innerNoSubscriptionYet() {
         AtomicReference<Observer<? super Integer>> ref1 = new AtomicReference<>();
-        Observable<Integer> o1 = new Observable<Integer>() {
+        Observable<Integer> o1 = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                 ref1.set(observer);
             }
         };
         AtomicReference<Observer<? super Integer>> ref2 = new AtomicReference<>();
-        Observable<Integer> o2 = new Observable<Integer>() {
+        Observable<Integer> o2 = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                 ref2.set(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTest.java
@@ -110,7 +110,7 @@ public class ObservableTakeLastTest extends RxJavaTest {
     }
 
     private Function<Integer, Integer> newSlowProcessor() {
-        return new Function<Integer, Integer>() {
+        return new Function<Integer, Integer>() /* NFI */ {
             int c;
 
             @Override
@@ -140,7 +140,8 @@ public class ObservableTakeLastTest extends RxJavaTest {
     @Test
     public void unsubscribeTakesEffectEarlyOnFastPath() {
         final AtomicInteger count = new AtomicInteger();
-        Observable.range(0, 100000).takeLast(100000).subscribe(new DefaultObserver<Integer>() {
+        Observable.range(0, 100000).takeLast(100000)
+        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
@@ -253,7 +253,7 @@ public class ObservableTakeTest extends RxJavaTest {
     public void takeFinalValueThrows() {
         Observable<Integer> source = Observable.just(1).take(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeUntilPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeUntilPredicateTest.java
@@ -141,7 +141,7 @@ public class ObservableTakeUntilPredicateTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeWhileTest.java
@@ -71,7 +71,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhile2() {
         Observable<String> w = Observable.just("one", "two", "three");
-        Observable<String> take = w.takeWhile(new Predicate<String>() {
+        Observable<String> take = w.takeWhile(new Predicate<String>() /* NFI */ {
             int index;
 
             @Override
@@ -132,7 +132,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
 
         Observer<String> observer = TestHelper.mockObserver();
         Observable<String> take = Observable.unsafeCreate(w)
-                .takeWhile(new Predicate<String>() {
+                .takeWhile(new Predicate<String>() /* NFI */ {
             int index;
 
             @Override
@@ -230,7 +230,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
 
     @Test
     public void badSource() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -196,7 +196,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
         TestScheduler sch = new TestScheduler();
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
@@ -341,7 +341,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -367,7 +367,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
     public void badSourceOther() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -361,7 +361,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserverEx<Integer> to = ps
-            .timeout(Functions.justFunction(new Observable<Integer>() {
+            .timeout(Functions.justFunction(new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -390,7 +390,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserverEx<Integer> to = ps
-            .timeout(Functions.justFunction(new Observable<Integer>() {
+            .timeout(Functions.justFunction(new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -423,7 +423,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
     @Test
     @SuppressUndeliverable
     public void badSourceTimeout() {
-        new Observable<Integer>() {
+        new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -486,7 +486,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() {
+                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -530,7 +530,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() {
+                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -575,7 +575,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() {
+                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -620,7 +620,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() {
+                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -663,7 +663,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() {
+                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
@@ -233,7 +233,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void onceObserverThrows() {
         Observable<Long> source = Observable.timer(100, TimeUnit.MILLISECONDS, scheduler);
 
-        source.safeSubscribe(new DefaultObserver<Long>() {
+        source.safeSubscribe(new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {
@@ -264,7 +264,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(observer);
 
-        source.safeSubscribe(new DefaultObserver<Long>() {
+        source.safeSubscribe(new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToFutureTest.java
@@ -111,7 +111,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
     @Test
     public void cancellationDuringFutureGet() throws Exception {
-        Future<Object> future = new Future<Object>() {
+        Future<Object> future = new Future<Object>() /* NFI */ {
             private AtomicBoolean isCancelled = new AtomicBoolean(false);
             private AtomicBoolean isDone = new AtomicBoolean(false);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
@@ -134,7 +134,7 @@ public class ObservableToMapTest extends RxJavaTest {
     public void toMapWithFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
             private static final long serialVersionUID = -3296811238780863394L;
 
@@ -273,7 +273,7 @@ public class ObservableToMapTest extends RxJavaTest {
     public void toMapWithFactory() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
             private static final long serialVersionUID = -3296811238780863394L;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
@@ -77,7 +77,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactoryObservable() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
             private static final long serialVersionUID = -2084477070717362859L;
 
@@ -268,7 +268,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactory() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
             private static final long serialVersionUID = -2084477070717362859L;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -222,7 +222,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
     public void signalAfterDispose() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsingTest.java
@@ -97,7 +97,7 @@ public class ObservableUsingTest extends RxJavaTest {
 
     private void performTestUsingWithSubscribingTwice(boolean disposeEagerly) {
         // When subscribe is called, a new resource should be created.
-        Supplier<Resource> resourceFactory = () -> new Resource() {
+        Supplier<Resource> resourceFactory = () -> new Resource() /* NFI */ {
 
             boolean first = true;
 
@@ -285,7 +285,7 @@ public class ObservableUsingTest extends RxJavaTest {
     }
 
     private static Supplier<Resource> createResourceFactory(final List<String> events) {
-        return () -> new Resource() {
+        return () -> new Resource() /* NFI */ {
 
             @Override
             public String getTextFromWeb() {
@@ -387,7 +387,7 @@ public class ObservableUsingTest extends RxJavaTest {
     public void eagerDisposedOnComplete() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
+        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -402,7 +402,7 @@ public class ObservableUsingTest extends RxJavaTest {
     public void eagerDisposedOnError() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() {
+        Observable.using(Functions.justSupplier(1), Functions.justFunction(new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -46,7 +46,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
+        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -103,7 +103,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
+        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -159,7 +159,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
+        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -209,7 +209,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() {
+        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -278,7 +278,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     public void reentrant() {
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -337,7 +337,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             TestObserverEx<Observable<Object>> to = Observable.error(new TestException("main"))
-            .window(new Observable<Object>() {
+            .window(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -373,14 +373,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
                 final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
                 final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-                TestObserverEx<Observable<Object>> to = new Observable<Object>() {
+                TestObserverEx<Observable<Object>> to = new Observable<Object>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Observer<? super Object> observer) {
                         observer.onSubscribe(Disposable.empty());
                         refMain.set(observer);
                     }
                 }
-                .window(new Observable<Object>() {
+                .window(new Observable<Object>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Observer<? super Object> observer) {
                         observer.onSubscribe(Disposable.empty());
@@ -413,14 +413,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            TestObserver<Observable<Object>> to = new Observable<Object>() {
+            TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() {
+            .window(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -446,14 +446,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
         final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-        TestObserverEx<Observable<Object>> to = new Observable<Object>() {
+        TestObserverEx<Observable<Object>> to = new Observable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());
                 refMain.set(observer);
             }
         }
-        .window(new Observable<Object>() {
+        .window(new Observable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -478,18 +478,18 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            final TestObserver<Observable<Object>> to = new Observable<Object>() {
+            final TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() {
+            .window(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     final AtomicInteger counter = new AtomicInteger();
-                    observer.onSubscribe(new Disposable() {
+                    observer.onSubscribe(new Disposable() /* NFI */ {
 
                         @Override
                         public void dispose() {
@@ -529,18 +529,18 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            final TestObserver<Observable<Object>> to = new Observable<Object>() {
+            final TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() {
+            .window(new Observable<Object>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     final AtomicInteger counter = new AtomicInteger();
-                    observer.onSubscribe(new Disposable() {
+                    observer.onSubscribe(new Disposable() /* NFI */ {
 
                         @Override
                         public void dispose() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -100,7 +100,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     }
 
     private Consumer<Observable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
-        return stringObservable -> stringObservable.subscribe(new DefaultObserver<String>() {
+        return stringObservable -> stringObservable.subscribe(new DefaultObserver<String>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -264,7 +264,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     public void reentrant() {
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -297,7 +297,8 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             BehaviorSubject.createDefault(1)
-            .window(BehaviorSubject.createDefault(1), (Function<Integer, Observable<Integer>>) _ -> new Observable<Integer>() {
+            .window(BehaviorSubject.createDefault(1),
+                    (Function<Integer, Observable<Integer>>) _ -> new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -121,7 +121,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     private <T> Consumer<Observable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
-        return stringObservable -> stringObservable.subscribe(new DefaultObserver<T>() {
+        return stringObservable -> stringObservable.subscribe(new DefaultObserver<T>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -425,7 +425,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -453,7 +453,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -481,7 +481,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -509,7 +509,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -662,7 +662,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {
@@ -703,7 +703,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {
@@ -743,7 +743,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {
@@ -784,7 +784,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {
@@ -824,7 +824,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {
@@ -865,7 +865,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() {
+        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
             int count;
             @Override
             public void accept(Observable<Integer> v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromTest.java
@@ -491,7 +491,7 @@ public class ObservableWithLatestFromTest extends RxJavaTest {
     public void manyErrors() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
@@ -228,7 +228,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
-        Iterable<String> r2 = () -> new Iterator<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
             int count;
 
             @Override
@@ -271,7 +271,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
-        Iterable<String> r2 = () -> new Iterator<String>() {
+        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -346,7 +346,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
     public void badSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Integer>() {
+            new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
@@ -677,7 +677,7 @@ public class ObservableZipTest extends RxJavaTest {
         final Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable.zip(Observable.just(1),
-                Observable.just(1), Integer::sum).subscribe(new DefaultObserver<Integer>() {
+                Observable.just(1), Integer::sum).subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -744,7 +744,7 @@ public class ObservableZipTest extends RxJavaTest {
                 .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteObservable), (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
-        os.subscribe(new DefaultObserver<String>() {
+        os.subscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -881,7 +881,7 @@ public class ObservableZipTest extends RxJavaTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() {
+        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -1141,7 +1141,7 @@ public class ObservableZipTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
@@ -62,7 +62,7 @@ public class SingleCacheTest extends RxJavaTest {
 
         final Single<Integer> cached = pp.single(-99).cache();
 
-        SingleObserver<Integer> doubleDisposer = new SingleObserver<Integer>() {
+        SingleObserver<Integer> doubleDisposer = new SingleObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
@@ -136,7 +136,7 @@ public class SingleCreateTest extends RxJavaTest {
                 // expected
             }
         })
-        .subscribe(new SingleObserver<Object>() {
+        .subscribe(new SingleObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 
@@ -168,7 +168,7 @@ public class SingleCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
         })
-        .subscribe(new SingleObserver<Object>() {
+        .subscribe(new SingleObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 
@@ -196,7 +196,7 @@ public class SingleCreateTest extends RxJavaTest {
                 // expected
             }
         })
-        .subscribe(new SingleObserver<Object>() {
+        .subscribe(new SingleObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }
@@ -226,7 +226,7 @@ public class SingleCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
         })
-        .subscribe(new SingleObserver<Object>() {
+        .subscribe(new SingleObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDeferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDeferTest.java
@@ -23,7 +23,7 @@ public class SingleDeferTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single<Integer> s = Single.defer(new Supplier<Single<Integer>>() {
+        Single<Integer> s = Single.defer(new Supplier<Single<Integer>>() /* NFI */ {
             int counter;
             @Override
             public Single<Integer> get() throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayTest.java
@@ -173,7 +173,7 @@ public class SingleDelayTest extends RxJavaTest {
 
         try {
             Single.just(1)
-            .delaySubscription(new Flowable<Integer>() {
+            .delaySubscription(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -209,7 +209,7 @@ public class SingleDelayTest extends RxJavaTest {
 
         try {
             Single.just(1)
-            .delaySubscription(new Observable<Integer>() {
+            .delaySubscription(new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
@@ -61,7 +61,7 @@ public class SingleDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Object> to = new Single<Object>() {
+        TestObserver<Object> to = new Single<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(wr.get());
@@ -87,7 +87,7 @@ public class SingleDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Integer> to = new Single<Integer>() {
+        TestObserver<Integer> to = new Single<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());
@@ -113,7 +113,7 @@ public class SingleDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Integer> to = new Single<Integer>() {
+        TestObserver<Integer> to = new Single<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 observer.onSubscribe(wr.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -34,7 +34,7 @@ public class SingleDoAfterSuccessTest extends RxJavaTest {
 
     final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() {
+    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnLifecycleTest.java
@@ -69,7 +69,7 @@ public class SingleDoOnLifecycleTest extends RxJavaTest {
 
             Disposable bs = Disposable.empty();
 
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(bs);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
@@ -252,7 +252,7 @@ public class SingleDoOnTest extends RxJavaTest {
         try {
             final Disposable bs = Disposable.empty();
 
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(bs);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -216,7 +216,8 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Single.just(1)
-        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() {
+        .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
+        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
             QueueSubscription<Integer> qs;
             @SuppressWarnings("unchecked")
             @Override
@@ -349,7 +350,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {
@@ -383,7 +384,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {
@@ -446,7 +447,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void slowPatchCancelAfterOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -207,7 +207,8 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Single.just(1)
-        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3)).subscribe(new Observer<Integer>() {
+        .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
+        .subscribe(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> qd;
             @SuppressWarnings("unchecked")
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFromPublisherTest.java
@@ -83,7 +83,7 @@ public class SingleFromPublisherTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.fromPublisher(new Flowable<Integer>() {
+            Single.fromPublisher(new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
@@ -23,7 +23,7 @@ public class SingleLiftTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single.just(1).lift((SingleOperator<Integer, Integer>) observer -> new SingleObserver<Integer>() {
+        Single.just(1).lift((SingleOperator<Integer, Integer>) observer -> new SingleObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -120,7 +120,7 @@ public class SingleMiscTest extends RxJavaTest {
         final AtomicBoolean flag = new AtomicBoolean();
 
         Single.just(1)
-        .doOnSuccess(new Consumer<Integer>() {
+        .doOnSuccess(new Consumer<Integer>() /* NFI */ {
             int c;
             @Override
             public void accept(Integer v) throws Exception {
@@ -137,7 +137,7 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retry() {
-        Single.fromCallable(new Callable<Object>() {
+        Single.fromCallable(new Callable<Object>() /* NFI */ {
             int c;
             @Override
             public Object call() throws Exception {
@@ -154,7 +154,7 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retryBiPredicate() {
-        Single.fromCallable(new Callable<Object>() {
+        Single.fromCallable(new Callable<Object>() /* NFI */ {
             int c;
             @Override
             public Object call() throws Exception {
@@ -188,7 +188,7 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retryPredicate() {
-        Single.fromCallable(new Callable<Object>() {
+        Single.fromCallable(new Callable<Object>() /* NFI */ {
             int c;
             @Override
             public Object call() throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
@@ -75,7 +75,7 @@ public class SingleSafeSubscribeTest {
 
             Disposable d = Disposable.empty();
 
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(d);
@@ -104,7 +104,7 @@ public class SingleSafeSubscribeTest {
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
             doThrow(new TestException()).when(consumer).onSuccess(any());
 
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -129,7 +129,7 @@ public class SingleSafeSubscribeTest {
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());
 
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntilTest.java
@@ -271,7 +271,7 @@ public class SingleTakeUntilTest extends RxJavaTest {
     @Test
     public void flowableCancelDelayed() {
         Single.never()
-        .takeUntil(new Flowable<Integer>() {
+        .takeUntil(new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeoutTest.java
@@ -211,7 +211,7 @@ public class SingleTimeoutTest extends RxJavaTest {
     public void timeoutBeforeOnSubscribeFromMain() {
         Disposable d = Disposable.empty();
 
-        new Single<Integer>() {
+        new Single<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull SingleObserver<? super @NonNull Integer> observer) {
                 try {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
@@ -92,7 +92,7 @@ public class SingleUnsubscribeOnTest extends RxJavaTest {
 
             final Disposable[] ds = { null };
             pp.single(-99).unsubscribeOn(Schedulers.computation())
-            .subscribe(new SingleObserver<Integer>() {
+            .subscribe(new SingleObserver<Integer>() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     ds[0] = d;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
@@ -214,7 +214,7 @@ public class SingleUsingTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justSupplier(1), (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() {
+            Single.using(Functions.justSupplier(1), (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
@@ -28,7 +28,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void cancelSetFuture() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -43,7 +43,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
         assertTrue(task.isDisposed());
 
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -60,7 +60,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void cancelSetFutureCurrentThread() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -77,7 +77,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
         assertTrue(task.isDisposed());
 
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -94,12 +94,12 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void setFutureCancel() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
 
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -123,12 +123,12 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void setFutureCancelSameThread() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
 
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -153,11 +153,11 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void finished() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -183,11 +183,11 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void finishedCancel() {
         @SuppressWarnings("resource")
-        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+        AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -218,12 +218,12 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void disposeSetFutureRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             @SuppressWarnings("resource")
-            final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) {
+            final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
                 private static final long serialVersionUID = 208585707945686116L;
             };
 
             final Boolean[] interrupted = { null };
-            final FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) {
+            final FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
                 @Override
                 public boolean cancel(boolean mayInterruptIfRunning) {
                     interrupted[0] = mayInterruptIfRunning;

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -31,7 +31,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
 
     @Test
     public void offerThrows() {
-        ConditionalSubscriber<Integer> cs = new ConditionalSubscriber<Integer>() {
+        var cs = new ConditionalSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -55,7 +55,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
             }
         };
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> fcs = new BasicFuseableConditionalSubscriber<Integer, Integer>(cs) {
+        var fcs = new BasicFuseableConditionalSubscriber<Integer, Integer>(cs) /* NFI */ {
 
             @Override
             public boolean tryOnNext(Integer t) {
@@ -92,7 +92,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         ConditionalSubscriber<Integer> ts = mock(ConditionalSubscriber.class);
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) {
+        var bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {
@@ -140,7 +140,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         ConditionalSubscriber<Integer> ts = mock(ConditionalSubscriber.class);
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) {
+        var bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {
@@ -180,7 +180,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         ConditionalSubscriber<Integer> ts = mock(ConditionalSubscriber.class);
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) {
+        var bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {
@@ -220,7 +220,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         ConditionalSubscriber<Integer> ts = mock(ConditionalSubscriber.class);
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) {
+        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -57,7 +57,7 @@ public class BasicFuseableSubscriberTest extends RxJavaTest {
     @Test
     public void implementationStopsOnSubscribe() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
-        BasicFuseableSubscriber<Integer, Integer> bfs = new BasicFuseableSubscriber<Integer, Integer>(ts) {
+        var bfs = new BasicFuseableSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BlockingSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BlockingSubscriberTest.java
@@ -89,7 +89,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
 
         final AtomicBoolean b = new AtomicBoolean();
 
-        Subscription s = new Subscription() {
+        Subscription s = new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 bf.cancelled = true;
@@ -115,7 +115,7 @@ public class BlockingSubscriberTest extends RxJavaTest {
 
         bf.cancelled = true;
 
-        Subscription s = new Subscription() {
+        Subscription s = new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 b.set(true);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -172,7 +172,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeAfterNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -194,7 +194,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeAfterNextViaRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
@@ -290,7 +290,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             subscribeAutoDispose(
-                    new Flowable<Integer>() {
+                    new Flowable<Integer>() /* NFI */ {
                         @Override
                         protected void subscribeActual(
                                 Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriberTest.java
@@ -26,7 +26,7 @@ public class InnerQueuedSubscriberTest extends RxJavaTest {
 
     @Test
     public void requestInBatches() {
-        InnerQueuedSubscriberSupport<Integer> support = new InnerQueuedSubscriberSupport<Integer>() {
+        InnerQueuedSubscriberSupport<Integer> support = new InnerQueuedSubscriberSupport<Integer>() /* NFI */ {
             @Override
             public void innerNext(InnerQueuedSubscriber<Integer> inner, Integer value) {
             }
@@ -48,7 +48,7 @@ public class InnerQueuedSubscriberTest extends RxJavaTest {
 
         final List<Long> requests = new ArrayList<>();
 
-        inner.onSubscribe(new Subscription() {
+        inner.onSubscribe(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 requests.add(n);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -27,7 +27,7 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) {
+            final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) /* NFI */ {
                 private static final long serialVersionUID = -2848918821531562637L;
 
                 @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
@@ -30,7 +30,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void strictMode() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -53,7 +53,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() {
+        new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -132,7 +132,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void deferredRequest() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -164,7 +164,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void requestZero() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -196,7 +196,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void requestNegative() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -228,7 +228,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void cancelAfterOnComplete() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             Subscription upstream;
             @Override
@@ -254,7 +254,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() {
+        new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 BooleanSubscription b = new BooleanSubscription();
@@ -270,7 +270,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void cancelAfterOnError() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() {
+        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
 
             Subscription upstream;
             @Override
@@ -296,7 +296,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() {
+        new Flowable<Object>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 BooleanSubscription b = new BooleanSubscription();
@@ -314,7 +314,7 @@ public class StrictSubscriberTest extends RxJavaTest {
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>();
         SubscriberWrapper<Integer> wrapper = new SubscriberWrapper<>(ts);
 
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 BooleanSubscription b1 = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionHelperTest.java
@@ -176,7 +176,7 @@ public class SubscriptionHelperTest extends RxJavaTest {
 
             final AtomicLong q = new AtomicLong();
 
-            final Subscription a = new Subscription() {
+            final Subscription a = new Subscription() /* NFI */ {
                 @Override
                 public void request(long n) {
                     q.addAndGet(n);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/AtomicThrowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/AtomicThrowableTest.java
@@ -250,7 +250,7 @@ public class AtomicThrowableTest extends RxJavaTest {
     }
 
     static <T> Emitter<T> wrapToEmitter(final Observer<T> observer) {
-        return new Emitter<T>() {
+        return new Emitter<T>() /* NFI */ {
             @Override
             public void onNext(T value) {
                 observer.onNext(value);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
@@ -51,7 +51,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDefaultSubscriber() {
-        Subscriber<Integer> consumer = new DefaultSubscriber<Integer>() {
+        Subscriber<Integer> consumer = new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -126,7 +126,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleDisposableSubscriber() {
         @SuppressWarnings("resource")
-        Subscriber<Integer> consumer = new DisposableSubscriber<Integer>() {
+        Subscriber<Integer> consumer = new DisposableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -162,7 +162,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleResourceSubscriber() {
         @SuppressWarnings("resource")
-        Subscriber<Integer> consumer = new ResourceSubscriber<Integer>() {
+        Subscriber<Integer> consumer = new ResourceSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -197,7 +197,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDefaultObserver() {
-        Observer<Integer> consumer = new DefaultObserver<Integer>() {
+        Observer<Integer> consumer = new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -233,7 +233,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleDisposableObserver() {
         @SuppressWarnings("resource")
-        Observer<Integer> consumer = new DisposableObserver<Integer>() {
+        Observer<Integer> consumer = new DisposableObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -269,7 +269,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleResourceObserver() {
         @SuppressWarnings("resource")
-        Observer<Integer> consumer = new ResourceObserver<Integer>() {
+        Observer<Integer> consumer = new ResourceObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -305,7 +305,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleDisposableSingleObserver() {
         @SuppressWarnings("resource")
-        SingleObserver<Integer> consumer = new DisposableSingleObserver<Integer>() {
+        SingleObserver<Integer> consumer = new DisposableSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -337,7 +337,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleResourceSingleObserver() {
         @SuppressWarnings("resource")
-        SingleObserver<Integer> consumer = new ResourceSingleObserver<Integer>() {
+        SingleObserver<Integer> consumer = new ResourceSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -369,7 +369,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleDisposableMaybeObserver() {
         @SuppressWarnings("resource")
-        MaybeObserver<Integer> consumer = new DisposableMaybeObserver<Integer>() {
+        MaybeObserver<Integer> consumer = new DisposableMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -405,7 +405,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleResourceMaybeObserver() {
         @SuppressWarnings("resource")
-        MaybeObserver<Integer> consumer = new ResourceMaybeObserver<Integer>() {
+        MaybeObserver<Integer> consumer = new ResourceMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -441,7 +441,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleDisposableCompletableObserver() {
         @SuppressWarnings("resource")
-        CompletableObserver consumer = new DisposableCompletableObserver() {
+        CompletableObserver consumer = new DisposableCompletableObserver() /* NFI */ {
             @Override
             public void onError(Throwable t) {
             }
@@ -473,7 +473,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
     @Test
     public void checkDoubleResourceCompletableObserver() {
         @SuppressWarnings("resource")
-        CompletableObserver consumer = new ResourceCompletableObserver() {
+        CompletableObserver consumer = new ResourceCompletableObserver() /* NFI */ {
             @Override
             public void onError(Throwable t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerObserverTest.java
@@ -38,7 +38,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final TestObserver to = new TestObserver();
 
-        Observer observer = new Observer() {
+        Observer observer = new Observer() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 to.onSubscribe(d);
@@ -82,7 +82,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final TestObserver to = new TestObserver();
 
-        Observer observer = new Observer() {
+        Observer observer = new Observer() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 to.onSubscribe(d);
@@ -126,7 +126,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final TestObserver to = new TestObserver();
 
-        Observer observer = new Observer() {
+        Observer observer = new Observer() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 to.onSubscribe(d);
@@ -171,7 +171,7 @@ public class HalfSerializerObserverTest extends RxJavaTest {
 
         final TestObserver to = new TestObserver();
 
-        Observer observer = new Observer() {
+        Observer observer = new Observer() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 to.onSubscribe(d);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/HalfSerializerSubscriberTest.java
@@ -44,7 +44,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        FlowableSubscriber s = new FlowableSubscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -88,7 +88,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        FlowableSubscriber s = new FlowableSubscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -132,7 +132,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        FlowableSubscriber s = new FlowableSubscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);
@@ -177,7 +177,7 @@ public class HalfSerializerSubscriberTest extends RxJavaTest {
 
         final TestSubscriber ts = new TestSubscriber();
 
-        FlowableSubscriber s = new FlowableSubscriber() {
+        FlowableSubscriber s = new FlowableSubscriber() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(s);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/MiscUtilTest.java
@@ -248,7 +248,7 @@ public class MiscUtilTest extends RxJavaTest {
 
         final List<Integer> out = new ArrayList<>();
 
-        list.forEachWhile(null, (state, value) -> {
+        list.forEachWhile(null, (_, value) -> {
             out.add(value);
             return false; // never terminate early
         });

--- a/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
@@ -44,7 +44,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void requestMaxInt() {
-        QueueDrainHelper.request(new Subscription() {
+        QueueDrainHelper.request(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 assertEquals(Integer.MAX_VALUE, n);
@@ -58,7 +58,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void requestMinInt() {
-        QueueDrainHelper.request(new Subscription() {
+        QueueDrainHelper.request(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 assertEquals(Long.MAX_VALUE, n);
@@ -72,7 +72,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void requestAlmostMaxInt() {
-        QueueDrainHelper.request(new Subscription() {
+        QueueDrainHelper.request(new Subscription() /* NFI */ {
             @Override
             public void request(long n) {
                 assertEquals(Integer.MAX_VALUE - 1, n);
@@ -154,7 +154,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void postCompleteCancelledAfterOne() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -179,7 +179,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -234,7 +234,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -293,7 +293,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -348,7 +348,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -402,7 +402,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -456,7 +456,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -510,7 +510,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() {
+        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -564,7 +564,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -607,7 +607,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -654,7 +654,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -697,7 +697,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -740,7 +740,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -783,7 +783,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() {
+        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -270,7 +270,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void defer() {
-        Maybe<Integer> source = Maybe.defer(new Supplier<Maybe<Integer>>() {
+        Maybe<Integer> source = Maybe.defer(new Supplier<Maybe<Integer>>() /* NFI */ {
             int count;
             @Override
             public Maybe<Integer> get() throws Exception {
@@ -1926,7 +1926,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void subscribeWith() {
-        MaybeObserver<Integer> mo = new MaybeObserver<Integer>() {
+        MaybeObserver<Integer> mo = new MaybeObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -2570,7 +2570,7 @@ public class MaybeTest extends RxJavaTest {
 
         long middle = usedMemoryNow();
 
-        MaybeObserver<Object> observer = new MaybeObserver<Object>() {
+        MaybeObserver<Object> observer = new MaybeObserver<Object>() /* NFI */ {
             @SuppressWarnings("unused")
             Disposable u;
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableErrorHandlingTests.java
@@ -35,7 +35,7 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
-        Observer<Long> observer = new DefaultObserver<Long>() {
+        Observer<Long> observer = new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -71,7 +71,7 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
-        Observer<Long> observer = new DefaultObserver<Long>() {
+        Observer<Long> observer = new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
@@ -33,7 +33,8 @@ public class ObservableSubscriberTest extends RxJavaTest {
     @Test
     public void onStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.just(1, 2, 3, 4).take(2).subscribe(new DefaultObserver<Integer>() {
+        Observable.just(1, 2, 3, 4).take(2)
+        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -62,7 +63,8 @@ public class ObservableSubscriberTest extends RxJavaTest {
     @Test
     public void onStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.just(1, 2, 3, 4).take(2).subscribe(new DefaultObserver<Integer>() {
+        Observable.just(1, 2, 3, 4).take(2)
+        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -91,7 +93,8 @@ public class ObservableSubscriberTest extends RxJavaTest {
     @Test
     public void onStartCalledOnceViaLift() {
         final AtomicInteger c = new AtomicInteger();
-        Observable.just(1, 2, 3, 4).lift((ObservableOperator<Integer, Integer>) child -> new DefaultObserver<Integer>() {
+        Observable.just(1, 2, 3, 4)
+        .lift((ObservableOperator<Integer, Integer>) child -> new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
@@ -327,7 +327,7 @@ public class ObservableTest extends RxJavaTest {
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
         .subscribeOn(Schedulers.newThread())
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
             @Override
             public void onComplete() {
                 System.out.println("completed");
@@ -374,7 +374,7 @@ public class ObservableTest extends RxJavaTest {
 
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -416,7 +416,7 @@ public class ObservableTest extends RxJavaTest {
         final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
         Observable.just("1", "2").concatWith(Observable.<String>error(NumberFormatException::new))
-        .subscribe(new DefaultObserver<String>() {
+        .subscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -584,7 +584,7 @@ public class ObservableTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         Observable.just("1", "2", "three", "4").take(3)
-        .safeSubscribe(new DefaultObserver<String>() {
+        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -900,28 +900,6 @@ public class ObservableTest extends RxJavaTest {
         verify(w, never()).onNext(any(Integer.class));
         verify(w, never()).onError(any(Throwable.class));
     }
-
-// FIXME this test doesn't make sense
-//    @Test // cf. https://github.com/ReactiveX/RxJava/issues/2599
-//    public void testSubscribingSubscriberAsObserverMaintainsSubscriptionChain() {
-//        TestObserver<Object> observer = new TestObserver<T>();
-//        Subscription subscription = Observable.just("event").subscribe((Observer<Object>) observer);
-//        subscription.unsubscribe();
-//
-//        subscriber.assertUnsubscribed();
-//    }
-
-// FIXME subscribers can't throw
-//    @Test(expected=OnErrorNotImplementedException.class)
-//    public void testForEachWithError() {
-//        Observable.error(new Exception("boo"))
-//        //
-//        .forEach(new Action1<Object>() {
-//            @Override
-//            public void call(Object t) {
-//                //do nothing
-//            }});
-//    }
 
     @Test
     public void extend() {

--- a/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
@@ -94,7 +94,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() {
+        return new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -115,7 +115,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
-        return new DefaultObserver<String>() {
+        return new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -136,7 +136,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONERROR_FAIL() {
-        return new DefaultObserver<String>() {
+        return new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -157,7 +157,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() {
+        return new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -186,7 +186,7 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void actual() {
-        Observer<Integer> actual = new DefaultObserver<Integer>() {
+        Observer<Integer> actual = new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -277,7 +277,7 @@ public class SerializedObserverTest extends RxJavaTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestObserverEx<String> to = new TestObserverEx<>(new DefaultObserver<String>() {
+                TestObserverEx<String> to = new TestObserverEx<>(new DefaultObserver<String>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -358,7 +358,7 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() {
+        TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -386,7 +386,7 @@ public class SerializedObserverTest extends RxJavaTest {
         AtomicInteger p2 = new AtomicInteger();
 
         o.onSubscribe(Disposable.empty());
-        DisposableObserver<String> as1 = new DisposableObserver<String>() {
+        DisposableObserver<String> as1 = new DisposableObserver<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 o.onNext(t);
@@ -403,7 +403,7 @@ public class SerializedObserverTest extends RxJavaTest {
             }
         };
 
-        DisposableObserver<String> as2 = new DisposableObserver<String>() {
+        DisposableObserver<String> as2 = new DisposableObserver<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 o.onNext(t);
@@ -834,7 +834,7 @@ public class SerializedObserverTest extends RxJavaTest {
         try {
             final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
-            TestObserver<Integer> to = new TestObserver<Integer>() {
+            TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer v) {
                     serial.get().onError(new TestException());
@@ -861,7 +861,7 @@ public class SerializedObserverTest extends RxJavaTest {
     public void completeReentry() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer v) {
                 serial.get().onComplete();
@@ -1094,7 +1094,7 @@ public class SerializedObserverTest extends RxJavaTest {
     @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedObserver<Integer>> soRef = new AtomicReference<>();
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -752,7 +752,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -788,7 +788,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() {
+        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/operators/SimpleQueueTest.java
+++ b/src/test/java/io/reactivex/rxjava4/operators/SimpleQueueTest.java
@@ -112,7 +112,7 @@ public class SimpleQueueTest extends RxJavaTest {
 
         final AtomicInteger c = new AtomicInteger(3);
 
-        Thread t1 = new Thread(new Runnable() {
+        Thread t1 = new Thread(new Runnable() /* NFI */ {
             int i;
             @Override
             public void run() {
@@ -126,7 +126,7 @@ public class SimpleQueueTest extends RxJavaTest {
         });
         t1.start();
 
-        Thread t2 = new Thread(new Runnable() {
+        Thread t2 = new Thread(new Runnable() /* NFI */ {
             int i = 10000;
             @Override
             public void run() {
@@ -140,7 +140,7 @@ public class SimpleQueueTest extends RxJavaTest {
         });
         t2.start();
 
-        Runnable r3 = new Runnable() {
+        Runnable r3 = new Runnable() /* NFI */ {
             int i = 20000;
             @Override
             public void run() {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
@@ -127,7 +127,7 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(new Consumer<Integer>() /* NFI */ {
             int count;
             @Override
             public void accept(Integer v) throws Exception {
@@ -247,7 +247,7 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() {
+        .doOnNext(new Consumer<Integer>() /* NFI */ {
             int count;
             @Override
             public void accept(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
@@ -132,7 +132,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
+        .filter(new Predicate<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean test(Integer v) throws Exception {
@@ -230,7 +230,7 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() {
+        .filter(new Predicate<Integer>() /* NFI */ {
             int count;
             @Override
             public boolean test(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
@@ -38,7 +38,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
 
     @Test
     public void sourceOverflow() {
-        new Flowable<Integer>() {
+        new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -216,7 +216,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void requestUnboundedRace() {
-        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() {
+        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Integer t) {
@@ -249,7 +249,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void requestRace() {
-        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() {
+        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
@@ -32,7 +32,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void overflowFastpath() {
-        new ParallelFlowable<Integer>() {
+        new ParallelFlowable<Integer>() /* NFI */ {
             @Override
             public void subscribe(Subscriber<? super Integer>[] subscribers) {
                 subscribers[0].onSubscribe(new BooleanSubscription());
@@ -56,7 +56,7 @@ public class ParallelJoinTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         final Subscriber<? super Integer>[] subs = new Subscriber[1];
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -65,7 +65,7 @@ public class ParallelJoinTest extends RxJavaTest {
             }
         };
 
-        new ParallelFlowable<Integer>() {
+        new ParallelFlowable<Integer>() /* NFI */ {
             @Override
             public void subscribe(Subscriber<? super Integer>[] subscribers) {
                 subs[0] = subscribers[0];
@@ -95,7 +95,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void overflowFastpathDelayError() {
-        new ParallelFlowable<Integer>() {
+        new ParallelFlowable<Integer>() /* NFI */ {
             @Override
             public void subscribe(Subscriber<? super Integer>[] subscribers) {
                 subscribers[0].onSubscribe(new BooleanSubscription());
@@ -119,7 +119,7 @@ public class ParallelJoinTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         final Subscriber<? super Integer>[] subs = new Subscriber[1];
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -130,7 +130,7 @@ public class ParallelJoinTest extends RxJavaTest {
             }
         };
 
-        new ParallelFlowable<Integer>() {
+        new ParallelFlowable<Integer>() /* NFI */ {
             @Override
             public void subscribe(Subscriber<? super Integer>[] subscribers) {
                 subs[0] = subscribers[0];
@@ -241,7 +241,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void consumerCancelsAfterOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -260,7 +260,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void delayErrorConsumerCancelsAfterOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -375,7 +375,7 @@ public class ParallelJoinTest extends RxJavaTest {
     public void onNextWhileProcessingSlowPath() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -399,7 +399,7 @@ public class ParallelJoinTest extends RxJavaTest {
     public void delayErrorOnNextWhileProcessingSlowPath() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -435,14 +435,14 @@ public class ParallelJoinTest extends RxJavaTest {
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
                 AtomicReference<Subscriber<? super Integer>> ref2 = new AtomicReference<>();
 
-                Flowable<Integer> f1 = new Flowable<Integer>() {
+                Flowable<Integer> f1 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
                         ref1.set(s);
                     }
                 };
-                Flowable<Integer> f2 = new Flowable<Integer>() {
+                Flowable<Integer> f2 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
@@ -479,14 +479,14 @@ public class ParallelJoinTest extends RxJavaTest {
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
                 AtomicReference<Subscriber<? super Integer>> ref2 = new AtomicReference<>();
 
-                Flowable<Integer> f1 = new Flowable<Integer>() {
+                Flowable<Integer> f1 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
                         ref1.set(s);
                     }
                 };
-                Flowable<Integer> f2 = new Flowable<Integer>() {
+                Flowable<Integer> f2 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
@@ -176,7 +176,7 @@ public class ParallelMapTest extends RxJavaTest {
 
     @Test
     public void conditionalCancelIgnored() {
-        Flowable<Integer> f = new Flowable<Integer>() {
+        Flowable<Integer> f = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super @NonNull Integer> s) {
                 @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTryTest.java
@@ -107,7 +107,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
+        .map(new Function<Integer, Integer>() /* NFI */ {
             int count;
             @Override
             public Integer apply(Integer v) throws Exception {
@@ -205,7 +205,7 @@ public class ParallelMapTryTest extends RxJavaTest implements Consumer<Object> {
     public void mapFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .map(new Function<Integer, Integer>() {
+        .map(new Function<Integer, Integer>() /* NFI */ {
             int count;
             @Override
             public Integer apply(Integer v) throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
@@ -75,7 +75,7 @@ public class ParallelRunOnTest extends RxJavaTest {
 
     @Test
     public void missingBackpressure() {
-        new ParallelFlowable<Integer>() {
+        new ParallelFlowable<Integer>() /* NFI */ {
             @Override
             public int parallelism() {
                 return 1;
@@ -238,7 +238,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @Test
     public void normalCancelAfterRequest1() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -259,7 +259,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @Test
     public void conditionalCancelAfterRequest1() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -475,7 +475,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void observableStart() {
         try {
-            RxJavaPlugins.setOnObservableSubscribe((_, t) -> new Observer() {
+            RxJavaPlugins.setOnObservableSubscribe((_, t) -> new Observer() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Disposable d) {
@@ -520,7 +520,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void flowableStart() {
         try {
-            RxJavaPlugins.setOnFlowableSubscribe((_, t) -> new Subscriber() {
+            RxJavaPlugins.setOnFlowableSubscribe((_, t) -> new Subscriber() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -566,7 +566,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             RxJavaPlugins.setOnParallelSubscribe((_, t) -> {
                     var result = new Subscriber<?>[] {
-                        new Subscriber<Object>() {
+                        new Subscriber<Object>() /* NFI */ {
 
                             @Override
                             public void onSubscribe(Subscription s) {
@@ -639,7 +639,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void singleStart() {
         try {
-            RxJavaPlugins.setOnSingleSubscribe((_, t) -> new SingleObserver<Object>() {
+            RxJavaPlugins.setOnSingleSubscribe((_, t) -> new SingleObserver<Object>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Disposable d) {
@@ -699,7 +699,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void completableStart() {
         try {
-            RxJavaPlugins.setOnCompletableSubscribe((_, t) -> new CompletableObserver() {
+            RxJavaPlugins.setOnCompletableSubscribe((_, t) -> new CompletableObserver() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     t.onSubscribe(d);
@@ -968,14 +968,14 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             assertNull(RxJavaPlugins.onAssembly((ConnectableFlowable)null));
 
-            Observable oos = new Observable() {
+            Observable oos = new Observable( /* NFI */) /* NFI */ {
                 @Override
                 public void subscribeActual(Observer t) {
 
                 }
             };
 
-            Flowable fos = new Flowable() {
+            Flowable fos = new Flowable() /* NFI */ {
                 @Override
                 public void subscribeActual(Subscriber t) {
 
@@ -988,7 +988,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             assertNull(RxJavaPlugins.onAssembly((Single)null));
 
-            Single sos = new Single() {
+            Single sos = new Single() /* NFI */ {
                 @Override
                 public void subscribeActual(SingleObserver t) {
 
@@ -999,7 +999,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             assertNull(RxJavaPlugins.onAssembly((Completable)null));
 
-            Completable cos = new Completable() {
+            Completable cos = new Completable() /* NFI */ {
                 @Override
                 public void subscribeActual(CompletableObserver t) {
 
@@ -1010,7 +1010,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
             assertNull(RxJavaPlugins.onAssembly((Maybe)null));
 
-            Maybe myb = new Maybe() {
+            Maybe myb = new Maybe() /* NFI */ {
                 @Override
                 public void subscribeActual(MaybeObserver t) {
 
@@ -1128,7 +1128,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideConnectableObservable() {
         try {
-            RxJavaPlugins.setOnConnectableObservableAssembly(_ -> new ConnectableObservable() {
+            RxJavaPlugins.setOnConnectableObservableAssembly(_ -> new ConnectableObservable() /* NFI */ {
 
                 @Override
                 public void connect(Consumer connection) {
@@ -1172,7 +1172,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void overrideConnectableFlowable() {
         try {
-            RxJavaPlugins.setOnConnectableFlowableAssembly(_ -> new ConnectableFlowable() {
+            RxJavaPlugins.setOnConnectableFlowableAssembly(_ -> new ConnectableFlowable() /* NFI */ {
 
                 @Override
                 public void connect(Consumer connection) {
@@ -1325,7 +1325,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @SuppressWarnings("rawtypes")
     public void maybeStart() {
         try {
-            RxJavaPlugins.setOnMaybeSubscribe((_, t) -> new MaybeObserver() {
+            RxJavaPlugins.setOnMaybeSubscribe((_, t) -> new MaybeObserver() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     t.onSubscribe(d);

--- a/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
@@ -434,7 +434,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
         final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
+        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 ts2.cancel();
@@ -458,7 +458,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
         final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
+        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 ts2.cancel();
@@ -480,7 +480,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
         final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() {
+        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
             @Override
             public void onComplete() {
                 ts2.cancel();

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -256,7 +256,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() {
+                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         subscriber.onNext(t);
@@ -383,7 +383,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultSubscriber<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
@@ -231,7 +231,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -259,7 +259,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -287,7 +287,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -316,7 +316,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>(1);
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(1) {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -345,7 +345,7 @@ public class MulticastProcessorTest extends RxJavaTest {
         try {
             MulticastProcessor<Integer> mp = MulticastProcessor.create(false);
 
-            mp.subscribe(new FlowableSubscriber<Integer>() {
+            mp.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
@@ -296,7 +296,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() {
+                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         subscriber.onNext(t);
@@ -394,7 +394,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void crossCancel() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -418,7 +418,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -441,7 +441,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void crossCancelOnComplete() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -482,7 +482,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
         TestSubscriber<Integer> ts = pp.test();
 
-        pp.subscribe(new FlowableSubscriber<Integer>() {
+        pp.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -48,7 +48,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Subscriber<Long> slow = new DefaultSubscriber<Long>() {
+            Subscriber<Long> slow = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -85,7 +85,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Subscriber<Long> fast = new DefaultSubscriber<Long>() {
+            Subscriber<Long> fast = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -313,7 +313,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
                 .subscribeOn(s)
                 .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
-                .subscribe(new DefaultSubscriber<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
 
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -48,7 +48,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Subscriber<Long> slow = new DefaultSubscriber<Long>() {
+            Subscriber<Long> slow = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -85,7 +85,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Subscriber<Long> fast = new DefaultSubscriber<Long>() {
+            Subscriber<Long> fast = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -305,7 +305,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultSubscriber<Object>() {
+                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
@@ -264,7 +264,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
-        Subscriber<String> subscriber1 = new DefaultSubscriber<String>() {
+        Subscriber<String> subscriber1 = new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -288,7 +288,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Subscriber<String> subscriber2 = new DefaultSubscriber<String>() {
+        Subscriber<String> subscriber2 = new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -383,7 +383,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() {
+                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
@@ -415,7 +415,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(new DefaultSubscriber<Integer>() {
+        source.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -1173,7 +1173,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rp.onNext(2);
         rp.onNext(3);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -1209,7 +1209,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rp.onNext(2);
         rp.onNext(3);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -1229,7 +1229,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1253,7 +1253,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1431,7 +1431,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     TestSubscriber<Integer> take1AndCancel() {
-        return new TestSubscriber<Integer>(1) {
+        return new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
@@ -590,7 +590,7 @@ public class SerializedProcessorTest extends RxJavaTest {
     public void onErrorQueued() {
         FlowableProcessor<Integer> sp = PublishProcessor.<Integer>create().toSerialized();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -52,7 +52,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                 })
                 .subscribeOn(getScheduler())
                 .observeOn(getScheduler())
-                .subscribe(new DefaultSubscriber<Long>() {
+                .subscribe(new DefaultSubscriber<Long>() /* NFI */ {
                     @Override
                     public void onComplete() {
                         System.out.println("--- completed");
@@ -93,37 +93,30 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final AtomicInteger counter = new AtomicInteger();
         final Worker inner = getScheduler().createWorker();
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(() -> inner.schedule(new Runnable() /* NFI */ {
+
+                int i;
 
                 @Override
                 public void run() {
-                    inner.schedule(new Runnable() {
-
-                        int i;
-
-                        @Override
-                        public void run() {
-                            System.out.println("Run: " + i++);
-                            if (i == 10) {
-                                latch.countDown();
-                                try {
-                                    // wait for unsubscribe to finish so we are not racing it
-                                    unsubscribeLatch.await();
-                                } catch (InterruptedException e) {
-                                    // we expect the countDown if unsubscribe is not working
-                                    // or to be interrupted if unsubscribe is successful since
-                                    // unsubscribe will interrupt it as it is calling Future.cancel(true)
-                                    // so we will ignore the stacktrace
-                                }
-                            }
-
-                            counter.incrementAndGet();
-                            inner.schedule(this);
+                    System.out.println("Run: " + i++);
+                    if (i == 10) {
+                        latch.countDown();
+                        try {
+                            // wait for unsubscribe to finish so we are not racing it
+                            unsubscribeLatch.await();
+                        } catch (InterruptedException e) {
+                            // we expect the countDown if unsubscribe is not working
+                            // or to be interrupted if unsubscribe is successful since
+                            // unsubscribe will interrupt it as it is calling Future.cancel(true)
+                            // so we will ignore the stacktrace
                         }
-                    });
-                }
+                    }
 
-            });
+                    counter.incrementAndGet();
+                    inner.schedule(this);
+                }
+            }));
 
             latch.await();
             inner.dispose();
@@ -141,28 +134,21 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final AtomicInteger counter = new AtomicInteger();
         final Worker inner = getScheduler().createWorker();
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(() -> inner.schedule(new Runnable() /* NFI */ {
+
+                int i;
 
                 @Override
                 public void run() {
-                    inner.schedule(new Runnable() {
+                    System.out.println("Run: " + i++);
+                    if (i == 10) {
+                        inner.dispose();
+                    }
 
-                        int i;
-
-                        @Override
-                        public void run() {
-                            System.out.println("Run: " + i++);
-                            if (i == 10) {
-                                inner.dispose();
-                            }
-
-                            counter.incrementAndGet();
-                            inner.schedule(this);
-                        }
-                    });
+                    counter.incrementAndGet();
+                    inner.schedule(this);
                 }
-
-            });
+            }));
 
             unsubscribeLatch.countDown();
             Thread.sleep(200); // let time pass to see if the scheduler is still doing work
@@ -180,35 +166,29 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final Worker inner = getScheduler().createWorker();
 
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(() -> inner.schedule(new Runnable() /* NFI */ {
+
+                long i = 1L;
 
                 @Override
                 public void run() {
-                    inner.schedule(new Runnable() {
-
-                        long i = 1L;
-
-                        @Override
-                        public void run() {
-                            if (i++ == 10) {
-                                latch.countDown();
-                                try {
-                                    // wait for unsubscribe to finish so we are not racing it
-                                    unsubscribeLatch.await();
-                                } catch (InterruptedException e) {
-                                    // we expect the countDown if unsubscribe is not working
-                                    // or to be interrupted if unsubscribe is successful since
-                                    // unsubscribe will interrupt it as it is calling Future.cancel(true)
-                                    // so we will ignore the stacktrace
-                                }
-                            }
-
-                            counter.incrementAndGet();
-                            inner.schedule(this, 10, TimeUnit.MILLISECONDS);
+                    if (i++ == 10) {
+                        latch.countDown();
+                        try {
+                            // wait for unsubscribe to finish so we are not racing it
+                            unsubscribeLatch.await();
+                        } catch (InterruptedException e) {
+                            // we expect the countDown if unsubscribe is not working
+                            // or to be interrupted if unsubscribe is successful since
+                            // unsubscribe will interrupt it as it is calling Future.cancel(true)
+                            // so we will ignore the stacktrace
                         }
-                    }, 10, TimeUnit.MILLISECONDS);
+                    }
+
+                    counter.incrementAndGet();
+                    inner.schedule(this, 10, TimeUnit.MILLISECONDS);
                 }
-            });
+            }, 10, TimeUnit.MILLISECONDS));
 
             latch.await();
             inner.dispose();
@@ -225,7 +205,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 int i;
 
@@ -254,7 +234,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch latch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 private long i;
 
@@ -285,10 +265,10 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
+            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
                 @Override
                 public void subscribe(final Subscriber<? super Integer> subscriber) {
-                    inner.schedule(new Runnable() {
+                    inner.schedule(new Runnable() /* NFI */ {
                         @Override
                         public void run() {
                             subscriber.onNext(42);
@@ -299,7 +279,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                         }
                     });
 
-                    subscriber.onSubscribe(new Subscription() {
+                    subscriber.onSubscribe(new Subscription() /* NFI */ {
 
                         @Override
                         public void cancel() {
@@ -319,7 +299,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
             final AtomicInteger count = new AtomicInteger();
             final AtomicBoolean completed = new AtomicBoolean(false);
-            ResourceSubscriber<Integer> s = new ResourceSubscriber<Integer>() {
+            ResourceSubscriber<Integer> s = new ResourceSubscriber<Integer>() /* NFI */ {
                 @Override
                 public void onComplete() {
                     System.out.println("Completed");

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -274,26 +274,27 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                             subscriber.onNext(42);
                             latch.countDown();
 
-                        // this will recursively schedule this task for execution again
-                        inner.schedule(this);
-                    }
-                });
+                            // this will recursively schedule this task for execution again
+                            inner.schedule(this);
+                        }
+                    });
 
-                subscriber.onSubscribe(new Subscription() /* NFI */ {
+                    subscriber.onSubscribe(new Subscription() /* NFI */ {
 
-                    @Override
-                    public void cancel() {
-                        inner.dispose();
-                        subscriber.onComplete();
-                        completionLatch.countDown();
-                    }
+                        @Override
+                        public void cancel() {
+                            inner.dispose();
+                            subscriber.onComplete();
+                            completionLatch.countDown();
+                        }
 
-                    @Override
-                    public void request(long n) {
+                        @Override
+                        public void request(long n) {
 
-                    }
-                });
+                        }
+                    });
 
+                }
             });
 
             final AtomicInteger count = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
@@ -224,7 +224,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
             final AtomicInteger i = new AtomicInteger();
             final CountDownLatch latch = new CountDownLatch(1);
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 @Override
                 public void run() {
@@ -252,7 +252,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final AtomicInteger i = new AtomicInteger();
             final CountDownLatch latch = new CountDownLatch(1);
 
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 int state;
 
@@ -277,35 +277,32 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
 
     @Test
     public final void recursiveSchedulerInObservable() {
-        Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() {
-            @Override
-            public void subscribe(final Subscriber<? super Integer> subscriber) {
-                final Scheduler.Worker inner = getScheduler().createWorker();
+        Flowable<Integer> obs = Flowable.unsafeCreate(subscriber -> {
+            final Scheduler.Worker inner = getScheduler().createWorker();
 
-                AsyncSubscription as = new AsyncSubscription();
-                subscriber.onSubscribe(as);
-                as.setResource(inner);
+            AsyncSubscription as = new AsyncSubscription();
+            subscriber.onSubscribe(as);
+            as.setResource(inner);
 
-                inner.schedule(new Runnable() {
-                    int i;
+            inner.schedule(new Runnable() /* NFI */ {
+                int i;
 
-                    @Override
-                    public void run() {
-                        if (i > 42) {
-                            try {
-                                subscriber.onComplete();
-                            } finally {
-                                inner.dispose();
-                            }
-                            return;
+                @Override
+                public void run() {
+                    if (i > 42) {
+                        try {
+                            subscriber.onComplete();
+                        } finally {
+                            inner.dispose();
                         }
-
-                        subscriber.onNext(i++);
-
-                        inner.schedule(this);
+                        return;
                     }
-                });
-            }
+
+                    subscriber.onNext(i++);
+
+                    inner.schedule(this);
+                }
+            });
         });
 
         final AtomicInteger lastValue = new AtomicInteger();
@@ -491,7 +488,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             final SequentialDisposable sd = new SequentialDisposable();
 
             try {
-                sd.replace(s.schedulePeriodicallyDirect(new Runnable() {
+                sd.replace(s.schedulePeriodicallyDirect(new Runnable() /* NFI */ {
                     int count;
 
                     @Override
@@ -527,7 +524,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
             Scheduler.Worker w = s.createWorker();
 
             try {
-                sd.replace(w.schedulePeriodically(new Runnable() {
+                sd.replace(w.schedulePeriodically(new Runnable() /* NFI */ {
                     int count;
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
@@ -46,7 +46,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         final Scheduler.Worker inner = Schedulers.computation().createWorker();
 
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 private HashMap<String, Integer> statefulMap = map;
                 int nonThreadSafeCounter;

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -223,11 +223,11 @@ public class SchedulerTest extends RxJavaTest {
 
     @Test
     public void defaultSchedulePeriodicallyDirectRejects() {
-        Scheduler s = new Scheduler() {
+        Scheduler s = new Scheduler() /* NFI */ {
             @NonNull
             @Override
             public Worker createWorker() {
-                return new Worker() {
+                return new Worker() /* NFI */ {
                     @NonNull
                     @Override
                     public Disposable schedule(@NonNull Runnable run, long delay, @NonNull TimeUnit unit) {
@@ -309,10 +309,10 @@ public class SchedulerTest extends RxJavaTest {
         final Runnable runnable = () -> {
         };
 
-        Scheduler scheduler = new Scheduler() {
+        Scheduler scheduler = new Scheduler() /* NFI */ {
             @Override
             public Worker createWorker() {
-                return new Worker() {
+                return new Worker() /* NFI */ {
                     @Override
                     public Disposable schedule(Runnable run, long delay, TimeUnit unit) {
                         SchedulerRunnableIntrospection outerWrapper = (SchedulerRunnableIntrospection) run;

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerWorkerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerWorkerTest.java
@@ -32,7 +32,7 @@ public class SchedulerWorkerTest extends RxJavaTest {
         @Override
         public Worker createWorker() {
             final Worker w = Schedulers.computation().createWorker();
-            return new Worker() {
+            return new Worker() /* NFI */ {
 
                 @Override
                 public void dispose() {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
@@ -136,7 +136,7 @@ public class TestSchedulerTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger(0);
 
         try {
-            inner.schedule(new Runnable() {
+            inner.schedule(new Runnable() /* NFI */ {
 
                 @Override
                 public void run() {
@@ -160,7 +160,7 @@ public class TestSchedulerTest extends RxJavaTest {
         try {
             final AtomicInteger counter = new AtomicInteger(0);
 
-            final Disposable subscription = inner.schedule(new Runnable() {
+            final Disposable subscription = inner.schedule(new Runnable() /* NFI */ {
 
                 @Override
                 public void run() {
@@ -186,21 +186,18 @@ public class TestSchedulerTest extends RxJavaTest {
             final Runnable calledOp = mock(Runnable.class);
 
             Flowable<Object> poller;
-            poller = Flowable.unsafeCreate(new Publisher<Object>() {
-                @Override
-                public void subscribe(final Subscriber<? super Object> aSubscriber) {
-                    final BooleanSubscription bs = new BooleanSubscription();
-                    aSubscriber.onSubscribe(bs);
-                    inner.schedule(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!bs.isCancelled()) {
-                                calledOp.run();
-                                inner.schedule(this, 5, TimeUnit.SECONDS);
-                            }
+            poller = Flowable.unsafeCreate(aSubscriber -> {
+                final BooleanSubscription bs = new BooleanSubscription();
+                aSubscriber.onSubscribe(bs);
+                inner.schedule(new Runnable() /* NFI */ {
+                    @Override
+                    public void run() {
+                        if (!bs.isCancelled()) {
+                            calledOp.run();
+                            inner.schedule(this, 5, TimeUnit.SECONDS);
                         }
-                    });
-                }
+                    }
+                });
             });
 
             InOrder inOrder = Mockito.inOrder(calledOp);
@@ -225,7 +222,7 @@ public class TestSchedulerTest extends RxJavaTest {
 
     @Test
     public void timedRunnableToString() {
-        TimedRunnable r = new TimedRunnable((TestWorker) new TestScheduler().createWorker(), 5, new Runnable() {
+        TimedRunnable r = new TimedRunnable((TestWorker) new TestScheduler().createWorker(), 5, new Runnable() /* NFI */ {
             @Override
             public void run() {
                 // deliberately no-op

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.mockito.*;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;

--- a/src/test/java/io/reactivex/rxjava4/single/SingleCacheMainTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleCacheMainTest.java
@@ -21,7 +21,7 @@ import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
-public class SingleCacheTest extends RxJavaTest {
+public class SingleCacheMainTest extends RxJavaTest {
 
     @Test
     public void normal() {
@@ -91,7 +91,7 @@ public class SingleCacheTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -114,9 +114,9 @@ public class SingleCacheTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         Single<Integer> cache = ps.single(-99).cache();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
+        final var ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);

--- a/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
@@ -71,7 +71,7 @@ public class SingleSubscribeTest extends RxJavaTest {
     @Test
     public void subscribeThrows() {
         try {
-            new Single<Integer>() {
+            new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
                     throw new IllegalArgumentException();

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -43,7 +43,8 @@ public class SingleTest extends RxJavaTest {
     @Test
     public void helloWorld2() {
         final AtomicReference<String> v = new AtomicReference<>();
-        Single.just("Hello World!").subscribe(new SingleObserver<String>() {
+        Single.just("Hello World!")
+        .subscribe(new SingleObserver<String>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -254,7 +255,7 @@ public class SingleTest extends RxJavaTest {
     public void unsubscribe2() throws InterruptedException {
         @SuppressWarnings("resource")
         final SerialDisposable sd = new SerialDisposable();
-        SingleObserver<String> ts = new SingleObserver<String>() {
+        var ts = new SingleObserver<String>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -494,7 +495,7 @@ public class SingleTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void implementationThrows() {
-        new Single<Integer>() {
+        new Single<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Integer> observer) {
                 throw new NullPointerException();

--- a/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
@@ -428,7 +428,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         AsyncSubject<Object> p = AsyncSubject.create();
 
         final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() {
+        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 to2.dispose();
@@ -452,7 +452,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         AsyncSubject<Object> p = AsyncSubject.create();
 
         final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() {
+        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 to2.dispose();
@@ -474,7 +474,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
         AsyncSubject<Object> p = AsyncSubject.create();
 
         final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() {
+        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
             @Override
             public void onComplete() {
                 to2.dispose();

--- a/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
@@ -256,7 +256,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultObserver<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);
@@ -383,7 +383,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultObserver<Object>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -613,7 +613,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
     @Test
     public void innerDisposed() {
         BehaviorSubject.create()
-        .subscribe(new Observer<Object>() {
+        .subscribe(new Observer<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subjects/CompletableSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/CompletableSubjectTest.java
@@ -162,7 +162,7 @@ public class CompletableSubjectTest extends RxJavaTest {
     @Test
     public void disposeTwice() {
         CompletableSubject.create()
-        .subscribe(new CompletableObserver() {
+        .subscribe(new CompletableObserver() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
@@ -202,7 +202,7 @@ public class MaybeSubjectTest extends RxJavaTest {
     @Test
     public void disposeTwice() {
         MaybeSubject.create()
-        .subscribe(new MaybeObserver<Object>() {
+        .subscribe(new MaybeObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/PublishSubjectTest.java
@@ -296,7 +296,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultObserver<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);
@@ -374,7 +374,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @Test
     public void crossCancel() {
         final TestObserver<Integer> to1 = new TestObserver<>();
-        TestObserver<Integer> to2 = new TestObserver<Integer>() {
+        var to2 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -398,7 +398,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestObserver<Integer> to1 = new TestObserver<>();
-        TestObserver<Integer> to2 = new TestObserver<Integer>() {
+        TestObserver<Integer> to2 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -421,7 +421,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @Test
     public void crossCancelOnComplete() {
         final TestObserver<Integer> to1 = new TestObserver<>();
-        TestObserver<Integer> to2 = new TestObserver<Integer>() {
+        TestObserver<Integer> to2 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -447,7 +447,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
         TestObserver<Integer> to = ps.test();
 
-        ps.subscribe(new Observer<Integer>() {
+        ps.subscribe(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -51,7 +51,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Observer<Long> slow = new DefaultObserver<Long>() {
+            Observer<Long> slow = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -88,7 +88,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Observer<Long> fast = new DefaultObserver<Long>() {
+            Observer<Long> fast = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -317,7 +317,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
                 .subscribeOn(s)
                 .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultObserver<Object>() /* NFI */ {
 
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -51,7 +51,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Observer<Long> slow = new DefaultObserver<Long>() {
+            Observer<Long> slow = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -88,7 +88,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Observer<Long> fast = new DefaultObserver<Long>() {
+            Observer<Long> fast = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -309,7 +309,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultObserver<Object>() {
+                .subscribe(new DefaultObserver<Object>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
@@ -261,7 +261,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
-        Observer<String> observer1 = new DefaultObserver<String>() {
+        Observer<String> observer1 = new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -285,7 +285,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Observer<String> observer2 = new DefaultObserver<String>() {
+        Observer<String> observer2 = new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -381,7 +381,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() {
+                .subscribe(new DefaultObserver<String>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
@@ -413,7 +413,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final Observer<Integer> o = TestHelper.mockObserver();
 
-        source.subscribe(new DefaultObserver<Integer>() {
+        source.subscribe(new DefaultObserver<Integer>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -1082,7 +1082,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final ReplaySubject<Integer> rp = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
@@ -591,7 +591,7 @@ public class SerializedSubjectTest extends RxJavaTest {
     public void onErrorQueued() {
         Subject<Integer> sp = PublishSubject.<Integer>create().toSerialized();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -615,7 +615,7 @@ public class SerializedSubjectTest extends RxJavaTest {
     public void onCompleteQueued() {
         Subject<Integer> sp = PublishSubject.<Integer>create().toSerialized();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() {
+        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
@@ -182,7 +182,7 @@ public class SingleSubjectTest extends RxJavaTest {
     @Test
     public void disposeTwice() {
         SingleSubject.create()
-        .subscribe(new SingleObserver<Object>() {
+        .subscribe(new SingleObserver<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
@@ -201,7 +201,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void request() {
-        TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<Integer>() {
+        var tc = new TestResourceSubscriber<Integer>() /* NFI */ {
             @Override
             protected void onStart() {
                 start++;

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
@@ -140,7 +140,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         @Override
         public void subscribe(Subscriber<? super String> subscriber) {
             this.subscriber = subscriber;
-            subscriber.onSubscribe(new Subscription() {
+            subscriber.onSubscribe(new Subscription() /* NFI */ {
 
                 @Override
                 public void cancel() {
@@ -222,7 +222,7 @@ public class SafeSubscriberTest extends RxJavaTest {
         }
     }
 
-    static final Subscription THROWING_DISPOSABLE = new Subscription() {
+    static final Subscription THROWING_DISPOSABLE = new Subscription() /* NFI */ {
 
         @Override
         public void cancel() {
@@ -237,7 +237,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     };
 
     private static Subscriber<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultSubscriber<String>() {
+        return new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -258,7 +258,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
-        return new DefaultSubscriber<String>() {
+        return new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -279,7 +279,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> subscriberOnErrorFail() {
-        return new DefaultSubscriber<String>() {
+        return new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -300,7 +300,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultSubscriber<String>() {
+        return new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -329,7 +329,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void actual() {
-        Subscriber<Integer> actual = new DefaultSubscriber<Integer>() {
+        Subscriber<Integer> actual = new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
@@ -278,7 +278,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestSubscriberEx<String> ts = new TestSubscriberEx<>(new DefaultSubscriber<String>() {
+                var ts = new TestSubscriberEx<>(new DefaultSubscriber<String>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -359,7 +359,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestSubscriber<String> ts = new TestSubscriber<>(new DefaultSubscriber<String>() {
+        TestSubscriber<String> ts = new TestSubscriber<>(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -387,7 +387,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         AtomicInteger p2 = new AtomicInteger();
 
         subscriber.onSubscribe(new BooleanSubscription());
-        ResourceSubscriber<String> as1 = new ResourceSubscriber<String>() {
+        ResourceSubscriber<String> as1 = new ResourceSubscriber<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 subscriber.onNext(t);
@@ -404,7 +404,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
             }
         };
 
-        ResourceSubscriber<String> as2 = new ResourceSubscriber<String>() {
+        ResourceSubscriber<String> as2 = new ResourceSubscriber<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 subscriber.onNext(t);
@@ -835,7 +835,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         try {
             final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+            TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer v) {
                     serial.get().onError(new TestException());
@@ -862,7 +862,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     public void completeReentry() {
         final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer v) {
                 serial.get().onComplete();
@@ -1078,7 +1078,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedSubscriber<Integer>> ssRef = new AtomicReference<>();
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -629,13 +629,13 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void onCompletedCrashCountsDownLatch() {
-        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>() {
+        var ts0 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 throw new TestException();
             }
         };
-        TestSubscriber<Integer> ts = new TestSubscriber<>(ts0);
+        var ts = new TestSubscriber<>(ts0);
 
         try {
             ts.onComplete();
@@ -648,7 +648,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorCrashCountsDownLatch() {
-        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>() {
+        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable e) {
                 throw new TestException();
@@ -1260,7 +1260,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1296,7 +1296,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() {
+        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -310,7 +310,7 @@ public enum TestHelper {
         try {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            source.subscribe(new FlowableSubscriber<Object>() {
+            source.subscribe(new FlowableSubscriber<Object>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -363,7 +363,7 @@ public enum TestHelper {
         try {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            FlowableSubscriber<Object> bad = new FlowableSubscriber<Object>() {
+            var bad = new FlowableSubscriber<Object>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -691,7 +691,7 @@ public enum TestHelper {
      */
     public static <T> void checkDisposed(Flowable<T> source) {
         final TestSubscriber<Object> ts = new TestSubscriber<>(0L);
-        source.subscribe(new FlowableSubscriber<Object>() {
+        source.subscribe(new FlowableSubscriber<Object>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 ts.onSubscribe(new BooleanSubscription());
@@ -726,7 +726,7 @@ public enum TestHelper {
     public static void checkDisposed(Maybe<?> source) {
         final Boolean[] b = { null, null };
         final CountDownLatch cdl = new CountDownLatch(1);
-        source.subscribe(new MaybeObserver<Object>() {
+        source.subscribe(new MaybeObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -777,7 +777,7 @@ public enum TestHelper {
     public static void checkDisposed(Observable<?> source) {
         final Boolean[] b = { null, null };
         final CountDownLatch cdl = new CountDownLatch(1);
-        source.subscribe(new Observer<Object>() {
+        source.subscribe(new Observer<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -828,7 +828,7 @@ public enum TestHelper {
     public static void checkDisposed(Single<?> source) {
         final Boolean[] b = { null, null };
         final CountDownLatch cdl = new CountDownLatch(1);
-        source.subscribe(new SingleObserver<Object>() {
+        source.subscribe(new SingleObserver<Object>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -874,7 +874,7 @@ public enum TestHelper {
     public static void checkDisposed(Completable source) {
         final Boolean[] b = { null, null };
         final CountDownLatch cdl = new CountDownLatch(1);
-        source.subscribe(new CompletableObserver() {
+        source.subscribe(new CompletableObserver() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -962,7 +962,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() {
+            Maybe<T> source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1016,7 +1016,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() {
+            Maybe<T> source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1070,7 +1070,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() {
+            Maybe<T> source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1124,7 +1124,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() {
+            Maybe<T> source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1178,7 +1178,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() {
+            Single<T> source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1232,7 +1232,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() {
+            Single<T> source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1286,7 +1286,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() {
+            Single<T> source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1339,7 +1339,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() {
+            Maybe<T> source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1393,7 +1393,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() {
+            Single<T> source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1447,7 +1447,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() {
+            Flowable<T> source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1501,7 +1501,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null, null, null };
             final CountDownLatch cdl = new CountDownLatch(2);
 
-            ParallelFlowable<T> source = new ParallelFlowable<T>() {
+            ParallelFlowable<T> source = new ParallelFlowable<T>() /* NFI */ {
                 @Override
                 public void subscribe(Subscriber<? super T>[] subscribers) {
                     for (int i = 0; i < subscribers.length; i++) {
@@ -1564,7 +1564,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null, null, null };
             final CountDownLatch cdl = new CountDownLatch(2);
 
-            ParallelFlowable<T> source = new ParallelFlowable<T>() {
+            ParallelFlowable<T> source = new ParallelFlowable<T>() /* NFI */ {
                 @Override
                 public void subscribe(Subscriber<? super T>[] subscribers) {
                     for (int i = 0; i < subscribers.length; i++) {
@@ -1629,7 +1629,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() {
+            Observable<T> source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1683,7 +1683,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() {
+            Observable<T> source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1737,7 +1737,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() {
+            Observable<T> source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1790,7 +1790,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() {
+            Observable<T> source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1844,7 +1844,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() {
+            Flowable<T> source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1898,7 +1898,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() {
+            Flowable<T> source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1952,7 +1952,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() {
+            Flowable<T> source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -2005,7 +2005,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() {
+            Flowable<T> source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -2057,7 +2057,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Completable source = new Completable() {
+            Completable source = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     try {
@@ -2110,7 +2110,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Completable source = new Completable() {
+            Completable source = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     try {
@@ -2163,7 +2163,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Completable source = new Completable() {
+            Completable source = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     try {
@@ -2215,7 +2215,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Completable source = new Completable() {
+            Completable source = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     try {
@@ -2267,7 +2267,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Completable source = new Completable() {
+            Completable source = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
                     try {
@@ -2527,7 +2527,7 @@ public enum TestHelper {
 
         final Boolean[] state = { null, null, null, null };
 
-        source.subscribe(new Observer<T>() {
+        source.subscribe(new Observer<T>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 try {
@@ -2593,7 +2593,7 @@ public enum TestHelper {
 
         final Boolean[] state = { null, null, null, null };
 
-        source.subscribe(new FlowableSubscriber<T>() {
+        source.subscribe(new FlowableSubscriber<T>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 try {
@@ -2681,7 +2681,7 @@ public enum TestHelper {
             final boolean error, final T goodValue, final T badValue, final Object... expected) {
         List<Throwable> errors = trackPluginErrors();
         try {
-            Observable<T> bad = new Observable<T>() {
+            Observable<T> bad = new Observable<T>() /* NFI */ {
                 boolean once;
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
@@ -2846,7 +2846,7 @@ public enum TestHelper {
             final boolean error, final T goodValue, final T badValue, final Object... expected) {
         List<Throwable> errors = trackPluginErrors();
         try {
-            Flowable<T> bad = new Flowable<T>() {
+            Flowable<T> bad = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -3014,10 +3014,10 @@ public enum TestHelper {
      * @return the new Observable
      */
     public static <T> Observable<T> rejectObservableFusion() {
-        return new Observable<T>() {
+        return new Observable<T>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super T> observer) {
-                observer.onSubscribe(new QueueDisposable<T>() {
+                observer.onSubscribe(new QueueDisposable<T>() /* NFI */ {
 
                     @Override
                     public int requestFusion(int mode) {
@@ -3068,10 +3068,10 @@ public enum TestHelper {
      * @return the new Observable
      */
     public static <T> Flowable<T> rejectFlowableFusion() {
-        return new Flowable<T>() {
+        return new Flowable<T>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super T> subscriber) {
-                subscriber.onSubscribe(new QueueSubscription<T>() {
+                subscriber.onSubscribe(new QueueSubscription<T>() /* NFI */ {
 
                     @Override
                     public int requestFusion(int mode) {
@@ -3753,7 +3753,7 @@ public enum TestHelper {
      * @return the new FlowableTransformer instance
      */
     public static <T> FlowableTransformer<T, T> conditional() {
-        return f -> new Flowable<T>() {
+        return f -> new Flowable<T>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super T> subscriber) {
                 f.subscribe(new ForwardingConditionalSubscriber<>(subscriber));

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
@@ -967,7 +967,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
+        var to = new TestObserverEx<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1003,7 +1003,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() {
+        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
@@ -656,7 +656,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onCompletedCrashCountsDownLatch() {
-        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<Integer>() {
+        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 throw new TestException();
@@ -675,13 +675,13 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onErrorCrashCountsDownLatch() {
-        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<Integer>() {
+        var ts0 = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable e) {
                 throw new TestException();
             }
         };
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts0);
+        var ts = new TestSubscriberEx<>(ts0);
 
         try {
             ts.onError(new RuntimeException());
@@ -694,7 +694,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void createDelegate() {
-        TestSubscriberEx<Integer> ts1 = new TestSubscriberEx<>();
+        var ts1 = new TestSubscriberEx<>();
 
         TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(ts1);
 
@@ -1427,7 +1427,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1463,7 +1463,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckAnonymousClassForLambda.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckAnonymousClassForLambda.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.validators;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+/**
+ * Adds license header to java files.
+ */
+public class CheckAnonymousClassForLambda {
+
+    String[] header = {
+    "/*",
+    " * Copyright (c) 2016-present, RxJava Contributors.",
+    " *",
+    " * Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in",
+    " * compliance with the License. You may obtain a copy of the License at",
+    " *",
+    " * http://www.apache.org/licenses/LICENSE-2.0",
+    " *",
+    " * Unless required by applicable law or agreed to in writing, software distributed under the License is",
+    " * distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See",
+    " * the License for the specific language governing permissions and limitations under the License.",
+    " */",
+    ""
+    };
+
+    @Test
+    public void checkAndUpdateLicenses() throws Exception {
+        if (System.getenv("CI") != null) {
+            // no point in changing the files in CI
+            return;
+        }
+        File f = TestHelper.findSource("Flowable");
+        if (f == null) {
+            return;
+        }
+
+        Queue<File> dirs = new ArrayDeque<>();
+
+        File parent = f.getParentFile().getParentFile();
+        dirs.offer(parent);
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/perf/java")));
+        dirs.offer(new File(parent.getAbsolutePath().replace('\\', '/').replace("src/main/java", "src/test/java")));
+
+        var fail = new StringBuilder();
+        var regex = Pattern.compile("new\\s+\\w+(?:\\s*<(?:[\\s\\w<>(\\[\\])?,.?]|\\s*<[\\s\\w<>(\\[\\])?,.?]*>)*>)?\\s*\\([^)]*\\)\\s*\\{");
+        int total = 0;
+
+        while (!dirs.isEmpty()) {
+            f = dirs.poll();
+
+            File[] list = f.listFiles();
+            if (list != null && list.length != 0) {
+
+                for (File u : list) {
+                    if (u.isDirectory()) {
+                        dirs.offer(u);
+                    } else {
+                        if (u.getName().endsWith(".java")) {
+
+                            List<String> lines = Files.readAllLines(u.toPath());
+
+                            for (int i = 0; i < lines.size(); i++) {
+
+                                String input = lines.get(i);
+                                if (input.trim().startsWith("*")) {
+                                    continue;
+                                }
+                                if (regex.matcher(input).find()) {
+                                    if (fail.isEmpty()) {
+                                        fail.append("java.lang.RuntimeException lambda possibility\r\n");
+                                    }
+                                    fail.append(" at ").append(u.getName())
+                                    .append("(").append(u.getName()).append(":").append(i + 1)
+                                    .append(")\r\n");
+                                    total++;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (fail.length() != 0) {
+            System.out.println(fail);
+            System.out.println(total);
+            throw new AssertionError(fail.toString());
+        }
+    }
+}


### PR DESCRIPTION
Runs the following regex against all java files to detect anonymous inner class creation:

`new\s+\w+(?:\s*<(?:[\s\w<>(\[\])?,.?]|\s*<[\s\w<>(\[\])?,.?]*>)*>)?\s*\([^)]*\)\s*\{`

It will have all the file and line numbers in the crash exception.

If an anonymous inner class has state, use the `/* NFI */` comment between the `)` and `{`:

```diff
- new SomeClass() {
+ new SomeClass() /* NFI */ {
```