### PR TITLE
4.x: Cleanup: Serial annotation, getFirst usage

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.core;
 
+import java.io.Serial;
 import java.lang.ref.Cleaner;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -41,6 +42,7 @@ public final class CompletionStageDisposable<T> implements AutoCloseable {
     static final class State extends AtomicBoolean implements Runnable {
 
         /** */
+        @Serial
         private static final long serialVersionUID = 262854674341831347L;
 
         Throwable allocationTrace;

--- a/src/main/java/io/reactivex/rxjava4/core/Notification.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Notification.java
@@ -95,8 +95,7 @@ public final class Notification<T> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof Notification) {
-            Notification<?> n = (Notification<?>) obj;
+        if (obj instanceof Notification<?> n) {
             return Objects.equals(value, n.value);
         }
         return false;

--- a/src/main/java/io/reactivex/rxjava4/disposables/ActionDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/ActionDisposable.java
@@ -17,11 +17,14 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
 
+import java.io.Serial;
+
 /**
  * A Disposable container that manages an {@link Action} instance.
  */
 final class ActionDisposable extends ReferenceDisposable<Action> {
 
+    @Serial
     private static final long serialVersionUID = -8219729196779211169L;
 
     ActionDisposable(Action value) {

--- a/src/main/java/io/reactivex/rxjava4/disposables/AutoCloseableDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/AutoCloseableDisposable.java
@@ -16,12 +16,15 @@ package io.reactivex.rxjava4.disposables;
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
 
+import java.io.Serial;
+
 /**
  * A disposable container that manages an {@link AutoCloseable} instance.
  * @since 3.0.0
  */
 final class AutoCloseableDisposable extends ReferenceDisposable<AutoCloseable> {
 
+    @Serial
     private static final long serialVersionUID = -6646144244598696847L;
 
     AutoCloseableDisposable(AutoCloseable value) {

--- a/src/main/java/io/reactivex/rxjava4/disposables/CompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/CompositeDisposable.java
@@ -250,7 +250,7 @@ public final class CompositeDisposable implements Disposable, DisposableContaine
         }
         if (errors != null) {
             if (errors.size() == 1) {
-                throw ExceptionHelper.wrapOrThrow(errors.get(0));
+                throw ExceptionHelper.wrapOrThrow(errors.getFirst());
             }
             throw new CompositeException(errors);
         }

--- a/src/main/java/io/reactivex/rxjava4/disposables/FutureDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/FutureDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.disposables;
 
+import java.io.Serial;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -21,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 final class FutureDisposable extends AtomicReference<Future<?>> implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = 6545242830671168775L;
 
     private final boolean allowInterrupt;

--- a/src/main/java/io/reactivex/rxjava4/disposables/ReferenceDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/ReferenceDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.disposables;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -26,6 +27,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
  */
 abstract class ReferenceDisposable<T> extends AtomicReference<T> implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = 6537757548749041217L;
 
     ReferenceDisposable(T value) {

--- a/src/main/java/io/reactivex/rxjava4/disposables/RunnableDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/RunnableDisposable.java
@@ -15,11 +15,14 @@ package io.reactivex.rxjava4.disposables;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 
+import java.io.Serial;
+
 /**
  * A disposable container that manages a {@link Runnable} instance.
  */
 final class RunnableDisposable extends ReferenceDisposable<Runnable> {
 
+    @Serial
     private static final long serialVersionUID = -8219729196779211169L;
 
     RunnableDisposable(Runnable value) {

--- a/src/main/java/io/reactivex/rxjava4/disposables/SubscriptionDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/SubscriptionDisposable.java
@@ -17,11 +17,14 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 
+import java.io.Serial;
+
 /**
  * A Disposable container that handles a {@link Subscription}.
  */
 final class SubscriptionDisposable extends ReferenceDisposable<Subscription> {
 
+    @Serial
     private static final long serialVersionUID = -707001650852963139L;
 
     SubscriptionDisposable(Subscription value) {

--- a/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
@@ -34,6 +34,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
  */
 public final class CompositeException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 3026362227162912146L;
 
     private final List<Throwable> exceptions;
@@ -164,7 +165,7 @@ public final class CompositeException extends RuntimeException {
 
                 cause = new ExceptionOverview(aggregateMessage.toString().trim());
             } else {
-                cause = exceptions.get(0);
+                cause = exceptions.getFirst();
             }
         }
         return cause;
@@ -276,6 +277,7 @@ public final class CompositeException extends RuntimeException {
      */
     static final class ExceptionOverview extends RuntimeException {
 
+        @Serial
         private static final long serialVersionUID = 3875212506787802066L;
 
         ExceptionOverview(String message) {

--- a/src/main/java/io/reactivex/rxjava4/exceptions/MissingBackpressureException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/MissingBackpressureException.java
@@ -13,11 +13,14 @@
 
 package io.reactivex.rxjava4.exceptions;
 
+import java.io.Serial;
+
 /**
  * Indicates that an operator attempted to emit a value but the downstream wasn't ready for it.
  */
 public final class MissingBackpressureException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 8517344746016032542L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
@@ -15,6 +15,8 @@ package io.reactivex.rxjava4.exceptions;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 
+import java.io.Serial;
+
 /**
  * Represents an exception used to signal to the {@code RxJavaPlugins.onError()} that a
  * callback-based subscribe() method on a base reactive type didn't specify
@@ -24,6 +26,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
  */
 public final class OnErrorNotImplementedException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = -6298857009889503852L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/exceptions/ProtocolViolationException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/ProtocolViolationException.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava4.exceptions;
 
+import java.io.Serial;
+
 /**
  * Explicitly named exception to indicate a Reactive-Streams
  * protocol violation.
@@ -21,6 +23,7 @@ package io.reactivex.rxjava4.exceptions;
  */
 public final class ProtocolViolationException extends IllegalStateException {
 
+    @Serial
     private static final long serialVersionUID = 1644750035281290266L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/exceptions/QueueOverflowException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/QueueOverflowException.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava4.exceptions;
 
+import java.io.Serial;
+
 /**
  * Indicates an overflow happened because the upstream disregarded backpressure completely or
  * {@link java.util.concurrent.Flow.Subscriber#onNext(Object)} was called concurrently from multiple threads
@@ -21,6 +23,7 @@ package io.reactivex.rxjava4.exceptions;
  */
 public final class QueueOverflowException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = 8517344746016032542L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava4.exceptions;
 
+import java.io.Serial;
+
 /**
  * Wrapper for Throwable errors that are sent to {@link io.reactivex.rxjava4.plugins.RxJavaPlugins#onError(Throwable) RxJavaPlugins.onError}.
  * <p>History: 2.0.6 - experimental; 2.1 - beta
@@ -20,6 +22,7 @@ package io.reactivex.rxjava4.exceptions;
  */
 public final class UndeliverableException extends IllegalStateException {
 
+    @Serial
     private static final long serialVersionUID = 1644750035281290266L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.disposables;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -26,6 +27,7 @@ import io.reactivex.rxjava4.disposables.Disposable;
  */
 public final class ArrayCompositeDisposable extends AtomicReferenceArray<Disposable> implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = 2746389416410565408L;
 
     public ArrayCompositeDisposable(int capacity) {

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.disposables;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -28,6 +29,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 public final class CancellableDisposable extends AtomicReference<Cancellable>
 implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = 5718521705281392066L;
 
     public CancellableDisposable(Cancellable cancellable) {

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposable.java
@@ -179,7 +179,7 @@ public final class ListCompositeDisposable implements Disposable, DisposableCont
         }
         if (errors != null) {
             if (errors.size() == 1) {
-                throw ExceptionHelper.wrapOrThrow(errors.get(0));
+                throw ExceptionHelper.wrapOrThrow(errors.getFirst());
             }
             throw new CompositeException(errors);
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/SequentialDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/SequentialDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.disposables;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -28,6 +29,7 @@ public final class SequentialDisposable
 extends AtomicReference<Disposable>
 implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = -754898800686245608L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
@@ -67,6 +68,7 @@ public final class FlowableCollectWithCollector<T, A, R> extends Flowable<R> {
     extends DeferredScalarSubscription<R>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -229544830565448758L;
 
         final BiConsumer<A, T> accumulator;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStream.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 import java.util.stream.Stream;
@@ -94,6 +95,7 @@ public final class FlowableFlatMapStream<T, R> extends Flowable<R> {
     static final class FlatMapStreamSubscriber<T, R> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5127032662980523968L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromCompletionStage.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -51,6 +52,7 @@ public final class FlowableFromCompletionStage<T> extends Flowable<T> {
     extends DeferredScalarSubscription<T>
     implements BiConsumer<T, Throwable> {
 
+        @Serial
         private static final long serialVersionUID = 4665335664328839859L;
 
         final BiConsumerAtomicReference<T> whenReference;
@@ -82,6 +84,7 @@ public final class FlowableFromCompletionStage<T> extends Flowable<T> {
     static final class BiConsumerAtomicReference<T> extends AtomicReference<BiConsumer<T, Throwable>>
     implements BiConsumer<T, Throwable> {
 
+        @Serial
         private static final long serialVersionUID = 45838553147237545L;
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStream.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -88,6 +89,7 @@ public final class FlowableFromStream<T> extends Flowable<T> {
 
     abstract static class AbstractStreamSubscription<T> extends AtomicLong implements QueueSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -9082954702547571853L;
 
         Iterator<T> iterator;
@@ -181,6 +183,7 @@ public final class FlowableFromStream<T> extends Flowable<T> {
 
     static final class StreamSubscription<T> extends AbstractStreamSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -9082954702547571853L;
 
         final Subscriber<? super T> downstream;
@@ -249,6 +252,7 @@ public final class FlowableFromStream<T> extends Flowable<T> {
 
     static final class StreamConditionalSubscription<T> extends AbstractStreamSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -9082954702547571853L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
@@ -56,6 +57,7 @@ public final class MaybeFlattenStreamAsFlowable<T, R> extends Flowable<R> {
     extends BasicIntQueueSubscription<R>
     implements MaybeObserver<T>, SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 7363336003027148283L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -54,6 +55,7 @@ public final class MaybeFlattenStreamAsObservable<T, R> extends Observable<R> {
     extends BasicIntQueueDisposable<R>
     implements MaybeObserver<T>, SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 7363336003027148283L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.function.*;
 import java.util.stream.Collector;
@@ -67,6 +68,7 @@ public final class ObservableCollectWithCollector<T, A, R> extends Observable<R>
     extends DeferredScalarDisposable<R>
     implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -229544830565448758L;
 
         final BiConsumer<A, T> accumulator;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStream.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStream.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -73,6 +74,7 @@ public final class ObservableFlatMapStream<T, R> extends Observable<R> {
     static final class FlatMapStreamObserver<T, R> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5127032662980523968L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromCompletionStage.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
@@ -49,6 +50,7 @@ public final class ObservableFromCompletionStage<T> extends Observable<T> {
     extends DeferredScalarDisposable<T>
     implements BiConsumer<T, Throwable> {
 
+        @Serial
         private static final long serialVersionUID = 4665335664328839859L;
 
         final BiConsumerAtomicReference<T> whenReference;
@@ -80,6 +82,7 @@ public final class ObservableFromCompletionStage<T> extends Observable<T> {
     static final class BiConsumerAtomicReference<T> extends AtomicReference<BiConsumer<T, Throwable>>
     implements BiConsumer<T, Throwable> {
 
+        @Serial
         private static final long serialVersionUID = 45838553147237545L;
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.jdk8;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
@@ -63,6 +64,7 @@ public final class ParallelCollector<T, A, R> extends Flowable<R> {
 
     static final class ParallelCollectorSubscriber<T, A, R> extends DeferredScalarSubscription<R> {
 
+        @Serial
         private static final long serialVersionUID = -5370107872170712765L;
 
         final ParallelCollectorInnerSubscriber<T, A, R>[] subscribers;
@@ -176,6 +178,7 @@ public final class ParallelCollector<T, A, R> extends Flowable<R> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7954444275102466525L;
 
         final ParallelCollectorSubscriber<T, A, R> parent;
@@ -241,6 +244,7 @@ public final class ParallelCollector<T, A, R> extends Flowable<R> {
 
     static final class SlotPair<T> extends AtomicInteger {
 
+        @Serial
         private static final long serialVersionUID = 473971317683868662L;
 
         T first;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/AbstractDisposableAutoRelease.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/AbstractDisposableAutoRelease.java
@@ -29,6 +29,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.disposables.*;
@@ -49,6 +50,7 @@ abstract class AbstractDisposableAutoRelease
 extends AtomicReference<Disposable>
 implements Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = 8924480688481408726L;
 
     final AtomicReference<DisposableContainer> composite;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/BasicIntQueueDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/BasicIntQueueDisposable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.operators.QueueDisposable;
@@ -26,6 +27,7 @@ public abstract class BasicIntQueueDisposable<T>
 extends AtomicInteger
 implements QueueDisposable<T> {
 
+    @Serial
     private static final long serialVersionUID = -1001730202384742097L;
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/BiConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/BiConsumerSingleObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.SingleObserver;
@@ -26,6 +27,7 @@ public final class BiConsumerSingleObserver<T>
 extends AtomicReference<Disposable>
 implements SingleObserver<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = 4943102778943297569L;
     final BiConsumer<? super T, ? super Throwable> onCallback;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/BlockingObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/BlockingObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,6 +24,7 @@ import io.reactivex.rxjava4.internal.util.NotificationLite;
 
 public final class BlockingObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -4875965440900746268L;
 
     public static final Object TERMINATED = new Object();

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/CallbackCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/CallbackCompletableObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.CompletableObserver;
@@ -28,6 +29,7 @@ public final class CallbackCompletableObserver
 extends AtomicReference<Disposable>
         implements CompletableObserver, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -4361286194466301354L;
 
     final Consumer<? super Throwable> onError;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/ConsumerSingleObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/ConsumerSingleObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.SingleObserver;
@@ -28,6 +29,7 @@ public final class ConsumerSingleObserver<T>
 extends AtomicReference<Disposable>
 implements SingleObserver<T>, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -7012088219455310787L;
 
     final Consumer<? super T> onSuccess;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarDisposable.java
@@ -17,6 +17,8 @@ import io.reactivex.rxjava4.annotations.Nullable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 /**
  * Represents a fuseable container for a single value.
  *
@@ -24,6 +26,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  */
 public class DeferredScalarDisposable<T> extends BasicIntQueueDisposable<T> {
 
+    @Serial
     private static final long serialVersionUID = -5502432239815349361L;
 
     /** The target of the events. */

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserver.java
@@ -17,6 +17,8 @@ import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 
+import java.io.Serial;
+
 /**
  * A fuseable Observer that can generate 0 or 1 resulting value.
  * @param <T> the input value type
@@ -26,6 +28,7 @@ public abstract class DeferredScalarObserver<T, R>
 extends DeferredScalarDisposable<R>
 implements Observer<T> {
 
+    @Serial
     private static final long serialVersionUID = -266195175408988651L;
 
     /** The upstream disposable. */

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/DisposableAutoReleaseMultiObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/DisposableAutoReleaseMultiObserver.java
@@ -36,6 +36,8 @@ import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 /**
  * Wraps lambda callbacks and when the upstream terminates or this (Single | Maybe | Completable)
  * observer gets disposed, removes itself from a {@link io.reactivex.rxjava4.disposables.CompositeDisposable}.
@@ -47,6 +49,7 @@ public final class DisposableAutoReleaseMultiObserver<T>
 extends AbstractDisposableAutoRelease
 implements SingleObserver<T>, MaybeObserver<T>, CompletableObserver {
 
+    @Serial
     private static final long serialVersionUID = 8924480688481408726L;
 
     final Consumer<? super T> onSuccess;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/DisposableAutoReleaseObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/DisposableAutoReleaseObserver.java
@@ -35,6 +35,8 @@ import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 
+import java.io.Serial;
+
 /**
  * Wraps lambda callbacks and when the upstream terminates or this observer gets disposed,
  * removes itself from a {@link io.reactivex.rxjava4.disposables.CompositeDisposable}.
@@ -46,6 +48,7 @@ public final class DisposableAutoReleaseObserver<T>
 extends AbstractDisposableAutoRelease
 implements Observer<T> {
 
+    @Serial
     private static final long serialVersionUID = 8924480688481408726L;
 
     final Consumer<? super T> onNext;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/EmptyCompletableObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/EmptyCompletableObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.CompletableObserver;
@@ -26,6 +27,7 @@ public final class EmptyCompletableObserver
 extends AtomicReference<Disposable>
 implements CompletableObserver, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -7545121636549663526L;
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/ForEachWhileObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/ForEachWhileObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.Observer;
@@ -26,6 +27,7 @@ public final class ForEachWhileObserver<T>
 extends AtomicReference<Disposable>
 implements Observer<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -4403180040475402120L;
 
     final Predicate<? super T> onNext;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/InnerQueuedObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/InnerQueuedObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.Observer;
@@ -33,6 +34,7 @@ public final class InnerQueuedObserver<T>
 extends AtomicReference<Disposable>
 implements Observer<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -5417183359794346637L;
 
     final InnerQueuedObserverSupport<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/observers/LambdaObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/observers/LambdaObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.observers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.Observer;
@@ -27,6 +28,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 public final class LambdaObserver<T> extends AtomicReference<Disposable>
         implements Observer<T>, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -39,6 +40,7 @@ public final class CompletableAndThenCompletable extends Completable {
             extends AtomicReference<Disposable>
             implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4101678820158072998L;
 
         final CompletableObserver actualObserver;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCache.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -147,6 +148,7 @@ public final class CompletableCache extends Completable implements CompletableOb
     extends AtomicBoolean
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8943152917179642732L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcat.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcat.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -42,6 +43,7 @@ public final class CompletableConcat extends Completable {
     static final class CompletableConcatSubscriber
     extends AtomicInteger
     implements FlowableSubscriber<CompletableSource>, Disposable {
+        @Serial
         private static final long serialVersionUID = 9032184911934499404L;
 
         final CompletableObserver downstream;
@@ -226,6 +228,7 @@ public final class CompletableConcat extends Completable {
         }
 
         static final class ConcatInnerObserver extends AtomicReference<Disposable> implements CompletableObserver {
+            @Serial
             private static final long serialVersionUID = -5454794857847146511L;
 
             final CompletableConcatSubscriber parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -35,6 +36,7 @@ public final class CompletableConcatArray extends Completable {
 
     static final class ConcatInnerObserver extends AtomicInteger implements CompletableObserver {
 
+        @Serial
         private static final long serialVersionUID = -7965400327305809232L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableConcatIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,6 +50,7 @@ public final class CompletableConcatIterable extends Completable {
 
     static final class ConcatInnerObserver extends AtomicInteger implements CompletableObserver {
 
+        @Serial
         private static final long serialVersionUID = -7965400327305809232L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCreate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -48,6 +49,7 @@ public final class CompletableCreate extends Completable {
     extends AtomicReference<Disposable>
     implements CompletableEmitter, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2467358622224974244L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDelay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDelay.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,6 +49,7 @@ public final class CompletableDelay extends Completable {
     static final class Delay extends AtomicReference<Disposable>
     implements CompletableObserver, Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 465972761105851022L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoFinally.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -45,6 +46,7 @@ public final class CompletableDoFinally extends Completable {
 
     static final class DoFinallyObserver extends AtomicInteger implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMerge.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMerge.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -44,6 +45,7 @@ public final class CompletableMerge extends Completable {
     extends AtomicInteger
     implements FlowableSubscriber<CompletableSource>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2108443387387077490L;
 
         final CompletableObserver downstream;
@@ -163,6 +165,7 @@ public final class CompletableMerge extends Completable {
         final class MergeInnerObserver
         extends AtomicReference<Disposable>
         implements CompletableObserver, Disposable {
+            @Serial
             private static final long serialVersionUID = 251330541679988317L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -53,6 +54,7 @@ public final class CompletableMergeArray extends Completable {
     }
 
     static final class InnerCompletableObserver extends AtomicInteger implements CompletableObserver, Disposable {
+        @Serial
         private static final long serialVersionUID = -8360547806504310570L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -96,6 +97,7 @@ public final class CompletableMergeIterable extends Completable {
 
     static final class MergeCompletableObserver extends AtomicBoolean implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -7730517613164279224L;
 
         final CompositeDisposable set;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableObserveOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -38,6 +39,7 @@ public final class CompletableObserveOn extends Completable {
     extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 8571289934935992137L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableResumeNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableResumeNext.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,6 +46,7 @@ public final class CompletableResumeNext extends Completable {
     extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 5018523762564524046L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -45,6 +46,7 @@ public final class CompletableSubscribeOn extends Completable {
     extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 7000911171163930287L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTakeUntilCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTakeUntilCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class CompletableTakeUntilCompletable extends Completable {
     static final class TakeUntilMainObserver extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 3533011714830024923L;
 
         final CompletableObserver downstream;
@@ -118,6 +120,7 @@ public final class CompletableTakeUntilCompletable extends Completable {
         static final class OtherObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = 5176264485428790318L;
             final TakeUntilMainObserver parent;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableTimer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,6 +45,7 @@ public final class CompletableTimer extends Completable {
 
     static final class TimerDisposable extends AtomicReference<Disposable> implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 3167244060586201109L;
         final CompletableObserver downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsing.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.completable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -87,6 +88,7 @@ public final class CompletableUsing<R> extends Completable {
     extends AtomicReference<Object>
     implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -674404550052917487L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/AbstractBackpressureThrottlingSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/AbstractBackpressureThrottlingSubscriber.java
@@ -18,6 +18,7 @@ import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import static java.util.concurrent.Flow.*;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -31,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 abstract class AbstractBackpressureThrottlingSubscriber<T, R> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+    @Serial
     private static final long serialVersionUID = -5050301752721603566L;
 
     final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.*;
@@ -47,6 +48,7 @@ public final class BlockingFlowableIterable<T> implements Iterable<T> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T>, Iterator<T>, Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 6695226475494099826L;
 
         final SpscArrayQueue<T> queue;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAll.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAll.java
@@ -21,6 +21,8 @@ import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolean> {
 
     final Predicate<? super T> predicate;
@@ -37,6 +39,7 @@ public final class FlowableAll<T> extends AbstractFlowableWithUpstream<T, Boolea
 
     static final class AllSubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -3521127104134758517L;
         final Predicate<? super T> predicate;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmb.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmb.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -149,6 +150,7 @@ public final class FlowableAmb<T> extends Flowable<T> {
 
     static final class AmbInnerSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -1185974347409665484L;
         final AmbCoordinator<T> parent;
         final int index;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAny.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAny.java
@@ -21,6 +21,8 @@ import io.reactivex.rxjava4.functions.Predicate;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolean> {
     final Predicate<? super T> predicate;
     public FlowableAny(Flowable<T> source, Predicate<? super T> predicate) {
@@ -35,6 +37,7 @@ public final class FlowableAny<T> extends AbstractFlowableWithUpstream<T, Boolea
 
     static final class AnySubscriber<T> extends DeferredScalarSubscription<Boolean> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -2311252482644620661L;
 
         final Predicate<? super T> predicate;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBuffer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -159,6 +160,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5616169793639412593L;
 
         final Subscriber<? super C> downstream;
@@ -289,6 +291,7 @@ public final class FlowableBuffer<T, C extends Collection<? super T>> extends Ab
     extends AtomicLong
     implements FlowableSubscriber<T>, Subscription, BooleanSupplier {
 
+        @Serial
         private static final long serialVersionUID = -7370244972039324525L;
 
         final Subscriber<? super C> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -54,6 +55,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     static final class BufferBoundarySubscriber<T, C extends Collection<? super T>, Open, Close>
     extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -8466418554264089604L;
 
         final Subscriber<? super C> downstream;
@@ -311,6 +313,7 @@ extends AbstractFlowableWithUpstream<T, U> {
         extends AtomicReference<Subscription>
         implements FlowableSubscriber<Open>, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -8498650778633225126L;
 
             final BufferBoundarySubscriber<?, ?, Open, ?> parent;
@@ -357,6 +360,7 @@ extends AbstractFlowableWithUpstream<T, U> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8498650778633225126L;
 
         final BufferBoundarySubscriber<T, C, ?, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -349,6 +350,7 @@ implements FlowableSubscriber<T> {
     static final class CacheSubscription<T> extends AtomicInteger
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 6770240836423125754L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCollect.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCollect.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T, U> {
@@ -50,6 +51,7 @@ public final class FlowableCollect<T, U> extends AbstractFlowableWithUpstream<T,
 
     static final class CollectSubscriber<T, U> extends DeferredScalarSubscription<U> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -3589550218733891694L;
 
         final BiConsumer<? super U, ? super T> collector;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -117,6 +118,7 @@ extends Flowable<R> {
     static final class CombineLatestCoordinator<T, R>
     extends BasicIntQueueSubscription<R> {
 
+        @Serial
         private static final long serialVersionUID = -5082275438355852221L;
 
         final Subscriber<? super R> downstream;
@@ -458,6 +460,7 @@ extends Flowable<R> {
     extends AtomicReference<Subscription>
             implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -8730235182291002949L;
 
         final CombineLatestCoordinator<T, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -43,6 +44,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
 
     static final class ConcatArraySubscriber<T> extends SubscriptionArbiter implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -8158322871608889516L;
 
         final Subscriber<? super T> downstream;
@@ -105,7 +107,7 @@ public final class FlowableConcatArray<T> extends Flowable<T> {
                         List<Throwable> list = errors;
                         if (list != null) {
                             if (list.size() == 1) {
-                                downstream.onError(list.get(0));
+                                downstream.onError(list.getFirst());
                             } else {
                                 downstream.onError(new CompositeException(list));
                             }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -70,6 +71,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     extends AtomicInteger
     implements FlowableSubscriber<T>, ConcatMapSupport<R>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -3511336836796789179L;
 
         final ConcatMapInner<R> inner;
@@ -176,6 +178,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     static final class ConcatMapImmediate<T, R>
     extends BaseConcatMapSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = 7898995095634264146L;
 
         final Subscriber<? super R> downstream;
@@ -330,6 +333,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     static final class SimpleScalarSubscription<T>
     extends AtomicBoolean
     implements Subscription {
+        @Serial
         private static final long serialVersionUID = -7606889335172043256L;
 
         final Subscriber<? super T> downstream;
@@ -358,6 +362,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     static final class ConcatMapDelayed<T, R>
     extends BaseConcatMapSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = -2945777694260521066L;
 
         final Subscriber<? super R> downstream;
@@ -540,6 +545,7 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
     extends SubscriptionArbiter
     implements FlowableSubscriber<R> {
 
+        @Serial
         private static final long serialVersionUID = 897683679971470653L;
 
         final ConcatMapSupport<R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEager.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class FlowableConcatMapEager<T, R> extends AbstractFlowableWithUpst
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, InnerQueuedSubscriberSupport<R> {
 
+        @Serial
         private static final long serialVersionUID = -4255299542215038287L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -66,6 +67,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
     extends AtomicInteger
     implements FlowableSubscriber<T>, ConcatMapSupport<R>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -3511336836796789179L;
 
         final ConcatMapInner<R> inner;
@@ -175,6 +177,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
     static final class ConcatMapImmediate<T, R>
     extends BaseConcatMapSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = 7898995095634264146L;
 
         final Subscriber<? super R> downstream;
@@ -366,6 +369,7 @@ public final class FlowableConcatMapScheduler<T, R> extends AbstractFlowableWith
     static final class ConcatMapDelayed<T, R>
     extends BaseConcatMapSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = -2945777694260521066L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -47,6 +48,7 @@ public final class FlowableConcatWithCompletable<T> extends AbstractFlowableWith
     extends AtomicReference<Disposable>
     implements FlowableSubscriber<T>, CompletableObserver, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -7346385463600070225L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -48,6 +49,7 @@ public final class FlowableConcatWithMaybe<T> extends AbstractFlowableWithUpstre
     extends SinglePostCompleteSubscriber<T, T>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -7346385463600070225L;
 
         final AtomicReference<Disposable> otherDisposable;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatWithSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -48,6 +49,7 @@ public final class FlowableConcatWithSingle<T> extends AbstractFlowableWithUpstr
     extends SinglePostCompleteSubscriber<T, T>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -7346385463600070225L;
 
         final AtomicReference<Disposable> otherDisposable;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCount.java
@@ -18,6 +18,8 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 
+import java.io.Serial;
+
 public final class FlowableCount<T> extends AbstractFlowableWithUpstream<T, Long> {
 
     public FlowableCount(Flowable<T> source) {
@@ -32,6 +34,7 @@ public final class FlowableCount<T> extends AbstractFlowableWithUpstream<T, Long
     static final class CountSubscriber extends DeferredScalarSubscription<Long>
     implements FlowableSubscriber<Object> {
 
+        @Serial
         private static final long serialVersionUID = 4973004223787171406L;
 
         Subscription upstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
 
@@ -82,6 +83,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
     extends AtomicInteger
     implements FlowableEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 4883307006032401862L;
 
         final BaseEmitter<T> emitter;
@@ -240,6 +242,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
     abstract static class BaseEmitter<T>
     extends AtomicLong
     implements FlowableEmitter<T>, Subscription {
+        @Serial
         private static final long serialVersionUID = 7326289992464377023L;
 
         final Subscriber<? super T> downstream;
@@ -356,6 +359,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     static final class MissingEmitter<T> extends BaseEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 3776720187248809713L;
 
         MissingEmitter(Subscriber<? super T> downstream) {
@@ -387,6 +391,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     abstract static class NoOverflowBaseAsyncEmitter<T> extends BaseEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 4127754106204442833L;
 
         NoOverflowBaseAsyncEmitter(Subscriber<? super T> downstream) {
@@ -417,6 +422,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     static final class DropAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 8360058422307496563L;
 
         DropAsyncEmitter(Subscriber<? super T> downstream) {
@@ -432,6 +438,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     static final class ErrorAsyncEmitter<T> extends NoOverflowBaseAsyncEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 338953216916120960L;
 
         ErrorAsyncEmitter(Subscriber<? super T> downstream) {
@@ -447,6 +454,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     static final class BufferAsyncEmitter<T> extends BaseEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 2427151001689639875L;
 
         final SpscLinkedArrayQueue<T> queue;
@@ -585,6 +593,7 @@ public final class FlowableCreate<T> extends Flowable<T> {
 
     static final class LatestAsyncEmitter<T> extends BaseEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 4023437720691792495L;
 
         final AtomicReference<T> queue;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounce.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounce.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -44,6 +45,7 @@ public final class FlowableDebounce<T, U> extends AbstractFlowableWithUpstream<T
     static final class DebounceSubscriber<T, U> extends AtomicLong
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 6725975399620862591L;
         final Subscriber<? super T> downstream;
         final Function<? super T, ? extends Publisher<U>> debounceSelector;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -53,6 +54,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
     static final class DebounceTimedSubscriber<T> extends AtomicLong
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -9102637559663639004L;
         final Subscriber<? super T> downstream;
         final long timeout;
@@ -181,6 +183,7 @@ public final class FlowableDebounceTimed<T> extends AbstractFlowableWithUpstream
 
     static final class DebounceEmitter<T> extends AtomicReference<Disposable> implements Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 6812032969491025141L;
 
         final T value;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOther.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelaySubscriptionOther.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -45,6 +46,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
 
     static final class MainSubscriber<T> extends AtomicLong implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 2259811067697317255L;
 
         final Subscriber<? super T> downstream;
@@ -101,6 +103,7 @@ public final class FlowableDelaySubscriptionOther<T, U> extends Flowable<T> {
 
         final class OtherSubscriber extends AtomicReference<Subscription> implements FlowableSubscriber<Object> {
 
+            @Serial
             private static final long serialVersionUID = -3892798459447644106L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerialize.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerialize.java
@@ -63,8 +63,7 @@ public final class FlowableDematerialize<T, R> extends AbstractFlowableWithUpstr
         @Override
         public void onNext(T item) {
             if (done) {
-                if (item instanceof Notification) {
-                    Notification<?> notification = (Notification<?>)item;
+                if (item instanceof Notification<?> notification) {
                     if (notification.isOnError()) {
                         RxJavaPlugins.onError(notification.getError());
                     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChanged.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctUntilChanged.java
@@ -35,8 +35,7 @@ public final class FlowableDistinctUntilChanged<T, K> extends AbstractFlowableWi
 
     @Override
     protected void subscribeActual(Subscriber<? super T> s) {
-        if (s instanceof ConditionalSubscriber) {
-            ConditionalSubscriber<? super T> cs = (ConditionalSubscriber<? super T>) s;
+        if (s instanceof ConditionalSubscriber<? super T> cs) {
             source.subscribe(new DistinctUntilChangedConditionalSubscriber<>(cs, keySelector, comparer));
         } else {
             source.subscribe(new DistinctUntilChangedSubscriber<>(s, keySelector, comparer));

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinally.java
@@ -24,6 +24,8 @@ import io.reactivex.rxjava4.operators.ConditionalSubscriber;
 import io.reactivex.rxjava4.operators.QueueSubscription;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 /**
  * Execute an action after an onError, onComplete or a cancel event.
  * <p>History: 2.0.1 - experimental
@@ -50,6 +52,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
 
     static final class DoFinallySubscriber<T> extends BasicIntQueueSubscription<T> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final Subscriber<? super T> downstream;
@@ -155,6 +158,7 @@ public final class FlowableDoFinally<T> extends AbstractFlowableWithUpstream<T, 
 
     static final class DoFinallyConditionalSubscriber<T> extends BasicIntQueueSubscription<T> implements ConditionalSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAt.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAt.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.NoSuchElementException;
 
 import static java.util.concurrent.Flow.*;
@@ -40,6 +41,7 @@ public final class FlowableElementAt<T> extends AbstractFlowableWithUpstream<T, 
 
     static final class ElementAtSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 4066607327284737757L;
 
         final long index;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
 
     static final class MergeSubscriber<T, U> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -2117620485640801370L;
 
         final Subscriber<? super U> downstream;
@@ -577,6 +579,7 @@ public final class FlowableFlatMap<T, U> extends AbstractFlowableWithUpstream<T,
     static final class InnerSubscriber<T, U> extends AtomicReference<Subscription>
     implements FlowableSubscriber<U>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4606175640614850599L;
         final long id;
         final MergeSubscriber<T, U> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,6 +56,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
 
     static final class FlatMapCompletableMainSubscriber<T> extends BasicIntQueueSubscription<T>
     implements FlowableSubscriber<T> {
+        @Serial
         private static final long serialVersionUID = 8443155186132538303L;
 
         final Subscriber<? super T> downstream;
@@ -199,6 +201,7 @@ public final class FlowableFlatMapCompletable<T> extends AbstractFlowableWithUps
         }
 
         final class InnerConsumer extends AtomicReference<Disposable> implements CompletableObserver, Disposable {
+            @Serial
             private static final long serialVersionUID = 8606673141535671828L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -63,6 +64,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
 
     static final class FlatMapCompletableMainSubscriber<T> extends AtomicInteger
     implements FlowableSubscriber<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = 8443155186132538303L;
 
         final CompletableObserver downstream;
@@ -186,6 +188,7 @@ public final class FlowableFlatMapCompletableCompletable<T> extends Completable 
         }
 
         final class InnerObserver extends AtomicReference<Disposable> implements CompletableObserver, Disposable {
+            @Serial
             private static final long serialVersionUID = 8606673141535671828L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -57,6 +58,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 8600231336733376951L;
 
         final Subscriber<? super R> downstream;
@@ -362,6 +364,7 @@ public final class FlowableFlatMapMaybe<T, R> extends AbstractFlowableWithUpstre
 
         final class InnerObserver extends AtomicReference<Disposable>
         implements MaybeObserver<R>, Disposable {
+            @Serial
             private static final long serialVersionUID = -502562646270949838L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -57,6 +58,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 8600231336733376951L;
 
         final Subscriber<? super R> downstream;
@@ -330,6 +332,7 @@ public final class FlowableFlatMapSingle<T, R> extends AbstractFlowableWithUpstr
 
         final class InnerObserver extends AtomicReference<Disposable>
         implements SingleObserver<R>, Disposable {
+            @Serial
             private static final long serialVersionUID = -502562646270949838L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -97,6 +98,7 @@ public final class FlowableFlattenIterable<T, R> extends AbstractFlowableWithUps
     extends BasicIntQueueSubscription<R>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -3096000382929934955L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromArray.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.ConditionalSubscriber;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableFromArray<T> extends Flowable<T> {
@@ -41,6 +42,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
     }
 
     abstract static class BaseArraySubscription<T> extends BasicQueueSubscription<T> {
+        @Serial
         private static final long serialVersionUID = -2252972430506210021L;
 
         final T[] array;
@@ -106,6 +108,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
 
     static final class ArraySubscription<T> extends BaseArraySubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final Subscriber<? super T> downstream;
@@ -189,6 +192,7 @@ public final class FlowableFromArray<T> extends Flowable<T> {
 
     static final class ArrayConditionalSubscription<T> extends BaseArraySubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -71,6 +72,7 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
     }
 
     abstract static class BaseRangeSubscription<T> extends BasicQueueSubscription<T> {
+        @Serial
         private static final long serialVersionUID = -2252972430506210021L;
 
         Iterator<? extends T> iterator;
@@ -146,6 +148,7 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
 
     static final class IteratorSubscription<T> extends BaseRangeSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -6022804456014692607L;
 
         final Subscriber<? super T> downstream;
@@ -282,6 +285,7 @@ public final class FlowableFromIterable<T> extends Flowable<T> {
 
     static final class IteratorConditionalSubscription<T> extends BaseRangeSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -6022804456014692607L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGenerate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGenerate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -55,6 +56,7 @@ public final class FlowableGenerate<T, S> extends Flowable<T> {
     extends AtomicLong
     implements Emitter<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 7565982551505011832L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -77,6 +78,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
     extends AtomicLong
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -3688291656102519502L;
 
         final Subscriber<? super GroupedFlowable<K, V>> downstream;
@@ -358,6 +360,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
 
     static final class State<T, K> extends BasicIntQueueSubscription<T> implements Publisher<T> {
 
+        @Serial
         private static final long serialVersionUID = -3852313036005250360L;
 
         final K key;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -85,6 +86,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
     static final class GroupJoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Subscription, JoinSupport {
 
+        @Serial
         private static final long serialVersionUID = -6071216598687999801L;
 
         final Subscriber<? super R> downstream;
@@ -389,6 +391,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1883890389173668373L;
 
         final JoinSupport parent;
@@ -436,6 +439,7 @@ public final class FlowableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> exte
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1883890389173668373L;
 
         final JoinSupport parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInterval.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInterval.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -60,6 +61,7 @@ public final class FlowableInterval extends Flowable<Long> {
     static final class IntervalSubscriber extends AtomicLong
     implements Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -2809475196591179431L;
 
         final Subscriber<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIntervalRange.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIntervalRange.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -64,6 +65,7 @@ public final class FlowableIntervalRange extends Flowable<Long> {
     static final class IntervalRangeSubscriber extends AtomicLong
     implements Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -2809475196591179431L;
 
         final Subscriber<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -72,6 +73,7 @@ public final class FlowableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends A
     static final class JoinSubscription<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Subscription, JoinSupport {
 
+        @Serial
         private static final long serialVersionUID = -6071216598687999801L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMapNotification.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.subscribers.SinglePostCompleteSubscriber;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUpstream<T, R> {
@@ -47,6 +48,7 @@ public final class FlowableMapNotification<T, R> extends AbstractFlowableWithUps
     static final class MapNotificationSubscriber<T, R>
     extends SinglePostCompleteSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = 2757120512858778108L;
         final Function<? super T, ? extends R> onNextMapper;
         final Function<? super Throwable, ? extends R> onErrorMapper;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterialize.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterialize.java
@@ -19,6 +19,8 @@ import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.subscribers.SinglePostCompleteSubscriber;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T, Notification<T>> {
 
     public FlowableMaterialize(Flowable<T> source) {
@@ -32,6 +34,7 @@ public final class FlowableMaterialize<T> extends AbstractFlowableWithUpstream<T
 
     static final class MaterializeSubscriber<T> extends SinglePostCompleteSubscriber<T, Notification<T>> {
 
+        @Serial
         private static final long serialVersionUID = -3740826063558713822L;
 
         MaterializeSubscriber(Subscriber<? super Notification<T>> downstream) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -50,6 +51,7 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
     static final class MergeWithSubscriber<T> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Subscriber<? super T> downstream;
@@ -125,6 +127,7 @@ public final class FlowableMergeWithCompletable<T> extends AbstractFlowableWithU
         static final class OtherObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithSubscriber<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -52,6 +53,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
     static final class MergeWithObserver<T> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Subscriber<? super T> downstream;
@@ -321,6 +323,7 @@ public final class FlowableMergeWithMaybe<T> extends AbstractFlowableWithUpstrea
         static final class OtherObserver<T> extends AtomicReference<Disposable>
         implements MaybeObserver<T> {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithObserver<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -52,6 +53,7 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
     static final class MergeWithObserver<T> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Subscriber<? super T> downstream;
@@ -316,6 +318,7 @@ public final class FlowableMergeWithSingle<T> extends AbstractFlowableWithUpstre
         static final class OtherObserver<T> extends AtomicReference<Disposable>
         implements SingleObserver<T> {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithObserver<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -62,6 +63,7 @@ final Scheduler scheduler;
     abstract static class BaseObserveOnSubscriber<T>
     extends BasicIntQueueSubscription<T>
     implements FlowableSubscriber<T>, Runnable {
+        @Serial
         private static final long serialVersionUID = -8241002408341274697L;
 
         final Worker worker;
@@ -246,6 +248,7 @@ final Scheduler scheduler;
 
     static final class ObserveOnSubscriber<T> extends BaseObserveOnSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -4547113800637756442L;
 
         final Subscriber<? super T> downstream;
@@ -483,6 +486,7 @@ final Scheduler scheduler;
     static final class ObserveOnConditionalSubscriber<T>
     extends BaseObserveOnSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 644624475404284533L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBuffer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBuffer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -49,6 +50,7 @@ public final class FlowableOnBackpressureBuffer<T> extends AbstractFlowableWithU
 
     static final class BackpressureBufferSubscriber<T> extends BasicIntQueueSubscription<T> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -2514538129242366402L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategy.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class FlowableOnBackpressureBufferStrategy<T> extends AbstractFlowa
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3240706908776709697L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDrop.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDrop.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -51,6 +52,7 @@ public final class FlowableOnBackpressureDrop<T> extends AbstractFlowableWithUps
     static final class BackpressureDropSubscriber<T>
     extends AtomicLong implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -6246093802440953054L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureError.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureError.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -36,6 +37,7 @@ public final class FlowableOnBackpressureError<T> extends AbstractFlowableWithUp
 
     static final class BackpressureErrorSubscriber<T>
             extends AtomicLong implements FlowableSubscriber<T>, Subscription {
+        @Serial
         private static final long serialVersionUID = -3176480756392482682L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatest.java
@@ -16,6 +16,9 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import io.reactivex.rxjava4.core.Flowable;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.Consumer;
+
+import java.io.Serial;
+
 import static java.util.concurrent.Flow.*;
 
 public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -34,6 +37,7 @@ public final class FlowableOnBackpressureLatest<T> extends AbstractFlowableWithU
 
     static final class BackpressureLatestSubscriber<T> extends AbstractBackpressureThrottlingSubscriber<T, T> {
 
+        @Serial
         private static final long serialVersionUID = 163080509307634843L;
 
         final Consumer<? super T> onDropped;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduce.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduce.java
@@ -19,6 +19,7 @@ import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.BiFunction;
 import static java.util.concurrent.Flow.*;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableOnBackpressureReduce<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -37,6 +38,7 @@ public final class FlowableOnBackpressureReduce<T> extends AbstractFlowableWithU
 
     static final class BackpressureReduceSubscriber<T> extends AbstractBackpressureThrottlingSubscriber<T, T> {
 
+        @Serial
         private static final long serialVersionUID = 821363947659780367L;
 
         final BiFunction<T, T, T> reducer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWith.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWith.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.functions.Supplier;
 import static java.util.concurrent.Flow.*;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableOnBackpressureReduceWith<T, R> extends AbstractFlowableWithUpstream<T, R> {
@@ -42,6 +43,7 @@ public final class FlowableOnBackpressureReduceWith<T, R> extends AbstractFlowab
 
     static final class BackpressureReduceWithSubscriber<T, R> extends AbstractBackpressureThrottlingSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = 8255923705960622424L;
 
         final BiFunction<R, ? super T, R> reducer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorNext.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.subscriptions.SubscriptionArbiter;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -42,6 +43,7 @@ public final class FlowableOnErrorNext<T> extends AbstractFlowableWithUpstream<T
     static final class OnErrorNextSubscriber<T>
     extends SubscriptionArbiter
     implements FlowableSubscriber<T> {
+        @Serial
         private static final long serialVersionUID = 4063763155303814625L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorReturn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorReturn.java
@@ -20,6 +20,7 @@ import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.subscribers.SinglePostCompleteSubscriber;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -37,6 +38,7 @@ public final class FlowableOnErrorReturn<T> extends AbstractFlowableWithUpstream
     static final class OnErrorReturnSubscriber<T>
     extends SinglePostCompleteSubscriber<T, T> {
 
+        @Serial
         private static final long serialVersionUID = -3740826063558713822L;
         final Function<? super Throwable, ? extends T> valueSupplier;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublish.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -145,6 +146,7 @@ implements HasUpstreamPublisher<T> {
     extends AtomicInteger
     implements FlowableSubscriber<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -1672047311619175801L;
 
         final AtomicReference<PublishConnection<T>> current;
@@ -445,6 +447,7 @@ implements HasUpstreamPublisher<T> {
     static final class InnerSubscription<T> extends AtomicLong
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 2845000326761540265L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishMulticast.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -481,6 +482,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
     extends AtomicLong
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 8664815189257569791L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRange.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRange.java
@@ -21,6 +21,8 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.ConditionalSubscriber;
 
+import java.io.Serial;
+
 /**
  * Emits a range of integer values.
  */
@@ -43,6 +45,7 @@ public final class FlowableRange extends Flowable<Integer> {
     }
 
     abstract static class BaseRangeSubscription extends BasicQueueSubscription<Integer> {
+        @Serial
         private static final long serialVersionUID = -2252972430506210021L;
 
         final int end;
@@ -107,6 +110,7 @@ public final class FlowableRange extends Flowable<Integer> {
 
     static final class RangeSubscription extends BaseRangeSubscription {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final Subscriber<? super Integer> downstream;
@@ -175,6 +179,7 @@ public final class FlowableRange extends Flowable<Integer> {
 
     static final class RangeConditionalSubscription extends BaseRangeSubscription {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final ConditionalSubscriber<? super Integer> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLong.java
@@ -21,6 +21,8 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.ConditionalSubscriber;
 
+import java.io.Serial;
+
 /**
  * Emits a range of long values.
  */
@@ -45,6 +47,7 @@ public final class FlowableRangeLong extends Flowable<Long> {
 
     abstract static class BaseRangeSubscription extends BasicQueueSubscription<Long> {
 
+        @Serial
         private static final long serialVersionUID = -2252972430506210021L;
 
         final long end;
@@ -109,6 +112,7 @@ public final class FlowableRangeLong extends Flowable<Long> {
 
     static final class RangeSubscription extends BaseRangeSubscription {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final Subscriber<? super Long> downstream;
@@ -177,6 +181,7 @@ public final class FlowableRangeLong extends Flowable<Long> {
 
     static final class RangeConditionalSubscription extends BaseRangeSubscription {
 
+        @Serial
         private static final long serialVersionUID = 2587302975077663557L;
 
         final ConditionalSubscriber<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduce.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduce.java
@@ -21,6 +21,7 @@ import io.reactivex.rxjava4.functions.BiFunction;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
 import java.util.Objects;
 
 /**
@@ -45,6 +46,7 @@ public final class FlowableReduce<T> extends AbstractFlowableWithUpstream<T, T> 
 
     static final class ReduceSubscriber<T> extends DeferredScalarSubscription<T> implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -4663883003264602070L;
 
         final BiFunction<T, T, T> reducer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCount.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -147,6 +148,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
     static final class RefConnection extends AtomicReference<Disposable>
     implements Runnable, Consumer<Disposable> {
 
+        @Serial
         private static final long serialVersionUID = -4552101107598366241L;
 
         final FlowableRefCount<?> parent;
@@ -182,6 +184,7 @@ public final class FlowableRefCount<T> extends Flowable<T> {
     static final class RefCountSubscriber<T>
     extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -7419642935409022375L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeat.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeat.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -38,6 +39,7 @@ public final class FlowableRepeat<T> extends AbstractFlowableWithUpstream<T, T> 
 
     static final class RepeatSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -40,6 +41,7 @@ public final class FlowableRepeatUntil<T> extends AbstractFlowableWithUpstream<T
 
     static final class RepeatSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatWhen.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRepeatWhen.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -68,6 +69,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
     extends AtomicInteger
     implements FlowableSubscriber<Object>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 2827772011130406689L;
 
         final Publisher<T> source;
@@ -131,6 +133,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
     abstract static class WhenSourceSubscriber<T, U> extends SubscriptionArbiter implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -5604623027276966720L;
 
         protected final Subscriber<? super T> downstream;
@@ -180,6 +183,7 @@ public final class FlowableRepeatWhen<T> extends AbstractFlowableWithUpstream<T,
 
     static final class RepeatWhenSubscriber<T> extends WhenSourceSubscriber<T, Object> {
 
+        @Serial
         private static final long serialVersionUID = -2680129890138081029L;
 
         RepeatWhenSubscriber(Subscriber<? super T> actual, FlowableProcessor<Object> processor,

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplay.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
@@ -226,6 +227,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
     static final class ReplaySubscriber<T>
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = 7224554242710036740L;
         /** Holds notifications from upstream. */
         final ReplayBuffer<T> buffer;
@@ -459,6 +461,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     static final class InnerSubscription<T> extends AtomicLong implements Subscription, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4453897557930727610L;
         /**
          * The parent subscriber-to-source used to allow removing the child in case of
@@ -590,6 +593,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     static final class UnboundedReplayBuffer<T> extends ArrayList<Object> implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 7063189396499112664L;
         /** The total number of events in the buffer. */
         volatile int size;
@@ -686,6 +690,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     static final class Node extends AtomicReference<Node> {
 
+        @Serial
         private static final long serialVersionUID = 245354315435971818L;
         final Object value;
         final long index;
@@ -704,6 +709,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     abstract static class BoundedReplayBuffer<T> extends AtomicReference<Node> implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 2346567790059478686L;
 
         final boolean eagerTruncate;
@@ -949,6 +955,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     static final class SizeBoundReplayBuffer<T> extends BoundedReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = -5898283885385201806L;
 
         final int limit;
@@ -975,6 +982,7 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
      */
     static final class SizeAndTimeBoundReplayBuffer<T> extends BoundedReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 3457957419649567404L;
         final Scheduler scheduler;
         final long maxAge;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryBiPredicate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -42,6 +43,7 @@ public final class FlowableRetryBiPredicate<T> extends AbstractFlowableWithUpstr
 
     static final class RetryBiSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryPredicate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryPredicate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -44,6 +45,7 @@ public final class FlowableRetryPredicate<T> extends AbstractFlowableWithUpstrea
 
     static final class RetrySubscriber<T> extends AtomicInteger implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWhen.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWhen.java
@@ -23,6 +23,7 @@ import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava4.processors.*;
 import io.reactivex.rxjava4.subscribers.SerializedSubscriber;
 
+import java.io.Serial;
 import java.util.Objects;
 
 public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, T> {
@@ -65,6 +66,7 @@ public final class FlowableRetryWhen<T> extends AbstractFlowableWithUpstream<T, 
 
     static final class RetryWhenSubscriber<T> extends WhenSourceSubscriber<T, Throwable> {
 
+        @Serial
         private static final long serialVersionUID = -2680129890138081029L;
 
         RetryWhenSubscriber(Subscriber<? super T> actual, FlowableProcessor<Throwable> processor,

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSamplePublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -47,6 +48,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
     abstract static class SamplePublisherSubscriber<T> extends AtomicReference<T> implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Subscriber<? super T> downstream;
@@ -169,6 +171,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
     static final class SampleMainNoLast<T> extends SamplePublisherSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -3029755663834015785L;
 
         SampleMainNoLast(Subscriber<? super T> actual, Publisher<?> other) {
@@ -188,6 +191,7 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
 
     static final class SampleMainEmitLast<T> extends SamplePublisherSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -3029755663834015785L;
 
         final AtomicInteger wip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSampleTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -55,6 +56,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
 
     abstract static class SampleTimedSubscriber<T> extends AtomicReference<T> implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Subscriber<? super T> downstream;
@@ -150,6 +152,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
 
     static final class SampleTimedNoLast<T> extends SampleTimedSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7139995637533111443L;
 
         SampleTimedNoLast(Subscriber<? super T> actual, long period, TimeUnit unit, Scheduler scheduler, Consumer<? super T> onDropped) {
@@ -169,6 +172,7 @@ public final class FlowableSampleTimed<T> extends AbstractFlowableWithUpstream<T
 
     static final class SampleTimedEmitLast<T> extends SampleTimedSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7139995637533111443L;
 
         final AtomicInteger wip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanSeed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanSeed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -55,6 +56,7 @@ public final class FlowableScanSeed<T, R> extends AbstractFlowableWithUpstream<T
     static final class ScanSeedSubscriber<T, R>
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
+        @Serial
         private static final long serialVersionUID = -1776795561228106469L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqual.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -60,6 +61,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
     static final class EqualCoordinator<T> extends DeferredScalarSubscription<Boolean>
     implements EqualCoordinatorHelper {
 
+        @Serial
         private static final long serialVersionUID = -6178010334400373240L;
 
         final BiPredicate<? super T, ? super T> comparer;
@@ -245,6 +247,7 @@ public final class FlowableSequenceEqual<T> extends Flowable<Boolean> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 4804128302091633067L;
 
         final EqualCoordinatorHelper parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -58,6 +59,7 @@ public final class FlowableSequenceEqualSingle<T> extends Single<Boolean> implem
     extends AtomicInteger
     implements Disposable, EqualCoordinatorHelper {
 
+        @Serial
         private static final long serialVersionUID = -6178010334400373240L;
 
         final SingleObserver<? super Boolean> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.NoSuchElementException;
 
 import static java.util.concurrent.Flow.*;
@@ -41,6 +42,7 @@ public final class FlowableSingle<T> extends AbstractFlowableWithUpstream<T, T> 
     static final class SingleElementSubscriber<T> extends DeferredScalarSubscription<T>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -5526049321428043809L;
 
         final T defaultValue;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLast.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 
 import static java.util.concurrent.Flow.*;
@@ -35,6 +36,7 @@ public final class FlowableSkipLast<T> extends AbstractFlowableWithUpstream<T, T
 
     static final class SkipLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -3807491841935125653L;
         final Subscriber<? super T> downstream;
         final int skip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipLastTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -46,6 +47,7 @@ public final class FlowableSkipLastTimed<T> extends AbstractFlowableWithUpstream
 
     static final class SkipLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5677354903406201275L;
         final Subscriber<? super T> downstream;
         final long time;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -41,6 +42,7 @@ public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<
 
     static final class SkipUntilMainSubscriber<T> extends AtomicInteger
     implements ConditionalSubscriber<T>, Subscription {
+        @Serial
         private static final long serialVersionUID = -6270983465606289181L;
 
         final Subscriber<? super T> downstream;
@@ -110,6 +112,7 @@ public final class FlowableSkipUntil<T, U> extends AbstractFlowableWithUpstream<
         final class OtherSubscriber extends AtomicReference<Subscription>
         implements FlowableSubscriber<Object> {
 
+            @Serial
             private static final long serialVersionUID = -5592042965931999169L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -51,6 +52,7 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
     static final class SubscribeOnSubscriber<T> extends AtomicReference<Thread>
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 8094547886072529208L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -52,6 +53,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
 
     static final class SwitchMapSubscriber<T, R> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -3491074160481096299L;
         final Subscriber<? super R> downstream;
         final Function<? super T, ? extends Publisher<? extends R>> mapper;
@@ -330,6 +332,7 @@ public final class FlowableSwitchMap<T, R> extends AbstractFlowableWithUpstream<
     static final class SwitchMapInnerSubscriber<T, R>
     extends AtomicReference<Subscription> implements FlowableSubscriber<R> {
 
+        @Serial
         private static final long serialVersionUID = 3837284832786408377L;
         final SwitchMapSubscriber<T, R> parent;
         final long index;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTake.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTake.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -39,6 +40,7 @@ public final class FlowableTake<T> extends AbstractFlowableWithUpstream<T, T> {
     extends AtomicLong
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 2288246011222124525L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLast.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 import java.util.concurrent.atomic.*;
 
@@ -37,6 +38,7 @@ public final class FlowableTakeLast<T> extends AbstractFlowableWithUpstream<T, T
 
     static final class TakeLastSubscriber<T> extends ArrayDeque<T> implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 7240042530241604978L;
         final Subscriber<? super T> downstream;
         final int count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastOne.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastOne.java
@@ -18,6 +18,8 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 
+import java.io.Serial;
+
 public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T, T> {
 
     public FlowableTakeLastOne(Flowable<T> source) {
@@ -32,6 +34,7 @@ public final class FlowableTakeLastOne<T> extends AbstractFlowableWithUpstream<T
     static final class TakeLastOneSubscriber<T> extends DeferredScalarSubscription<T>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -5467847744262967226L;
 
         Subscription upstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -50,6 +51,7 @@ public final class FlowableTakeLastTimed<T> extends AbstractFlowableWithUpstream
 
     static final class TakeLastTimedSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5677354903406201275L;
         final Subscriber<? super T> downstream;
         final long count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -40,6 +41,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
 
     static final class TakeUntilMainSubscriber<T> extends AtomicInteger implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4945480365982832967L;
 
         final Subscriber<? super T> downstream;
@@ -95,6 +97,7 @@ public final class FlowableTakeUntil<T, U> extends AbstractFlowableWithUpstream<
 
         final class OtherSubscriber extends AtomicReference<Subscription> implements FlowableSubscriber<Object> {
 
+            @Serial
             private static final long serialVersionUID = -3592821756711087922L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleFirstTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -59,6 +60,7 @@ public final class FlowableThrottleFirstTimed<T> extends AbstractFlowableWithUps
     static final class DebounceTimedSubscriber<T>
     extends AtomicLong
     implements FlowableSubscriber<T>, Subscription, Runnable {
+        @Serial
         private static final long serialVersionUID = -9102637559663639004L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -70,6 +71,7 @@ public final class FlowableThrottleLatest<T> extends AbstractFlowableWithUpstrea
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -8296689127439125014L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeout.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeout.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.*;
@@ -66,6 +67,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
     static final class TimeoutSubscriber<T> extends AtomicLong
     implements FlowableSubscriber<T>, Subscription, TimeoutSelectorSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Subscriber<? super T> downstream;
@@ -189,6 +191,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
     static final class TimeoutFallbackSubscriber<T> extends SubscriptionArbiter
     implements FlowableSubscriber<T>, TimeoutSelectorSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Subscriber<? super T> downstream;
@@ -331,6 +334,7 @@ public final class FlowableTimeout<T, U, V> extends AbstractFlowableWithUpstream
     static final class TimeoutConsumer extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8708641127342403073L;
 
         final TimeoutSelectorSupport parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 
 import static io.reactivex.rxjava4.internal.util.ExceptionHelper.timeoutMessage;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -58,6 +59,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
     static final class TimeoutSubscriber<T> extends AtomicLong
     implements FlowableSubscriber<T>, Subscription, TimeoutSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Subscriber<? super T> downstream;
@@ -174,6 +176,7 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
     static final class TimeoutFallbackSubscriber<T> extends SubscriptionArbiter
     implements FlowableSubscriber<T>, TimeoutSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,6 +48,7 @@ public final class FlowableTimer extends Flowable<Long> {
     static final class TimerSubscriber extends AtomicReference<Disposable>
     implements Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -2809475196591179431L;
 
         final Subscriber<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToList.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToList.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Collection;
 
 import static java.util.concurrent.Flow.*;
@@ -48,6 +49,7 @@ public final class FlowableToList<T, U extends Collection<? super T>> extends Ab
     extends DeferredScalarSubscription<U>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -8134157938864266736L;
         Subscription upstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUnsubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.concurrent.Flow.*;
@@ -35,6 +36,7 @@ public final class FlowableUnsubscribeOn<T> extends AbstractFlowableWithUpstream
 
     static final class UnsubscribeSubscriber<T> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 1015244841293359600L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsing.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -75,6 +76,7 @@ public final class FlowableUsing<T, D> extends Flowable<T> {
 
     static final class UsingSubscriber<T, D> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 5904473792286235046L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindow.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindow.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 import java.util.concurrent.atomic.*;
 
@@ -54,6 +55,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -2365647875069161133L;
 
         final Subscriber<? super Flowable<T>> downstream;
@@ -168,6 +170,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -8792836352386833856L;
 
         final Subscriber<? super Flowable<T>> downstream;
@@ -300,6 +303,7 @@ public final class FlowableWindow<T> extends AbstractFlowableWithUpstream<T, Flo
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 2428527070996323976L;
 
         final Subscriber<? super Flowable<T>> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -53,6 +54,7 @@ public final class FlowableWindowBoundary<T, B> extends AbstractFlowableWithUpst
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 2233020065421370272L;
 
         final Subscriber<? super Flowable<T>> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -53,6 +54,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
     static final class WindowBoundaryMainSubscriber<T, B, V>
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
+        @Serial
         private static final long serialVersionUID = 8646217640096099753L;
 
         final Subscriber<? super Flowable<T>> downstream;
@@ -339,6 +341,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
         static final class WindowStartSubscriber<B> extends AtomicReference<Subscription>
         implements FlowableSubscriber<B> {
 
+            @Serial
             private static final long serialVersionUID = -3326496781427702834L;
 
             final WindowBoundaryMainSubscriber<?, B, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
@@ -73,6 +74,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     abstract static class AbstractWindowSubscriber<T>
     extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
+        @Serial
         private static final long serialVersionUID = 5724293814035355511L;
 
         final Subscriber<? super Flowable<T>> downstream;
@@ -172,6 +174,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             extends AbstractWindowSubscriber<T>
             implements Runnable {
 
+        @Serial
         private static final long serialVersionUID = 1155822639622580836L;
 
         final Scheduler scheduler;
@@ -331,6 +334,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     static final class WindowExactBoundedSubscriber<T>
     extends AbstractWindowSubscriber<T>
     implements Runnable {
+        @Serial
         private static final long serialVersionUID = -6130475889925953722L;
 
         final Scheduler scheduler;
@@ -453,8 +457,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                         upstreamCancelled = true;
                         continue;
                     } else if (!isEmpty) {
-                        if (o instanceof WindowBoundaryRunnable) {
-                            WindowBoundaryRunnable boundary = (WindowBoundaryRunnable) o;
+                        if (o instanceof WindowBoundaryRunnable boundary) {
                             if (boundary.index == emitted || !restartTimerOnMaxSize) {
                                 this.count = 0;
                                 window = createNewWindow(window);
@@ -544,6 +547,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
     static final class WindowSkipSubscriber<T>
     extends AbstractWindowSubscriber<T>
     implements Runnable {
+        @Serial
         private static final long serialVersionUID = -7852870764194095894L;
 
         final long timeskip;
@@ -667,7 +671,7 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
                             }
                         } else if (o == WINDOW_CLOSE) {
                             if (!windows.isEmpty()) {
-                                windows.remove(0).onComplete();
+                                windows.removeFirst().onComplete();
                             }
                         } else {
                             @SuppressWarnings("unchecked")

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFrom.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -49,6 +50,7 @@ public final class FlowableWithLatestFrom<T, U, R> extends AbstractFlowableWithU
     static final class WithLatestFromSubscriber<T, U, R> extends AtomicReference<U>
     implements ConditionalSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -312246233408980075L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -98,6 +99,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
     extends AtomicInteger
     implements ConditionalSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 1577321883966341961L;
 
         final Subscriber<? super R> downstream;
@@ -254,6 +256,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object> {
 
+        @Serial
         private static final long serialVersionUID = 3256684027868224024L;
 
         final WithLatestFromSubscriber<?, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZip.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.flowable;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -83,6 +84,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
     extends AtomicInteger
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = -2434867452883857743L;
 
         final Subscriber<? super R> downstream;
@@ -311,6 +313,7 @@ public final class FlowableZip<T, R> extends Flowable<R> {
 
     static final class ZipSubscriber<T, R> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4627193790118206028L;
 
         final ZipCoordinator<T, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCache.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -173,6 +174,7 @@ public final class MaybeCache<T> extends Maybe<T> implements MaybeObserver<T> {
     extends AtomicReference<MaybeCache<T>>
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5791853038359966195L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.MaybeObserver;
@@ -33,6 +34,7 @@ public final class MaybeCallbackObserver<T>
 extends AtomicReference<Disposable>
 implements MaybeObserver<T>, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -6076952298809384986L;
 
     final Consumer<? super T> onSuccess;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -47,6 +48,7 @@ public final class MaybeConcatArray<T> extends Flowable<T> {
     extends AtomicInteger
     implements MaybeObserver<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3520831347801429610L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayDelayError.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayDelayError.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -48,6 +49,7 @@ public final class MaybeConcatArrayDelayError<T> extends Flowable<T> {
     extends AtomicInteger
     implements MaybeObserver<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3520831347801429610L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -61,6 +62,7 @@ public final class MaybeConcatIterable<T> extends Flowable<T> {
     extends AtomicInteger
     implements MaybeObserver<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3520831347801429610L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -60,6 +61,7 @@ public final class MaybeCreate<T> extends Maybe<T> {
             this.downstream = downstream;
         }
 
+        @Serial
         private static final long serialVersionUID = -2467358622224974244L;
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelay.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -52,6 +53,7 @@ public final class MaybeDelay<T> extends AbstractMaybeWithUpstream<T, T> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 5566860102500855068L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -106,6 +107,7 @@ public final class MaybeDelayOtherPublisher<T, U> extends AbstractMaybeWithUpstr
     AtomicReference<Subscription>
     implements FlowableSubscriber<Object> {
 
+        @Serial
         private static final long serialVersionUID = -1215060610805418006L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionOtherPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -119,6 +120,7 @@ public final class MaybeDelaySubscriptionOtherPublisher<T, U> extends AbstractMa
     static final class DelayMaybeObserver<T> extends AtomicReference<Disposable>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 706635022205076709L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -38,6 +39,7 @@ public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
     static final class OtherObserver<T>
     extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable {
+        @Serial
         private static final long serialVersionUID = 703409937383992161L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoFinally.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -44,6 +45,7 @@ public final class MaybeDoFinally<T> extends AbstractMaybeWithUpstream<T, T> {
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeEqualSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -127,6 +128,7 @@ public final class MaybeEqualSingle<T> extends Single<Boolean> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -3031974433025990931L;
 
         final EqualCoordinator<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapBiSelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapBiSelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -112,6 +113,7 @@ public final class MaybeFlatMapBiSelector<T, U, R> extends AbstractMaybeWithUpst
         extends AtomicReference<Disposable>
         implements MaybeObserver<U> {
 
+            @Serial
             private static final long serialVersionUID = -2897979525538174559L;
 
             final MaybeObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,6 +49,7 @@ public final class MaybeFlatMapCompletable<T> extends Completable {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2177128922851101253L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -55,6 +56,7 @@ public final class MaybeFlatMapIterableFlowable<T, R> extends Flowable<R> {
     extends BasicIntQueueSubscription<R>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -8938804753851907758L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotification.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,6 +56,7 @@ public final class MaybeFlatMapNotification<T, R> extends AbstractMaybeWithUpstr
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4375739915521278546L;
 
         final MaybeObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -49,6 +50,7 @@ public final class MaybeFlatMapSingle<T, R> extends Maybe<R> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4827726964688405508L;
 
         final MaybeObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatten.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatten.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,6 +47,7 @@ public final class MaybeFlatten<T, R> extends AbstractMaybeWithUpstream<T, R> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4375739915521278546L;
 
         final MaybeObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.*;
@@ -69,6 +70,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
     static final class MergeMaybeObserver<T>
     extends BasicIntQueueSubscription<T> implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -660395290758764731L;
 
         final Subscriber<? super T> downstream;
@@ -315,6 +317,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
     extends AtomicReferenceArray<T>
     implements SimpleQueueWithConsumerIndex<T> {
 
+        @Serial
         private static final long serialVersionUID = -7969063454040569579L;
         final AtomicInteger producerIndex;
 
@@ -401,6 +404,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
 
     static final class ClqSimpleQueue<T> extends ConcurrentLinkedQueue<T> implements SimpleQueueWithConsumerIndex<T> {
 
+        @Serial
         private static final long serialVersionUID = -4025173261791142821L;
 
         int consumerIndex;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeObserveOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -42,6 +43,7 @@ public final class MaybeObserveOn<T> extends AbstractMaybeWithUpstream<T, T> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 8571289934935992137L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorNext.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,6 +47,7 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 2026620218879969836L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -61,6 +62,7 @@ public final class MaybeSubscribeOn<T> extends AbstractMaybeWithUpstream<T, T> {
 
         final SequentialDisposable task;
 
+        @Serial
         private static final long serialVersionUID = 8571289934935992137L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmpty.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -42,6 +43,7 @@ public final class MaybeSwitchIfEmpty<T> extends AbstractMaybeWithUpstream<T, T>
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2223459372976438024L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class MaybeSwitchIfEmptySingle<T> extends Single<T> implements HasU
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4603919676453758899L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class MaybeTakeUntilMaybe<T, U> extends AbstractMaybeWithUpstream<T
     static final class TakeUntilMainMaybeObserver<T, U>
     extends AtomicReference<Disposable> implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2187421758664251153L;
 
         final MaybeObserver<? super T> downstream;
@@ -119,6 +121,7 @@ public final class MaybeTakeUntilMaybe<T, U> extends AbstractMaybeWithUpstream<T
         static final class TakeUntilOtherMaybeObserver<U>
         extends AtomicReference<Disposable> implements MaybeObserver<U> {
 
+            @Serial
             private static final long serialVersionUID = -1266041316834525931L;
 
             final TakeUntilMainMaybeObserver<?, U> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTakeUntilPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -52,6 +53,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
     static final class TakeUntilMainMaybeObserver<T, U>
     extends AtomicReference<Disposable> implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2187421758664251153L;
 
         final MaybeObserver<? super T> downstream;
@@ -122,6 +124,7 @@ public final class MaybeTakeUntilPublisher<T, U> extends AbstractMaybeWithUpstre
         static final class TakeUntilOtherMaybeObserver<U>
         extends AtomicReference<Subscription> implements FlowableSubscriber<U> {
 
+            @Serial
             private static final long serialVersionUID = -1266041316834525931L;
 
             final TakeUntilMainMaybeObserver<?, U> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +55,7 @@ public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, 
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5955289211445418871L;
 
         final MaybeObserver<? super T> downstream;
@@ -140,6 +142,7 @@ public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, 
     extends AtomicReference<Disposable>
     implements MaybeObserver<Object> {
 
+        @Serial
         private static final long serialVersionUID = 8663801314800248617L;
 
         final TimeoutMainMaybeObserver<T, U> parent;
@@ -172,6 +175,7 @@ public final class MaybeTimeoutMaybe<T, U> extends AbstractMaybeWithUpstream<T, 
     extends AtomicReference<Disposable>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 8663801314800248617L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -57,6 +58,7 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
     extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5955289211445418871L;
 
         final MaybeObserver<? super T> downstream;
@@ -143,6 +145,7 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object> {
 
+        @Serial
         private static final long serialVersionUID = 8663801314800248617L;
 
         final TimeoutMainMaybeObserver<T, U> parent;
@@ -177,6 +180,7 @@ public final class MaybeTimeoutPublisher<T, U> extends AbstractMaybeWithUpstream
     extends AtomicReference<Disposable>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 8663801314800248617L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,6 +47,7 @@ public final class MaybeTimer extends Maybe<Long> {
 
     static final class TimerDisposable extends AtomicReference<Disposable> implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 2875964065294031672L;
         final MaybeObserver<? super Long> downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToFlowable.java
@@ -21,6 +21,8 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.internal.subscriptions.DeferredScalarSubscription;
 
+import java.io.Serial;
+
 /**
  * Wraps a MaybeSource and exposes it as a Flowable, relaying signals in a backpressure-aware manner
  * and composes cancellation through.
@@ -48,6 +50,7 @@ public final class MaybeToFlowable<T> extends Flowable<T> implements HasUpstream
     static final class MaybeToFlowableSubscriber<T> extends DeferredScalarSubscription<T>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 7603343402964826922L;
 
         Disposable upstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeToObservable.java
@@ -19,6 +19,8 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 import io.reactivex.rxjava4.internal.observers.DeferredScalarDisposable;
 
+import java.io.Serial;
+
 /**
  * Wraps a MaybeSource and exposes it as an Observable, relaying signals in a backpressure-aware manner
  * and composes cancellation through.
@@ -58,6 +60,7 @@ public final class MaybeToObservable<T> extends Observable<T> implements HasUpst
     static final class MaybeToObservableObserver<T> extends DeferredScalarDisposable<T>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 7603343402964826922L;
 
         Disposable upstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -41,6 +42,7 @@ public final class MaybeUnsubscribeOn<T> extends AbstractMaybeWithUpstream<T, T>
     static final class UnsubscribeOnMaybeObserver<T> extends AtomicReference<Disposable>
     implements MaybeObserver<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 3256698449646456986L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsing.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -98,6 +99,7 @@ public final class MaybeUsing<T, D> extends Maybe<T> {
     extends AtomicReference<Object>
     implements MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -674404550052917487L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.maybe;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -65,6 +66,7 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
 
     static final class ZipCoordinator<T, R> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5556924161382950569L;
 
         final MaybeObserver<? super R> downstream;
@@ -160,6 +162,7 @@ public final class MaybeZipArray<T, R> extends Maybe<R> {
     extends AtomicReference<Disposable>
     implements MaybeObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 3323743579927613702L;
 
         final ZipCoordinator<T, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class CompletableAndThenObservable<R> extends Observable<R> {
     extends AtomicReference<Disposable>
     implements Observer<R>, CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8948264376121066672L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/CompletableAndThenPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -50,6 +51,7 @@ public final class CompletableAndThenPublisher<R> extends Flowable<R> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<R>, CompletableObserver, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -8948264376121066672L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ConcatMapXMainObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ConcatMapXMainObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.ErrorMode;
@@ -34,6 +35,7 @@ import io.reactivex.rxjava4.operators.SpscLinkedArrayQueue;
 public abstract class ConcatMapXMainObserver<T> extends AtomicInteger
 implements Observer<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -3214213361171757852L;
 
     final AtomicThrowable errors;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ConcatMapXMainSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ConcatMapXMainSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -36,6 +37,7 @@ import io.reactivex.rxjava4.operators.SpscArrayQueue;
 public abstract class ConcatMapXMainSubscriber<T> extends AtomicInteger
 implements FlowableSubscriber<T> {
 
+    @Serial
     private static final long serialVersionUID = -3214213361171757852L;
 
     final AtomicThrowable errors;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -60,6 +61,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
     extends ConcatMapXMainSubscriber<T>
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 3610901111000061034L;
 
         final CompletableObserver downstream;
@@ -203,6 +205,7 @@ public final class FlowableConcatMapCompletable<T> extends Completable {
         static final class ConcatMapInnerObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = 5638352172918776687L;
 
             final ConcatMapCompletableObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -62,6 +63,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
     static final class ConcatMapMaybeSubscriber<T, R>
     extends ConcatMapXMainSubscriber<T> implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = -9140123220065488293L;
 
         final Subscriber<? super R> downstream;
@@ -258,6 +260,7 @@ public final class FlowableConcatMapMaybe<T, R> extends Flowable<R> {
         extends AtomicReference<Disposable>
         implements MaybeObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = -3051469169682093892L;
 
             final ConcatMapMaybeSubscriber<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -62,6 +63,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
     static final class ConcatMapSingleSubscriber<T, R>
     extends ConcatMapXMainSubscriber<T> implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = -9140123220065488293L;
 
         final Subscriber<? super R> downstream;
@@ -253,6 +255,7 @@ public final class FlowableConcatMapSingle<T, R> extends Flowable<R> {
         extends AtomicReference<Disposable>
         implements SingleObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = -3051469169682093892L;
 
             final ConcatMapSingleSubscriber<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -189,6 +190,7 @@ public final class FlowableSwitchMapCompletable<T> extends Completable {
         static final class SwitchMapInnerObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = -8003404460084760287L;
 
             final SwitchMapCompletableObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -60,6 +61,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
     static final class SwitchMapMaybeSubscriber<T, R> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5402190102429853762L;
 
         final Subscriber<? super R> downstream;
@@ -255,6 +257,7 @@ public final class FlowableSwitchMapMaybe<T, R> extends Flowable<R> {
         static final class SwitchMapMaybeObserver<R>
         extends AtomicReference<Disposable> implements MaybeObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = 8042919737683345351L;
 
             final SwitchMapMaybeSubscriber<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -60,6 +61,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
     static final class SwitchMapSingleSubscriber<T, R> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -5402190102429853762L;
 
         final Subscriber<? super R> downstream;
@@ -249,6 +251,7 @@ public final class FlowableSwitchMapSingle<T, R> extends Flowable<R> {
         static final class SwitchMapSingleObserver<R>
         extends AtomicReference<Disposable> implements SingleObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = 8042919737683345351L;
 
             final SwitchMapSingleSubscriber<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,6 +54,7 @@ public final class MaybeFlatMapObservable<T, R> extends Observable<R> {
     extends AtomicReference<Disposable>
     implements Observer<R>, MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8948264376121066672L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/MaybeFlatMapPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -54,6 +55,7 @@ public final class MaybeFlatMapPublisher<T, R> extends Flowable<R> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<R>, MaybeObserver<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -8948264376121066672L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -61,6 +62,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
     static final class ConcatMapCompletableObserver<T>
     extends ConcatMapXMainObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 3610901111000061034L;
 
         final CompletableObserver downstream;
@@ -169,6 +171,7 @@ public final class ObservableConcatMapCompletable<T> extends Completable {
         static final class ConcatMapInnerObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = 5638352172918776687L;
 
             final ConcatMapCompletableObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -62,6 +63,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
     static final class ConcatMapMaybeMainObserver<T, R>
     extends ConcatMapXMainObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -9140123220065488293L;
 
         final Observer<? super R> downstream;
@@ -222,6 +224,7 @@ public final class ObservableConcatMapMaybe<T, R> extends Observable<R> {
         extends AtomicReference<Disposable>
         implements MaybeObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = -3051469169682093892L;
 
             final ConcatMapMaybeMainObserver<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -62,6 +63,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
     static final class ConcatMapSingleMainObserver<T, R>
     extends ConcatMapXMainObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -9140123220065488293L;
 
         final Observer<? super R> downstream;
@@ -217,6 +219,7 @@ public final class ObservableConcatMapSingle<T, R> extends Observable<R> {
         extends AtomicReference<Disposable>
         implements SingleObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = -3051469169682093892L;
 
             final ConcatMapSingleMainObserver<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -187,6 +188,7 @@ public final class ObservableSwitchMapCompletable<T> extends Completable {
         static final class SwitchMapInnerObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = -8003404460084760287L;
 
             final SwitchMapCompletableObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
     static final class SwitchMapMaybeMainObserver<T, R> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5402190102429853762L;
 
         final Observer<? super R> downstream;
@@ -242,6 +244,7 @@ public final class ObservableSwitchMapMaybe<T, R> extends Observable<R> {
         static final class SwitchMapMaybeObserver<R>
         extends AtomicReference<Disposable> implements MaybeObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = 8042919737683345351L;
 
             final SwitchMapMaybeMainObserver<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
     static final class SwitchMapSingleMainObserver<T, R> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5402190102429853762L;
 
         final Observer<? super R> downstream;
@@ -236,6 +238,7 @@ public final class ObservableSwitchMapSingle<T, R> extends Observable<R> {
         static final class SwitchMapSingleObserver<R>
         extends AtomicReference<Disposable> implements SingleObserver<R> {
 
+            @Serial
             private static final long serialVersionUID = 8042919737683345351L;
 
             final SwitchMapSingleMainObserver<?, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/SingleFlatMapObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/mixed/SingleFlatMapObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.mixed;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,6 +54,7 @@ public final class SingleFlatMapObservable<T, R> extends Observable<R> {
     extends AtomicReference<Disposable>
     implements Observer<R>, SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8948264376121066672L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableIterable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.*;
@@ -44,6 +45,7 @@ public final class BlockingObservableIterable<T> implements Iterable<T> {
     extends AtomicReference<Disposable>
     implements io.reactivex.rxjava4.core.Observer<T>, Iterator<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 6695226475494099826L;
 
         final SpscLinkedArrayQueue<T> queue;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmb.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -139,6 +140,7 @@ public final class ObservableAmb<T> extends Observable<T> {
 
     static final class AmbInnerObserver<T> extends AtomicReference<Disposable> implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -1185974347409665484L;
         final AmbCoordinator<T> parent;
         final int index;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBuffer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBuffer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -140,6 +141,7 @@ public final class ObservableBuffer<T, U extends Collection<? super T>> extends 
     static final class BufferSkipObserver<T, U extends Collection<? super T>>
     extends AtomicBoolean implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8223395059921494546L;
         final Observer<? super U> downstream;
         final int count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferBoundary.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -53,6 +54,7 @@ extends AbstractObservableWithUpstream<T, U> {
     static final class BufferBoundaryObserver<T, C extends Collection<? super T>, Open, Close>
     extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8466418554264089604L;
 
         final Observer<? super C> downstream;
@@ -279,6 +281,7 @@ extends AbstractObservableWithUpstream<T, U> {
         extends AtomicReference<Disposable>
         implements Observer<Open>, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -8498650778633225126L;
 
             final BufferBoundaryObserver<?, ?, Open, ?> parent;
@@ -325,6 +328,7 @@ extends AbstractObservableWithUpstream<T, U> {
     extends AtomicReference<Disposable>
     implements Observer<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8498650778633225126L;
 
         final BufferBoundaryObserver<T, C, ?, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCache.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -113,6 +114,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
     static final class Multicaster<T> extends AtomicReference<CacheDisposable<T>[]> implements Observer<T> {
 
         /** */
+        @Serial
         private static final long serialVersionUID = 8514643269016498691L;
 
         /**
@@ -353,6 +355,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
     static final class CacheDisposable<T> extends AtomicInteger
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 6770240836423125754L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -79,6 +80,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
 
     static final class LatestCoordinator<T, R> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8567835998786448817L;
         final Observer<? super R> downstream;
         final Function<? super Object[], ? extends R> combiner;
@@ -281,6 +283,7 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
     }
 
     static final class CombinerObserver<T, R> extends AtomicReference<Disposable> implements Observer<T> {
+        @Serial
         private static final long serialVersionUID = -4823716997131257941L;
 
         final LatestCoordinator<T, R> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
 
     static final class SourceObserver<T, U> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8828587559905699186L;
         final Observer<? super U> downstream;
         final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
@@ -232,6 +234,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
 
         static final class InnerObserver<U> extends AtomicReference<Disposable> implements Observer<U> {
 
+            @Serial
             private static final long serialVersionUID = -7449079488798789337L;
 
             final Observer<? super U> downstream;
@@ -273,6 +276,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
     extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -6951100001833242599L;
 
         final Observer<? super R> downstream;
@@ -479,6 +483,7 @@ public final class ObservableConcatMap<T, U> extends AbstractObservableWithUpstr
 
         static final class DelayErrorInnerObserver<R> extends AtomicReference<Disposable> implements Observer<R> {
 
+            @Serial
             private static final long serialVersionUID = 2620149119579502636L;
 
             final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEager.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEager.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -58,6 +59,7 @@ public final class ObservableConcatMapEager<T, R> extends AbstractObservableWith
     extends AtomicInteger
     implements Observer<T>, Disposable, InnerQueuedObserverSupport<R> {
 
+        @Serial
         private static final long serialVersionUID = 8080567949447303262L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -59,6 +60,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
 
     static final class ConcatMapObserver<T, U> extends AtomicInteger implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 8828587559905699186L;
         final Observer<? super U> downstream;
         final Function<? super T, ? extends ObservableSource<? extends U>> mapper;
@@ -243,6 +245,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
 
         static final class InnerObserver<U> extends AtomicReference<Disposable> implements Observer<U> {
 
+            @Serial
             private static final long serialVersionUID = -7449079488798789337L;
 
             final Observer<? super U> downstream;
@@ -284,6 +287,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
     extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -6951100001833242599L;
 
         final Observer<? super R> downstream;
@@ -503,6 +507,7 @@ public final class ObservableConcatMapScheduler<T, U> extends AbstractObservable
 
         static final class DelayErrorInnerObserver<R> extends AtomicReference<Disposable> implements Observer<R> {
 
+            @Serial
             private static final long serialVersionUID = 2620149119579502636L;
 
             final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -44,6 +45,7 @@ public final class ObservableConcatWithCompletable<T> extends AbstractObservable
     extends AtomicReference<Disposable>
     implements Observer<T>, CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -1953724749712440952L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -44,6 +45,7 @@ public final class ObservableConcatWithMaybe<T> extends AbstractObservableWithUp
     extends AtomicReference<Disposable>
     implements Observer<T>, MaybeObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -1953724749712440952L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatWithSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -44,6 +45,7 @@ public final class ObservableConcatWithSingle<T> extends AbstractObservableWithU
     extends AtomicReference<Disposable>
     implements Observer<T>, SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -1953724749712440952L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class ObservableCreate<T> extends Observable<T> {
     extends AtomicReference<Disposable>
     implements ObservableEmitter<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3434801548987643227L;
 
         final Observer<? super T> observer;
@@ -142,6 +144,7 @@ public final class ObservableCreate<T> extends Observable<T> {
     extends AtomicInteger
     implements ObservableEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = 4883307006032401862L;
 
         final ObservableEmitter<T> emitter;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -161,6 +162,7 @@ public final class ObservableDebounceTimed<T> extends AbstractObservableWithUpst
 
     static final class DebounceEmitter<T> extends AtomicReference<Disposable> implements Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 6812032969491025141L;
 
         final T value;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerialize.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerialize.java
@@ -72,8 +72,7 @@ public final class ObservableDematerialize<T, R> extends AbstractObservableWithU
         @Override
         public void onNext(T item) {
             if (done) {
-                if (item instanceof Notification) {
-                    Notification<?> notification = (Notification<?>)item;
+                if (item instanceof Notification<?> notification) {
                     if (notification.isOnError()) {
                         RxJavaPlugins.onError(notification.getError());
                     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinally.java
@@ -23,6 +23,8 @@ import io.reactivex.rxjava4.internal.observers.BasicIntQueueDisposable;
 import io.reactivex.rxjava4.operators.QueueDisposable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 /**
  * Execute an action after an onError, onComplete or a dispose event.
  * <p>History: 2.0.1 - experimental
@@ -45,6 +47,7 @@ public final class ObservableDoFinally<T> extends AbstractObservableWithUpstream
 
     static final class DoFinallyObserver<T> extends BasicIntQueueDisposable<T> implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -54,6 +55,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
 
     static final class MergeObserver<T, U> extends AtomicInteger implements Disposable, Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -2117620485640801370L;
 
         final Observer<? super U> downstream;
@@ -479,6 +481,7 @@ public final class ObservableFlatMap<T, U> extends AbstractObservableWithUpstrea
     static final class InnerObserver<T, U> extends AtomicReference<Disposable>
     implements Observer<U> {
 
+        @Serial
         private static final long serialVersionUID = -4606175640614850599L;
         final long id;
         final MergeObserver<T, U> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -49,6 +50,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
 
     static final class FlatMapCompletableMainObserver<T> extends BasicIntQueueDisposable<T>
     implements Observer<T> {
+        @Serial
         private static final long serialVersionUID = 8443155186132538303L;
 
         final Observer<? super T> downstream;
@@ -173,6 +175,7 @@ public final class ObservableFlatMapCompletable<T> extends AbstractObservableWit
         }
 
         final class InnerObserver extends AtomicReference<Disposable> implements CompletableObserver, Disposable {
+            @Serial
             private static final long serialVersionUID = 8606673141535671828L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -55,6 +56,7 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
     }
 
     static final class FlatMapCompletableMainObserver<T> extends AtomicInteger implements Disposable, Observer<T> {
+        @Serial
         private static final long serialVersionUID = 8443155186132538303L;
 
         final CompletableObserver downstream;
@@ -158,6 +160,7 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
         }
 
         final class InnerObserver extends AtomicReference<Disposable> implements CompletableObserver, Disposable {
+            @Serial
             private static final long serialVersionUID = 8606673141535671828L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -51,6 +52,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
     extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8600231336733376951L;
 
         final Observer<? super R> downstream;
@@ -277,6 +279,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
         final class InnerObserver extends AtomicReference<Disposable>
         implements MaybeObserver<R>, Disposable {
+            @Serial
             private static final long serialVersionUID = -502562646270949838L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -51,6 +52,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
     extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8600231336733376951L;
 
         final Observer<? super R> downstream;
@@ -256,6 +258,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
         final class InnerObserver extends AtomicReference<Disposable>
         implements SingleObserver<R>, Disposable {
+            @Serial
             private static final long serialVersionUID = -502562646270949838L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupBy.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.*;
@@ -49,6 +50,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
     public static final class GroupByObserver<T, K, V> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3688291656102519502L;
 
         final Observer<? super GroupedObservable<K, V>> downstream;
@@ -221,6 +223,7 @@ public final class ObservableGroupBy<T, K, V> extends AbstractObservableWithUpst
 
     static final class State<T, K> extends AtomicInteger implements Disposable, ObservableSource<T> {
 
+        @Serial
         private static final long serialVersionUID = -3852313036005250360L;
 
         final K key;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -84,6 +85,7 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
     static final class GroupJoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Disposable, JoinSupport {
 
+        @Serial
         private static final long serialVersionUID = -6071216598687999801L;
 
         final Observer<? super R> downstream;
@@ -378,6 +380,7 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
     extends AtomicReference<Disposable>
     implements Observer<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1883890389173668373L;
 
         final JoinSupport parent;
@@ -425,6 +428,7 @@ public final class ObservableGroupJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> ex
     extends AtomicReference<Disposable>
     implements Observer<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1883890389173668373L;
 
         final JoinSupport parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInterval.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInterval.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -56,6 +57,7 @@ public final class ObservableInterval extends Observable<Long> {
     extends AtomicReference<Disposable>
     implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 346773832286157679L;
 
         final Observer<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableIntervalRange.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableIntervalRange.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -60,6 +61,7 @@ public final class ObservableIntervalRange extends Observable<Long> {
     extends AtomicReference<Disposable>
     implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 1891866368734007884L;
 
         final Observer<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -70,6 +71,7 @@ public final class ObservableJoin<TLeft, TRight, TLeftEnd, TRightEnd, R> extends
     static final class JoinDisposable<TLeft, TRight, TLeftEnd, TRightEnd, R>
     extends AtomicInteger implements Disposable, JoinSupport {
 
+        @Serial
         private static final long serialVersionUID = -6071216598687999801L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -47,6 +48,7 @@ public final class ObservableMergeWithCompletable<T> extends AbstractObservableW
     static final class MergeWithObserver<T> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Observer<? super T> downstream;
@@ -119,6 +121,7 @@ public final class ObservableMergeWithCompletable<T> extends AbstractObservableW
         static final class OtherObserver extends AtomicReference<Disposable>
         implements CompletableObserver {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
     static final class MergeWithObserver<T> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Observer<? super T> downstream;
@@ -230,6 +232,7 @@ public final class ObservableMergeWithMaybe<T> extends AbstractObservableWithUps
         static final class OtherObserver<T> extends AtomicReference<Disposable>
         implements MaybeObserver<T> {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithObserver<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -49,6 +50,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
     static final class MergeWithObserver<T> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4592979584110982903L;
 
         final Observer<? super T> downstream;
@@ -225,6 +227,7 @@ public final class ObservableMergeWithSingle<T> extends AbstractObservableWithUp
         static final class OtherObserver<T> extends AtomicReference<Disposable>
         implements SingleObserver<T> {
 
+            @Serial
             private static final long serialVersionUID = -2935427570954647017L;
 
             final MergeWithObserver<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOn.java
@@ -25,6 +25,8 @@ import io.reactivex.rxjava4.operators.SimpleQueue;
 import io.reactivex.rxjava4.operators.SpscLinkedArrayQueue;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream<T, T> {
     final Scheduler scheduler;
     final boolean delayError;
@@ -50,6 +52,7 @@ public final class ObservableObserveOn<T> extends AbstractObservableWithUpstream
     static final class ObserveOnObserver<T> extends BasicIntQueueDisposable<T>
     implements Observer<T>, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 6576896619930983584L;
         final Observer<? super T> downstream;
         final Scheduler.Worker worker;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublish.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublish.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -132,6 +133,7 @@ implements HasUpstreamObservableSource<T> {
     extends AtomicReference<InnerDisposable<T>[]>
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3251430252873581268L;
 
         final AtomicBoolean connect;
@@ -264,6 +266,7 @@ implements HasUpstreamObservableSource<T> {
     extends AtomicReference<PublishConnection<T>>
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 7463222674719692880L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishSelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishSelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -93,6 +94,7 @@ public final class ObservablePublishSelector<T, R> extends AbstractObservableWit
 
     static final class TargetObserver<R>
     extends AtomicReference<Disposable> implements Observer<R>, Disposable {
+        @Serial
         private static final long serialVersionUID = 854110278590336484L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRange.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRange.java
@@ -17,6 +17,8 @@ import io.reactivex.rxjava4.annotations.Nullable;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.observers.BasicIntQueueDisposable;
 
+import java.io.Serial;
+
 /**
  * Emits a range of integer values from start to end.
  */
@@ -39,6 +41,7 @@ public final class ObservableRange extends Observable<Integer> {
     static final class RangeDisposable
     extends BasicIntQueueDisposable<Integer> {
 
+        @Serial
         private static final long serialVersionUID = 396518478098735504L;
 
         final Observer<? super Integer> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLong.java
@@ -17,6 +17,8 @@ import io.reactivex.rxjava4.annotations.Nullable;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.observers.BasicIntQueueDisposable;
 
+import java.io.Serial;
+
 public final class ObservableRangeLong extends Observable<Long> {
     private final long start;
     private final long count;
@@ -36,6 +38,7 @@ public final class ObservableRangeLong extends Observable<Long> {
     static final class RangeDisposable
     extends BasicIntQueueDisposable<Long> {
 
+        @Serial
         private static final long serialVersionUID = 396518478098735504L;
 
         final Observer<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCount.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -145,6 +146,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
     static final class RefConnection extends AtomicReference<Disposable>
     implements Runnable, Consumer<Disposable> {
 
+        @Serial
         private static final long serialVersionUID = -4552101107598366241L;
 
         final ObservableRefCount<?> parent;
@@ -180,6 +182,7 @@ public final class ObservableRefCount<T> extends Observable<T> {
     static final class RefCountObserver<T>
     extends AtomicBoolean implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -7419642935409022375L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeat.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeat.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -37,6 +38,7 @@ public final class ObservableRepeat<T> extends AbstractObservableWithUpstream<T,
 
     static final class RepeatObserver<T> extends AtomicInteger implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -39,6 +40,7 @@ public final class ObservableRepeatUntil<T> extends AbstractObservableWithUpstre
 
     static final class RepeatUntilObserver<T> extends AtomicInteger implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatWhen.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRepeatWhen.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -62,6 +63,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
 
     static final class RepeatWhenObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 802743776666017014L;
 
         final Observer<? super T> downstream;
@@ -156,6 +158,7 @@ public final class ObservableRepeatWhen<T> extends AbstractObservableWithUpstrea
 
         final class InnerRepeatObserver extends AtomicReference<Disposable> implements Observer<Object> {
 
+            @Serial
             private static final long serialVersionUID = 3254781284376480842L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplay.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
@@ -222,6 +223,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     static final class ReplayObserver<T>
     extends AtomicReference<Disposable>
     implements Observer<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = -533785617179540163L;
         /** Holds notifications from upstream. */
         final ReplayBuffer<T> buffer;
@@ -416,6 +418,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
     static final class InnerDisposable<T>
     extends AtomicInteger
     implements Disposable {
+        @Serial
         private static final long serialVersionUID = 2728361546769921047L;
         /**
          * The parent subscriber-to-source used to allow removing the child in case of
@@ -499,6 +502,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     static final class UnboundedReplayBuffer<T> extends ArrayList<Object> implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 7063189396499112664L;
         /** The total number of events in the buffer. */
         volatile int size;
@@ -569,6 +573,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     static final class Node extends AtomicReference<Node> {
 
+        @Serial
         private static final long serialVersionUID = 245354315435971818L;
         final Object value;
         Node(Object value) {
@@ -584,6 +589,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     abstract static class BoundedReplayBuffer<T> extends AtomicReference<Node> implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 2346567790059478686L;
 
         Node tail;
@@ -791,6 +797,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     static final class SizeBoundReplayBuffer<T> extends BoundedReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = -5898283885385201806L;
 
         final int limit;
@@ -818,6 +825,7 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
      */
     static final class SizeAndTimeBoundReplayBuffer<T> extends BoundedReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 3457957419649567404L;
         final Scheduler scheduler;
         final long maxAge;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryBiPredicate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryBiPredicate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -41,6 +42,7 @@ public final class ObservableRetryBiPredicate<T> extends AbstractObservableWithU
 
     static final class RetryBiObserver<T> extends AtomicInteger implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryPredicate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryPredicate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -43,6 +44,7 @@ public final class ObservableRetryPredicate<T> extends AbstractObservableWithUps
 
     static final class RepeatObserver<T> extends AtomicInteger implements Observer<T> {
 
+        @Serial
         private static final long serialVersionUID = -7098360935104053232L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWhen.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWhen.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -62,6 +63,7 @@ public final class ObservableRetryWhen<T> extends AbstractObservableWithUpstream
 
     static final class RepeatWhenObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 802743776666017014L;
 
         final Observer<? super T> downstream;
@@ -156,6 +158,7 @@ public final class ObservableRetryWhen<T> extends AbstractObservableWithUpstream
 
         final class InnerRepeatObserver extends AtomicReference<Disposable> implements Observer<Object> {
 
+            @Serial
             private static final long serialVersionUID = 3254781284376480842L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -56,6 +57,7 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
 
     abstract static class SampleTimedObserver<T> extends AtomicReference<T> implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Observer<? super T> downstream;
@@ -141,6 +143,7 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
 
     static final class SampleTimedNoLast<T> extends SampleTimedObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -7139995637533111443L;
 
         SampleTimedNoLast(Observer<? super T> actual, long period, TimeUnit unit, Scheduler scheduler, Consumer<? super T> onDropped) {
@@ -160,6 +163,7 @@ public final class ObservableSampleTimed<T> extends AbstractObservableWithUpstre
 
     static final class SampleTimedEmitLast<T> extends SampleTimedObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -7139995637533111443L;
 
         final AtomicInteger wip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleWithObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -45,6 +46,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
     abstract static class SampleMainObserver<T> extends AtomicReference<T>
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3517602651313910099L;
 
         final Observer<? super T> downstream;
@@ -154,6 +156,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
 
     static final class SampleMainNoLast<T> extends SampleMainObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -3029755663834015785L;
 
         SampleMainNoLast(Observer<? super T> actual, ObservableSource<?> other) {
@@ -173,6 +176,7 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
 
     static final class SampleMainEmitLast<T> extends SampleMainObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -3029755663834015785L;
 
         final AtomicInteger wip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScalarXMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScalarXMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -177,6 +178,7 @@ public final class ObservableScalarXMap {
     extends AtomicInteger
     implements QueueDisposable<T>, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 3880992722410194083L;
 
         final Observer<? super T> observer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqual.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqual.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -45,6 +46,7 @@ public final class ObservableSequenceEqual<T> extends Observable<Boolean> {
 
     static final class EqualCoordinator<T> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -6178010334400373240L;
         final Observer<? super Boolean> downstream;
         final BiPredicate<? super T, ? super T> comparer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqualSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqualSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -52,6 +53,7 @@ public final class ObservableSequenceEqualSingle<T> extends Single<Boolean> impl
 
     static final class EqualCoordinator<T> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -6178010334400373240L;
         final SingleObserver<? super Boolean> downstream;
         final BiPredicate<? super T, ? super T> comparer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLast.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 
 import io.reactivex.rxjava4.core.*;
@@ -34,6 +35,7 @@ public final class ObservableSkipLast<T> extends AbstractObservableWithUpstream<
 
     static final class SkipLastObserver<T> extends ArrayDeque<T> implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3807491841935125653L;
         final Observer<? super T> downstream;
         final int skip;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipLastTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,6 +46,7 @@ public final class ObservableSkipLastTimed<T> extends AbstractObservableWithUpst
 
     static final class SkipLastTimedObserver<T> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5677354903406201275L;
         final Observer<? super T> downstream;
         final long time;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -38,6 +39,7 @@ public final class ObservableSubscribeOn<T> extends AbstractObservableWithUpstre
 
     static final class SubscribeOnObserver<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8094547886072529208L;
         final Observer<? super T> downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -54,6 +55,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
     static final class SwitchMapObserver<T, R> extends AtomicInteger implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -3491074160481096299L;
         final Observer<? super R> downstream;
         final Function<? super T, ? extends ObservableSource<? extends R>> mapper;
@@ -307,6 +309,7 @@ public final class ObservableSwitchMap<T, R> extends AbstractObservableWithUpstr
 
     static final class SwitchMapInnerObserver<T, R> extends AtomicReference<Disposable> implements Observer<R> {
 
+        @Serial
         private static final long serialVersionUID = 3837284832786408377L;
         final SwitchMapObserver<T, R> parent;
         final long index;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLast.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 
 import io.reactivex.rxjava4.core.*;
@@ -34,6 +35,7 @@ public final class ObservableTakeLast<T> extends AbstractObservableWithUpstream<
 
     static final class TakeLastObserver<T> extends ArrayDeque<T> implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 7240042530241604978L;
         final Observer<? super T> downstream;
         final int count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -48,6 +49,7 @@ public final class ObservableTakeLastTimed<T> extends AbstractObservableWithUpst
     static final class TakeLastTimedObserver<T>
     extends AtomicBoolean implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5677354903406201275L;
         final Observer<? super T> downstream;
         final long count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -41,6 +42,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
     static final class TakeUntilMainObserver<T, U> extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1418547743690811973L;
 
         final Observer<? super T> downstream;
@@ -104,6 +106,7 @@ public final class ObservableTakeUntil<T, U> extends AbstractObservableWithUpstr
         final class OtherObserver extends AtomicReference<Disposable>
         implements Observer<U> {
 
+            @Serial
             private static final long serialVersionUID = -8693423678067375039L;
 
             @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleFirstTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleFirstTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +55,7 @@ public final class ObservableThrottleFirstTimed<T> extends AbstractObservableWit
     static final class DebounceTimedObserver<T>
     extends AtomicReference<Disposable>
     implements Observer<T>, Disposable, Runnable {
+        @Serial
         private static final long serialVersionUID = 786994795061867455L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatest.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
 
@@ -68,6 +69,7 @@ public final class ObservableThrottleLatest<T> extends AbstractObservableWithUps
     extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -8296689127439125014L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeout.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeout.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.*;
@@ -63,6 +64,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
     static final class TimeoutObserver<T> extends AtomicLong
     implements Observer<T>, Disposable, TimeoutSelectorSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Observer<? super T> downstream;
@@ -184,6 +186,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
     extends AtomicReference<Disposable>
     implements Observer<T>, Disposable, TimeoutSelectorSupport {
 
+        @Serial
         private static final long serialVersionUID = -7508389464265974549L;
 
         final Observer<? super T> downstream;
@@ -320,6 +323,7 @@ public final class ObservableTimeout<T, U, V> extends AbstractObservableWithUpst
     static final class TimeoutConsumer extends AtomicReference<Disposable>
     implements Observer<Object>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 8708641127342403073L;
 
         final TimeoutSelectorSupport parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTimed.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.operators.observable;
 
 import static io.reactivex.rxjava4.internal.util.ExceptionHelper.timeoutMessage;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -56,6 +57,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
     static final class TimeoutObserver<T> extends AtomicLong
     implements Observer<T>, Disposable, TimeoutSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Observer<? super T> downstream;
@@ -169,6 +171,7 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
     static final class TimeoutFallbackObserver<T> extends AtomicReference<Disposable>
     implements Observer<T>, Disposable, TimeoutSupport {
 
+        @Serial
         private static final long serialVersionUID = 3764492702657003550L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,6 +44,7 @@ public final class ObservableTimer extends Observable<Long> {
     static final class TimerObserver extends AtomicReference<Disposable>
     implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -2809475196591179431L;
 
         final Observer<? super Long> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.reactivex.rxjava4.core.*;
@@ -34,6 +35,7 @@ public final class ObservableUnsubscribeOn<T> extends AbstractObservableWithUpst
 
     static final class UnsubscribeObserver<T> extends AtomicBoolean implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1015244841293359600L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsing.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -74,6 +75,7 @@ public final class ObservableUsing<T, D> extends Observable<T> {
 
     static final class UsingObserver<T, D> extends AtomicBoolean implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 5904473792286235046L;
 
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindow.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindow.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.ArrayDeque;
 import java.util.concurrent.atomic.*;
 
@@ -46,6 +47,7 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
     extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = -7481782523886138128L;
         final Observer<? super Observable<T>> downstream;
         final long count;
@@ -149,6 +151,7 @@ public final class ObservableWindow<T> extends AbstractObservableWithUpstream<T,
     static final class WindowSkipObserver<T> extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 3366976432059579510L;
         final Observer<? super Observable<T>> downstream;
         final long count;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundary.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundary.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -48,6 +49,7 @@ public final class ObservableWindowBoundary<T, B> extends AbstractObservableWith
     extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 2233020065421370272L;
 
         final Observer<? super Observable<T>> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -53,6 +54,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
     static final class WindowBoundaryMainObserver<T, B, V>
     extends AtomicInteger
     implements Observer<T>, Disposable, Runnable {
+        @Serial
         private static final long serialVersionUID = 8646217640096099753L;
 
         final Observer<? super Observable<T>> downstream;
@@ -324,6 +326,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
         static final class WindowStartObserver<B> extends AtomicReference<Disposable>
         implements Observer<B> {
 
+            @Serial
             private static final long serialVersionUID = -3326496781427702834L;
 
             final WindowBoundaryMainObserver<?, B, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowTimed.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.*;
@@ -71,6 +72,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
     abstract static class AbstractWindowObserver<T>
     extends AtomicInteger
     implements Observer<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = 5724293814035355511L;
 
         final Observer<? super Observable<T>> downstream;
@@ -166,6 +168,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             extends AbstractWindowObserver<T>
             implements Runnable {
 
+        @Serial
         private static final long serialVersionUID = 1155822639622580836L;
 
         final Scheduler scheduler;
@@ -307,6 +310,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
     static final class WindowExactBoundedObserver<T>
     extends AbstractWindowObserver<T>
     implements Runnable {
+        @Serial
         private static final long serialVersionUID = -6130475889925953722L;
 
         final Scheduler scheduler;
@@ -419,8 +423,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                         upstreamCancelled = true;
                         continue;
                     } else if (!isEmpty) {
-                        if (o instanceof WindowBoundaryRunnable) {
-                            WindowBoundaryRunnable boundary = (WindowBoundaryRunnable) o;
+                        if (o instanceof WindowBoundaryRunnable boundary) {
                             if (boundary.index == emitted || !restartTimerOnMaxSize) {
                                 this.count = 0;
                                 window = createNewWindow(window);
@@ -502,6 +505,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
     static final class WindowSkipObserver<T>
     extends AbstractWindowObserver<T>
     implements Runnable {
+        @Serial
         private static final long serialVersionUID = -7852870764194095894L;
 
         final long timeskip;
@@ -602,7 +606,7 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
                             }
                         } else if (o == WINDOW_CLOSE) {
                             if (!windows.isEmpty()) {
-                                windows.remove(0).onComplete();
+                                windows.removeFirst().onComplete();
                             }
                         } else {
                             @SuppressWarnings("unchecked")

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFrom.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFrom.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -47,6 +48,7 @@ public final class ObservableWithLatestFrom<T, U, R> extends AbstractObservableW
 
     static final class WithLatestFromObserver<T, U, R> extends AtomicReference<U> implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -312246233408980075L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWithLatestFromMany.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -99,6 +100,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
     extends AtomicInteger
     implements Observer<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 1577321883966341961L;
 
         final Observer<? super R> downstream;
@@ -243,6 +245,7 @@ public final class ObservableWithLatestFromMany<T, R> extends AbstractObservable
     extends AtomicReference<Disposable>
     implements Observer<Object> {
 
+        @Serial
         private static final long serialVersionUID = 3256684027868224024L;
 
         final WithLatestFromObserver<?, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZip.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
@@ -75,6 +76,7 @@ public final class ObservableZip<T, R> extends Observable<R> {
 
     static final class ZipCoordinator<T, R> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 2983708048395377667L;
         final Observer<? super R> downstream;
         final Function<? super Object[], ? extends R> zipper;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObserverResourceWrapper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObserverResourceWrapper.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.observable;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.Observer;
@@ -21,6 +22,7 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 
 public final class ObserverResourceWrapper<T> extends AtomicReference<Disposable> implements Observer<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -8612022020200669122L;
 
     final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelCollect.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelCollect.java
@@ -22,6 +22,7 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.parallel.ParallelFlowable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
 import java.util.Objects;
 
 /**
@@ -88,6 +89,7 @@ public final class ParallelCollect<T, C> extends ParallelFlowable<C> {
 
     static final class ParallelCollectSubscriber<T, C> extends DeferredScalarSubscriber<T, C> {
 
+        @Serial
         private static final long serialVersionUID = -4767392946044436228L;
 
         final BiConsumer<? super C, ? super T> collector;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelFromPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.parallel;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -66,6 +67,7 @@ public final class ParallelFromPublisher<T> extends ParallelFlowable<T> {
     extends AtomicInteger
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -4470634016609963609L;
 
         final Subscriber<? super T>[] subscribers;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.parallel;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -62,6 +63,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
     abstract static class JoinSubscriptionBase<T> extends AtomicInteger
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3100232009247827843L;
 
         final Subscriber<? super T> downstream;
@@ -133,6 +135,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
     static final class JoinSubscription<T> extends JoinSubscriptionBase<T> {
 
+        @Serial
         private static final long serialVersionUID = 6312374661811000451L;
 
         JoinSubscription(Subscriber<? super T> actual, int n, int prefetch) {
@@ -313,6 +316,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
     static final class JoinSubscriptionDelayError<T> extends JoinSubscriptionBase<T> {
 
+        @Serial
         private static final long serialVersionUID = -5737965195918321883L;
 
         JoinSubscriptionDelayError(Subscriber<? super T> actual, int n, int prefetch) {
@@ -475,6 +479,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 8410034718427740355L;
 
         final JoinSubscriptionBase<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelReduce.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelReduce.java
@@ -22,6 +22,7 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 import io.reactivex.rxjava4.parallel.ParallelFlowable;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
 import java.util.Objects;
 
 /**
@@ -87,6 +88,7 @@ public final class ParallelReduce<T, R> extends ParallelFlowable<R> {
 
     static final class ParallelReduceSubscriber<T, R> extends DeferredScalarSubscriber<T, R> {
 
+        @Serial
         private static final long serialVersionUID = 8200530050639449080L;
 
         final BiFunction<R, ? super T, R> reducer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelReduceFull.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelReduceFull.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.parallel;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -53,6 +54,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
     static final class ParallelReduceFullMainSubscriber<T> extends DeferredScalarSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -5370107872170712765L;
 
         final ParallelReduceFullInnerSubscriber<T>[] subscribers;
@@ -163,6 +165,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = -7954444275102466525L;
 
         final ParallelReduceFullMainSubscriber<T> parent;
@@ -231,6 +234,7 @@ public final class ParallelReduceFull<T> extends Flowable<T> {
 
     static final class SlotPair<T> extends AtomicInteger {
 
+        @Serial
         private static final long serialVersionUID = 473971317683868662L;
 
         T first;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelRunOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelRunOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.parallel;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -61,8 +62,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
         @SuppressWarnings("unchecked")
         final Subscriber<T>[] parents = new Subscriber[n];
 
-        if (scheduler instanceof SchedulerMultiWorkerSupport) {
-            SchedulerMultiWorkerSupport multiworker = (SchedulerMultiWorkerSupport) scheduler;
+        if (scheduler instanceof SchedulerMultiWorkerSupport multiworker) {
             multiworker.createWorkers(n, new MultiWorkerCallback(subscribers, parents));
         } else {
             for (int i = 0; i < n; i++) {
@@ -112,6 +112,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
     abstract static class BaseRunOnSubscriber<T> extends AtomicInteger
     implements FlowableSubscriber<T>, Subscription, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 9222303586456402150L;
 
         final int prefetch;
@@ -204,6 +205,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
 
     static final class RunOnSubscriber<T> extends BaseRunOnSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 1075119423897941642L;
 
         final Subscriber<? super T> downstream;
@@ -328,6 +330,7 @@ public final class ParallelRunOn<T> extends ParallelFlowable<T> {
 
     static final class RunOnConditionalSubscriber<T> extends BaseRunOnSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 1075119423897941642L;
 
         final ConditionalSubscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelSortedJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelSortedJoin.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.parallel;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.*;
 
@@ -56,6 +57,7 @@ public final class ParallelSortedJoin<T> extends Flowable<T> {
     extends AtomicInteger
     implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3481980673745556697L;
 
         final Subscriber<? super T> downstream;
@@ -259,6 +261,7 @@ public final class ParallelSortedJoin<T> extends Flowable<T> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<List<T>> {
 
+        @Serial
         private static final long serialVersionUID = 6751017204873808094L;
 
         final SortedJoinSubscription<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCache.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.core.*;
@@ -152,6 +153,7 @@ public final class SingleCache<T> extends Single<T> implements SingleObserver<T>
     extends AtomicBoolean
     implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 7514387411091976596L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCreate.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCreate.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -48,6 +49,7 @@ public final class SingleCreate<T> extends Single<T> {
     extends AtomicReference<Disposable>
     implements SingleEmitter<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2467358622224974244L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -40,6 +41,7 @@ public final class SingleDelayWithCompletable<T> extends Single<T> {
     extends AtomicReference<Disposable>
     implements CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8565274649390031272L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -41,6 +42,7 @@ public final class SingleDelayWithObservable<T, U> extends Single<T> {
     extends AtomicReference<Disposable>
     implements Observer<U>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8565274649390031272L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -44,6 +45,7 @@ public final class SingleDelayWithPublisher<T, U> extends Single<T> {
     extends AtomicReference<Disposable>
     implements FlowableSubscriber<U>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8565274649390031272L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDelayWithSingle.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -40,6 +41,7 @@ public final class SingleDelayWithSingle<T, U> extends Single<T> {
     extends AtomicReference<Disposable>
     implements SingleObserver<U>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -8565274649390031272L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoFinally.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoFinally.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.core.*;
@@ -46,6 +47,7 @@ public final class SingleDoFinally<T> extends Single<T> {
 
     static final class DoFinallyObserver<T> extends AtomicInteger implements SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4109457741734051389L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnDispose.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnDispose.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -41,6 +42,7 @@ public final class SingleDoOnDispose<T> extends Single<T> {
     static final class DoOnDisposeObserver<T>
     extends AtomicReference<Action>
     implements SingleObserver<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = -8583764624474935784L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMap.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -40,6 +41,7 @@ public final class SingleFlatMap<T, R> extends Single<R> {
     static final class SingleFlatMapCallback<T, R>
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = 3258103020495908596L;
 
         final SingleObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapBiSelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapBiSelector.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -110,6 +111,7 @@ public final class SingleFlatMapBiSelector<T, U, R> extends Single<R> {
         extends AtomicReference<Disposable>
         implements SingleObserver<U> {
 
+            @Serial
             private static final long serialVersionUID = -2897979525538174559L;
 
             final SingleObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapCompletable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -48,6 +49,7 @@ public final class SingleFlatMapCompletable<T> extends Completable {
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, CompletableObserver, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -2177128922851101253L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -55,6 +56,7 @@ public final class SingleFlatMapIterableFlowable<T, R> extends Flowable<R> {
     extends BasicIntQueueSubscription<R>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -8938804753851907758L;
 
         final Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -51,6 +52,7 @@ public final class SingleFlatMapIterableObservable<T, R> extends Observable<R> {
     extends BasicIntQueueDisposable<R>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = -8938804753851907758L;
 
         final Observer<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybe.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -42,6 +43,7 @@ public final class SingleFlatMapMaybe<T, R> extends Maybe<R> {
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5843758257109742742L;
 
         final MaybeObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotification.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotification.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -54,6 +55,7 @@ public final class SingleFlatMapNotification<T, R> extends Single<R> {
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 4375739915521278546L;
 
         final SingleObserver<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapPublisher.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -62,6 +63,7 @@ public final class SingleFlatMapPublisher<T, R> extends Flowable<R> {
     static final class SingleFlatMapPublisherObserver<S, T> extends AtomicLong
             implements SingleObserver<S>, FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = 7759721921468635667L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleObserveOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleObserveOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -37,6 +38,7 @@ public final class SingleObserveOn<T> extends Single<T> {
 
     static final class ObserveOnSingleObserver<T> extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable, Runnable {
+        @Serial
         private static final long serialVersionUID = 3528003840217436037L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleResumeNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleResumeNext.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -41,6 +42,7 @@ public final class SingleResumeNext<T> extends Single<T> {
 
     static final class ResumeMainSingleObserver<T> extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
+        @Serial
         private static final long serialVersionUID = -5314538511045349925L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleSubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -44,6 +45,7 @@ public final class SingleSubscribeOn<T> extends Single<T> {
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 7000911171163930287L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntil.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -55,6 +56,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
     extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -622603812305745221L;
 
         final SingleObserver<? super T> downstream;
@@ -127,6 +129,7 @@ public final class SingleTakeUntil<T, U> extends Single<T> {
     extends AtomicReference<Subscription>
     implements FlowableSubscriber<Object> {
 
+        @Serial
         private static final long serialVersionUID = 5170026210238877381L;
 
         final TakeUntilMainObserver<?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeout.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTimeout.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.operators.single;
 
 import static io.reactivex.rxjava4.internal.util.ExceptionHelper.timeoutMessage;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,6 +59,7 @@ public final class SingleTimeout<T> extends Single<T> {
     static final class TimeoutMainObserver<T> extends AtomicReference<Disposable>
     implements SingleObserver<T>, Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = 37497744973048446L;
 
         final SingleObserver<? super T> downstream;
@@ -75,6 +77,7 @@ public final class SingleTimeout<T> extends Single<T> {
         static final class TimeoutFallbackObserver<T> extends AtomicReference<Disposable>
         implements SingleObserver<T> {
 
+            @Serial
             private static final long serialVersionUID = 2071387740092105509L;
             final SingleObserver<? super T> downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTimer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTimer.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -44,6 +45,7 @@ public final class SingleTimer extends Single<Long> {
 
     static final class TimerDisposable extends AtomicReference<Disposable> implements Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 8465401857522493082L;
         final SingleObserver<? super Long> downstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleToFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleToFlowable.java
@@ -20,6 +20,8 @@ import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.internal.subscriptions.DeferredScalarSubscription;
 
+import java.io.Serial;
+
 /**
  * Wraps a Single and exposes it as a Flowable.
  *
@@ -41,6 +43,7 @@ public final class SingleToFlowable<T> extends Flowable<T> {
     static final class SingleToFlowableObserver<T> extends DeferredScalarSubscription<T>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 187782011903685568L;
 
         Disposable upstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleToObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleToObservable.java
@@ -18,6 +18,8 @@ import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.internal.observers.DeferredScalarDisposable;
 
+import java.io.Serial;
+
 /**
  * Wraps a Single and exposes it as an Observable.
  *
@@ -52,6 +54,7 @@ public final class SingleToObservable<T> extends Observable<T> {
     extends DeferredScalarDisposable<T>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 3786543492451018833L;
         Disposable upstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOn.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.core.*;
@@ -43,6 +44,7 @@ public final class SingleUnsubscribeOn<T> extends Single<T> {
     static final class UnsubscribeOnSingleObserver<T> extends AtomicReference<Disposable>
     implements SingleObserver<T>, Disposable, Runnable {
 
+        @Serial
         private static final long serialVersionUID = 3256698449646456986L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleUsing.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleUsing.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -86,6 +87,7 @@ public final class SingleUsing<T, U> extends Single<T> {
     static final class UsingSingleObserver<T, U> extends
     AtomicReference<Object> implements SingleObserver<T>, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5331524057054083935L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleZipArray.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.operators.single;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -66,6 +67,7 @@ public final class SingleZipArray<T, R> extends Single<R> {
 
     static final class ZipCoordinator<T, R> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5556924161382950569L;
 
         final SingleObserver<? super R> downstream;
@@ -153,6 +155,7 @@ public final class SingleZipArray<T, R> extends Single<R> {
     extends AtomicReference<Disposable>
     implements SingleObserver<T> {
 
+        @Serial
         private static final long serialVersionUID = 3323743579927613702L;
 
         final ZipCoordinator<T, ?> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/queue/MpscLinkedQueue.java
@@ -18,6 +18,7 @@
 
 package io.reactivex.rxjava4.internal.queue;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.annotations.Nullable;
@@ -153,6 +154,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
 
     static final class LinkedQueueNode<E> extends AtomicReference<LinkedQueueNode<E>> {
 
+        @Serial
         private static final long serialVersionUID = 2404266111789071508L;
 
         private E value;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTask.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -28,6 +29,7 @@ abstract class AbstractDirectTask
 extends AtomicReference<Future<?>>
 implements Disposable, SchedulerRunnableIntrospection {
 
+    @Serial
     private static final long serialVersionUID = 1811839108042568751L;
 
     protected final Runnable runnable;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/BlockingCurrentThreadScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/BlockingCurrentThreadScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -239,6 +240,7 @@ public final class BlockingCurrentThreadScheduler extends Scheduler {
     extends AtomicInteger
     implements Action, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -9165914884456950194L;
         final Runnable task;
 
@@ -362,6 +364,7 @@ public final class BlockingCurrentThreadScheduler extends Scheduler {
         extends AtomicInteger
         implements Action, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -9165914884456950194L;
 
             final Runnable task;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -253,6 +254,7 @@ public final class DeferredExecutorScheduler extends Scheduler {
 
         static final class BooleanRunnable extends AtomicBoolean implements Runnable, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -2421395018820541164L;
 
             final Runnable actual;
@@ -308,6 +310,7 @@ public final class DeferredExecutorScheduler extends Scheduler {
          */
         static final class InterruptibleRunnable extends AtomicInteger implements Runnable, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -3603436687413320876L;
 
             final Runnable run;
@@ -403,6 +406,7 @@ public final class DeferredExecutorScheduler extends Scheduler {
     static final class DelayedRunnable extends AtomicReference<Runnable>
             implements Runnable, Disposable, SchedulerRunnableIntrospection {
 
+        @Serial
         private static final long serialVersionUID = -4101336210206799084L;
 
         final SequentialDisposable timed;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ExecutorScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
@@ -309,6 +310,7 @@ public final class ExecutorScheduler extends Scheduler {
 
         static final class BooleanRunnable extends AtomicBoolean implements Runnable, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -2421395018820541164L;
 
             final Runnable actual;
@@ -364,6 +366,7 @@ public final class ExecutorScheduler extends Scheduler {
          */
         static final class InterruptibleRunnable extends AtomicInteger implements Runnable, Disposable {
 
+            @Serial
             private static final long serialVersionUID = -3603436687413320876L;
 
             final Runnable run;
@@ -459,6 +462,7 @@ public final class ExecutorScheduler extends Scheduler {
     static final class DelayedRunnable extends AtomicReference<Runnable>
             implements Runnable, Disposable, SchedulerRunnableIntrospection {
 
+        @Serial
         private static final long serialVersionUID = -4101336210206799084L;
 
         final SequentialDisposable timed;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ParallelScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ParallelScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -321,6 +322,7 @@ public final class ParallelScheduler extends Scheduler {
                 DISPOSED.cancel(false);
             }
 
+            @Serial
             private static final long serialVersionUID = 4949851341419870956L;
 
             final AtomicReference<Future<?>> future;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/RxThreadFactory.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/RxThreadFactory.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 
+import java.io.Serial;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class RxThreadFactory extends AtomicLong implements ThreadFactory {
 
+    @Serial
     private static final long serialVersionUID = -7789753024099756196L;
 
     final String prefix;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTask.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTask.java
@@ -15,6 +15,8 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
+import java.io.Serial;
+
 /**
  * A Callable to be submitted to an ExecutorService that runs a Runnable
  * action periodically and manages completion/cancellation.
@@ -22,6 +24,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  */
 public final class ScheduledDirectPeriodicTask extends AbstractDirectTask implements Runnable {
 
+    @Serial
     private static final long serialVersionUID = 1811839108042568751L;
 
     public ScheduledDirectPeriodicTask(Runnable runnable, boolean interruptOnCancel) {

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectTask.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectTask.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.Callable;
 
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -24,6 +25,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  */
 public final class ScheduledDirectTask extends AbstractDirectTask implements Callable<Void> {
 
+    @Serial
     private static final long serialVersionUID = 1811839108042568751L;
 
     public ScheduledDirectTask(Runnable runnable, boolean interruptOnCancel) {

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -22,6 +23,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 public final class ScheduledRunnable extends AtomicReferenceArray<Object>
 implements Runnable, Callable<Object>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -6120223772001106981L;
     final Runnable actual;
     final boolean interruptOnCancel;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SharedScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SharedScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -122,6 +123,7 @@ public final class SharedScheduler extends Scheduler {
         static final class SharedAction
         extends AtomicReference<DisposableContainer>
         implements Runnable, Disposable {
+            @Serial
             private static final long serialVersionUID = 4949851341419870956L;
 
             final AtomicReference<Disposable> future;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/BlockingSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/BlockingSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -24,6 +25,7 @@ import io.reactivex.rxjava4.internal.util.NotificationLite;
 
 public final class BlockingSubscriber<T> extends AtomicReference<Subscription> implements FlowableSubscriber<T>, Subscription {
 
+    @Serial
     private static final long serialVersionUID = -4875965440900746268L;
 
     public static final Object TERMINATED = new Object();

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -29,6 +30,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 public final class BoundedSubscriber<T> extends AtomicReference<Subscription>
         implements FlowableSubscriber<T>, Subscription, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriber.java
@@ -18,6 +18,8 @@ import static java.util.concurrent.Flow.*;
 import io.reactivex.rxjava4.core.FlowableSubscriber;
 import io.reactivex.rxjava4.internal.subscriptions.*;
 
+import java.io.Serial;
+
 /**
  * A subscriber, extending a DeferredScalarSubscription,
  *  that is unbounded-in and can generate 0 or 1 resulting value.
@@ -27,6 +29,7 @@ import io.reactivex.rxjava4.internal.subscriptions.*;
 public abstract class DeferredScalarSubscriber<T, R> extends DeferredScalarSubscription<R>
 implements FlowableSubscriber<T> {
 
+    @Serial
     private static final long serialVersionUID = 2984505488220891551L;
 
     /** The upstream subscription. */

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/DisposableAutoReleaseSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/DisposableAutoReleaseSubscriber.java
@@ -29,6 +29,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -53,6 +54,7 @@ public final class DisposableAutoReleaseSubscriber<T>
 extends AtomicReference<Subscription>
 implements FlowableSubscriber<T>, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = 8924480688481408726L;
 
     final AtomicReference<DisposableContainer> composite;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/ForEachWhileSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/ForEachWhileSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -28,6 +29,7 @@ public final class ForEachWhileSubscriber<T>
 extends AtomicReference<Subscription>
 implements FlowableSubscriber<T>, Disposable {
 
+    @Serial
     private static final long serialVersionUID = -4403180040475402120L;
 
     final Predicate<? super T> onNext;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -33,6 +34,7 @@ public final class InnerQueuedSubscriber<T>
 extends AtomicReference<Subscription>
 implements FlowableSubscriber<T>, Subscription {
 
+    @Serial
     private static final long serialVersionUID = 22876611072430776L;
 
     final InnerQueuedSubscriberSupport<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -29,6 +30,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 public final class LambdaSubscriber<T> extends AtomicReference<Subscription>
         implements FlowableSubscriber<T>, Subscription, Disposable, LambdaConsumerIntrospection {
 
+    @Serial
     private static final long serialVersionUID = -7251123623727029452L;
     final Consumer<? super T> onNext;
     final Consumer<? super Throwable> onError;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.concurrent.Flow.*;
@@ -29,6 +30,7 @@ import io.reactivex.rxjava4.internal.util.BackpressureHelper;
  * @param <R> the output value type
  */
 public abstract class SinglePostCompleteSubscriber<T, R> extends AtomicLong implements FlowableSubscriber<T>, Subscription {
+    @Serial
     private static final long serialVersionUID = 7917814472626990048L;
 
     /** The downstream consumer. */

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -39,6 +40,7 @@ public class StrictSubscriber<T>
 extends AtomicInteger
 implements FlowableSubscriber<T>, Subscription {
 
+    @Serial
     private static final long serialVersionUID = -4945028590049415624L;
 
     final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/SubscriberResourceWrapper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/SubscriberResourceWrapper.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscribers;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -24,6 +25,7 @@ import io.reactivex.rxjava4.internal.subscriptions.SubscriptionHelper;
 
 public final class SubscriberResourceWrapper<T> extends AtomicReference<Disposable> implements FlowableSubscriber<T>, Disposable, Subscription {
 
+    @Serial
     private static final long serialVersionUID = -8612022020200669122L;
 
     final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import static java.util.concurrent.Flow.*;
@@ -28,6 +29,7 @@ import io.reactivex.rxjava4.disposables.Disposable;
  */
 public final class ArrayCompositeSubscription extends AtomicReferenceArray<Subscription> implements Disposable {
 
+    @Serial
     private static final long serialVersionUID = 2746389416410565408L;
 
     public ArrayCompositeSubscription(int capacity) {

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/AsyncSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/AsyncSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -28,6 +29,7 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
  */
 public final class AsyncSubscription extends AtomicLong implements Subscription, Disposable {
 
+    @Serial
     private static final long serialVersionUID = 7028635084060361255L;
 
     final AtomicReference<Subscription> actual;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BasicIntQueueSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BasicIntQueueSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.reactivex.rxjava4.annotations.NonNull;
@@ -25,6 +26,7 @@ import io.reactivex.rxjava4.operators.QueueSubscription;
  */
 public abstract class BasicIntQueueSubscription<@NonNull T> extends AtomicInteger implements QueueSubscription<T> {
 
+    @Serial
     private static final long serialVersionUID = -6671519529404341862L;
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BasicQueueSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BasicQueueSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.operators.QueueSubscription;
@@ -24,6 +25,7 @@ import io.reactivex.rxjava4.operators.QueueSubscription;
  */
 public abstract class BasicQueueSubscription<T> extends AtomicLong implements QueueSubscription<T> {
 
+    @Serial
     private static final long serialVersionUID = -6671519529404341862L;
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BooleanSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/BooleanSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.util.concurrent.Flow.*;
@@ -23,6 +24,7 @@ import static java.util.concurrent.Flow.*;
  */
 public final class BooleanSubscription extends AtomicBoolean implements Subscription {
 
+    @Serial
     private static final long serialVersionUID = -8127758972444290902L;
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscription.java
@@ -17,6 +17,8 @@ import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.*;
 
+import java.io.Serial;
+
 /**
  * A subscription that signals a single value eventually.
  * <p>
@@ -35,6 +37,7 @@ import io.reactivex.rxjava4.annotations.*;
  */
 public class DeferredScalarSubscription<@NonNull T> extends BasicIntQueueSubscription<T> {
 
+    @Serial
     private static final long serialVersionUID = -2151279923272604993L;
 
     /** The Subscriber to emit the value to. */

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/ScalarSubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/ScalarSubscription.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.concurrent.Flow.*;
@@ -26,6 +27,7 @@ import io.reactivex.rxjava4.operators.QueueSubscription;
  */
 public final class ScalarSubscription<T> extends AtomicInteger implements QueueSubscription<T> {
 
+    @Serial
     private static final long serialVersionUID = -3830916580126663321L;
     /** The single value to emit, set to null. */
     final T value;

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionArbiter.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/SubscriptionArbiter.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.subscriptions;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -25,6 +26,7 @@ import io.reactivex.rxjava4.internal.util.BackpressureHelper;
  */
 public class SubscriptionArbiter extends AtomicInteger implements Subscription {
 
+    @Serial
     private static final long serialVersionUID = -2189523197179400958L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/util/AtomicThrowable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/AtomicThrowable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.util;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -28,6 +29,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  */
 public final class AtomicThrowable extends AtomicReference<Throwable> {
 
+    @Serial
     private static final long serialVersionUID = 3949248817947090603L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.util;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -93,8 +94,7 @@ public final class ExceptionHelper {
 
         while (!deque.isEmpty()) {
             Throwable e = deque.removeFirst();
-            if (e instanceof CompositeException) {
-                CompositeException ce = (CompositeException) e;
+            if (e instanceof CompositeException ce) {
                 List<Throwable> exceptions = ce.getExceptions();
                 for (int i = exceptions.size() - 1; i >= 0; i--) {
                     deque.offerFirst(exceptions.get(i));
@@ -132,6 +132,7 @@ public final class ExceptionHelper {
 
     static final class Termination extends Throwable {
 
+        @Serial
         private static final long serialVersionUID = -4649703670690200604L;
 
         Termination() {

--- a/src/main/java/io/reactivex/rxjava4/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/NotificationLite.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.rxjava4.internal.util;
 
-import java.io.Serializable;
+import java.io.*;
 
 import java.util.Objects;
 import static java.util.concurrent.Flow.*;
@@ -33,6 +33,7 @@ public enum NotificationLite {
      */
     static final class ErrorNotification implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -8759979445933046293L;
         final Throwable e;
         ErrorNotification(Throwable e) {
@@ -51,8 +52,7 @@ public enum NotificationLite {
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof ErrorNotification) {
-                ErrorNotification n = (ErrorNotification) obj;
+            if (obj instanceof ErrorNotification n) {
                 return Objects.equals(e, n.e);
             }
             return false;
@@ -64,6 +64,7 @@ public enum NotificationLite {
      */
     static final class SubscriptionNotification implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -1322257508628817540L;
         final Subscription upstream;
         SubscriptionNotification(Subscription s) {
@@ -81,6 +82,7 @@ public enum NotificationLite {
      */
     static final class DisposableNotification implements Serializable {
 
+        @Serial
         private static final long serialVersionUID = -7482590109178395495L;
         final Disposable upstream;
 

--- a/src/main/java/io/reactivex/rxjava4/internal/util/VolatileSizeArrayList.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/VolatileSizeArrayList.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.util;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -26,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class VolatileSizeArrayList<T> extends AtomicInteger implements List<T>, RandomAccess {
 
+    @Serial
     private static final long serialVersionUID = 3972397474470203923L;
 
     final ArrayList<T> list;

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.virtual;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.Flow.*;
@@ -65,6 +66,7 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
     static final class ExecutorVirtualCreateSubscription<T> extends AtomicLong
     implements Subscription, Callable<Void>, Runnable, VirtualEmitter<T> {
 
+        @Serial
         private static final long serialVersionUID = -6959205135542203083L;
 
         Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.virtual;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.Flow.*;
@@ -65,6 +66,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
     static final class ExecutorVirtualTransformSubscriber<T, R> extends AtomicLong
     implements FlowableSubscriber<T>, Subscription, VirtualEmitter<R>, Callable<Void>, Runnable, Disposable {
 
+        @Serial
         private static final long serialVersionUID = -4702456711290258571L;
 
         Subscriber<? super R> downstream;

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/VirtualResumable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/VirtualResumable.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.internal.virtual;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
@@ -22,6 +23,7 @@ import java.util.concurrent.locks.LockSupport;
  */
 public class VirtualResumable extends AtomicReference<Object> {
 
+    @Serial
     private static final long serialVersionUID = -3462467580179834124L;
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
@@ -128,7 +128,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
         AssertionError ae = new AssertionError(b.toString());
         if (!errors.isEmpty()) {
             if (errors.size() == 1) {
-                ae.initCause(errors.get(0));
+                ae.initCause(errors.getFirst());
             } else {
                 CompositeException ce = new CompositeException(errors);
                 ae.initCause(ce);
@@ -308,7 +308,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
         if (s != 1) {
             throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + values);
         }
-        T v = values.get(0);
+        T v = values.getFirst();
         if (!Objects.equals(value, v)) {
             throw fail("\nexpected: " + valueAndClass(value) + "\ngot: " + valueAndClass(v));
         }

--- a/src/main/java/io/reactivex/rxjava4/operators/SpscArrayQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/operators/SpscArrayQueue.java
@@ -18,6 +18,7 @@
 
 package io.reactivex.rxjava4.operators;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.Nullable;
@@ -39,6 +40,7 @@ import io.reactivex.rxjava4.internal.util.Pow2;
  * @since 3.1.1
  */
 public final class SpscArrayQueue<E> extends AtomicReferenceArray<E> implements SimplePlainQueue<E> {
+    @Serial
     private static final long serialVersionUID = -1296597691183856449L;
     private static final Integer MAX_LOOK_AHEAD_STEP = Integer.getInteger("jctools.spsc.max.lookahead.step", 4096);
     final int mask;

--- a/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.Flow.*;
@@ -338,6 +339,7 @@ public final class AsyncProcessor<@NonNull T> extends FlowableProcessor<T> {
     }
 
     static final class AsyncSubscription<@NonNull T> extends DeferredScalarSubscription<T> {
+        @Serial
         private static final long serialVersionUID = 5629876084736248016L;
 
         final AsyncProcessor<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 import java.util.concurrent.locks.*;
@@ -467,6 +468,7 @@ public final class BehaviorProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     static final class BehaviorSubscription<@NonNull T> extends AtomicLong implements Subscription, NonThrowingPredicate<Object> {
 
+        @Serial
         private static final long serialVersionUID = 3293175281126227086L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -585,6 +586,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     static final class MulticastSubscription<@NonNull T> extends AtomicLong implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = -363282618957264509L;
 
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -336,6 +337,7 @@ public final class PublishProcessor<@NonNull T> extends FlowableProcessor<T> {
      */
     static final class PublishSubscription<@NonNull T> extends AtomicLong implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 3562861878281475070L;
         /** The actual subscriber. */
         final Subscriber<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -614,6 +615,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     static final class ReplaySubscription<@NonNull T> extends AtomicInteger implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = 466549804534799122L;
         final Subscriber<? super T> downstream;
         final ReplayProcessor<T> state;
@@ -824,6 +826,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     static final class Node<T> extends AtomicReference<Node<T>> {
 
+        @Serial
         private static final long serialVersionUID = 6404226426336033100L;
 
         final T value;
@@ -835,6 +838,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     static final class TimedNode<T> extends AtomicReference<TimedNode<T>> {
 
+        @Serial
         private static final long serialVersionUID = 6404226426336033100L;
 
         final T value;

--- a/src/main/java/io/reactivex/rxjava4/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/UnicastProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.processors;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -492,6 +493,7 @@ public final class UnicastProcessor<@NonNull T> extends FlowableProcessor<T> {
 
     final class UnicastQueueSubscription extends BasicIntQueueSubscription<T> {
 
+        @Serial
         private static final long serialVersionUID = -4896760517184205454L;
 
         @Nullable

--- a/src/main/java/io/reactivex/rxjava4/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/TestScheduler.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.schedulers;
 
+import java.io.Serial;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -233,6 +234,7 @@ public final class TestScheduler extends Scheduler {
 
         final class QueueRemove extends AtomicReference<TimedRunnable> implements Disposable {
 
+            @Serial
             private static final long serialVersionUID = -7874968252110604360L;
 
             QueueRemove(TimedRunnable timedAction) {

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
@@ -78,8 +78,7 @@ public final class Timed<T> {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof Timed) {
-            Timed<?> o = (Timed<?>) other;
+        if (other instanceof Timed<?> o) {
             return Objects.equals(value, o.value)
                     && time == o.time
                     && Objects.equals(unit, o.unit);

--- a/src/main/java/io/reactivex/rxjava4/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/AsyncSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -325,6 +326,7 @@ public final class AsyncSubject<T> extends Subject<T> {
     }
 
     static final class AsyncDisposable<T> extends DeferredScalarDisposable<T> {
+        @Serial
         private static final long serialVersionUID = 5629876084736248016L;
 
         final AsyncSubject<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/subjects/CompletableSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/CompletableSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -256,6 +257,7 @@ public final class CompletableSubject extends Completable implements Completable
 
     static final class CompletableDisposable
     extends AtomicReference<CompletableSubject> implements Disposable {
+        @Serial
         private static final long serialVersionUID = -7650903191002190468L;
 
         final CompletableObserver downstream;

--- a/src/main/java/io/reactivex/rxjava4/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/MaybeSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -326,6 +327,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
 
     static final class MaybeDisposable<T>
     extends AtomicReference<MaybeSubject<T>> implements Disposable {
+        @Serial
         private static final long serialVersionUID = -7650903191002190468L;
 
         final MaybeObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -289,6 +290,7 @@ public final class PublishSubject<T> extends Subject<T> {
      */
     static final class PublishDisposable<T> extends AtomicBoolean implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 3562861878281475070L;
         /** The actual subscriber. */
         final Observer<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.lang.reflect.Array;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -617,6 +618,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
     static final class ReplayDisposable<T> extends AtomicInteger implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = 466549804534799122L;
         final Observer<? super T> downstream;
         final ReplaySubject<T> state;
@@ -648,6 +650,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     extends AtomicReference<Object>
     implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = -733876083048047795L;
 
         final List<Object> buffer;
@@ -815,6 +818,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
     static final class Node<T> extends AtomicReference<Node<T>> {
 
+        @Serial
         private static final long serialVersionUID = 6404226426336033100L;
 
         final T value;
@@ -826,6 +830,7 @@ public final class ReplaySubject<T> extends Subject<T> {
 
     static final class TimedNode<T> extends AtomicReference<TimedNode<T>> {
 
+        @Serial
         private static final long serialVersionUID = 6404226426336033100L;
 
         final T value;
@@ -841,6 +846,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     extends AtomicReference<Object>
     implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = 1107649250281456395L;
 
         final int maxSize;
@@ -1047,6 +1053,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     extends AtomicReference<Object>
     implements ReplayBuffer<T> {
 
+        @Serial
         private static final long serialVersionUID = -8056260896137901749L;
 
         final int maxSize;

--- a/src/main/java/io/reactivex/rxjava4/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/SingleSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.*;
@@ -287,6 +288,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
 
     static final class SingleDisposable<T>
     extends AtomicReference<SingleSubject<T>> implements Disposable {
+        @Serial
         private static final long serialVersionUID = -7650903191002190468L;
 
         final SingleObserver<? super T> downstream;

--- a/src/main/java/io/reactivex/rxjava4/subjects/UnicastSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/UnicastSubject.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subjects;
 
+import java.io.Serial;
 import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
@@ -507,6 +508,7 @@ public final class UnicastSubject<T> extends Subject<T> {
 
     final class UnicastQueueDisposable extends BasicIntQueueDisposable<T> {
 
+        @Serial
         private static final long serialVersionUID = 7926949470189395511L;
 
         @Override

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.Flow.Publisher;
@@ -102,6 +103,7 @@ public class CompletableTest extends RxJavaTest {
      */
     static final class NormalCompletable extends AtomicInteger {
 
+        @Serial
         private static final long serialVersionUID = 7192337844700923752L;
 
         public final Completable completable = Completable.unsafeCreate(observer -> {
@@ -124,6 +126,7 @@ public class CompletableTest extends RxJavaTest {
      */
     static final class ErrorCompletable extends AtomicInteger {
 
+        @Serial
         private static final long serialVersionUID = 7192337844700923752L;
 
         public final Completable completable = Completable.unsafeCreate(observer -> {
@@ -2636,7 +2639,7 @@ public class CompletableTest extends RxJavaTest {
         ts.assertNotComplete();
         ts.assertError(CompositeException.class);
 
-        CompositeException ex = (CompositeException)ts.errors().get(0);
+        CompositeException ex = (CompositeException)ts.errors().getFirst();
 
         List<Throwable> listEx = ex.getExceptions();
 
@@ -3041,7 +3044,7 @@ public class CompletableTest extends RxJavaTest {
         ts.assertNotComplete();
         ts.assertError(CompositeException.class);
 
-        CompositeException ex = (CompositeException)ts.errors().get(0);
+        CompositeException ex = (CompositeException)ts.errors().getFirst();
 
         List<Throwable> listEx = ex.getExceptions();
 
@@ -3121,7 +3124,7 @@ public class CompletableTest extends RxJavaTest {
         ts.assertNotComplete();
         ts.assertError(CompositeException.class);
 
-        CompositeException composite = (CompositeException)ts.errors().get(0);
+        CompositeException composite = (CompositeException)ts.errors().getFirst();
 
         List<Throwable> errors = composite.getExceptions();
         Assert.assertEquals(2, errors.size());

--- a/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/CompositeExceptionTest.java
@@ -192,6 +192,7 @@ public class CompositeExceptionTest extends RxJavaTest {
     public void compositeExceptionWithUnsupportedInitCause() {
         Throwable t = new Throwable() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -3282577447436848385L;
 
             @Override
@@ -216,6 +217,7 @@ public class CompositeExceptionTest extends RxJavaTest {
     public void compositeExceptionWithNullInitCause() {
         Throwable t = new Throwable("ThrowableWithNullInitCause") /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -7984762607894527888L;
 
             @Override
@@ -250,11 +252,11 @@ public class CompositeExceptionTest extends RxJavaTest {
 
     @Test
     public void constructorWithNull() {
-        assertTrue(new CompositeException((Throwable[])null).getExceptions().get(0) instanceof NullPointerException);
+        assertTrue(new CompositeException((Throwable[])null).getExceptions().getFirst() instanceof NullPointerException);
 
-        assertTrue(new CompositeException((Iterable<Throwable>)null).getExceptions().get(0) instanceof NullPointerException);
+        assertTrue(new CompositeException((Iterable<Throwable>)null).getExceptions().getFirst() instanceof NullPointerException);
 
-        assertTrue(new CompositeException(null, new TestException()).getExceptions().get(0) instanceof NullPointerException);
+        assertTrue(new CompositeException(null, new TestException()).getExceptions().getFirst() instanceof NullPointerException);
     }
 
     @Test
@@ -362,6 +364,7 @@ public class CompositeExceptionTest extends RxJavaTest {
 }
 
 final class BadException extends Throwable {
+    @Serial
     private static final long serialVersionUID = 8999507293896399171L;
 
     @Override

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
@@ -44,7 +44,7 @@ public class ExceptionsTest extends RxJavaTest {
         });
 
         TestHelper.assertError(errors, 0, RuntimeException.class);
-        assertTrue(errors.get(0).toString(), errors.get(0).getMessage().contains("hello"));
+        assertTrue(errors.getFirst().toString(), errors.getFirst().getMessage().contains("hello"));
         RxJavaPlugins.reset();
     }
 

--- a/src/test/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedExceptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedExceptionTest.java
@@ -39,7 +39,7 @@ public class OnErrorNotImplementedExceptionTest extends RxJavaTest {
 
         assertFalse("" + errors, errors.isEmpty());
         TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
-        Throwable c = errors.get(0).getCause();
+        Throwable c = errors.getFirst().getCause();
         assertTrue("" + c, c instanceof TestException);
     }
 

--- a/src/test/java/io/reactivex/rxjava4/exceptions/TestException.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/TestException.java
@@ -13,12 +13,15 @@
 
 package io.reactivex.rxjava4.exceptions;
 
+import java.io.Serial;
+
 /**
  * Exception for testing if unchecked exceptions propagate as-is without confusing with
  * other type of common exceptions.
  */
 public final class TestException extends RuntimeException {
 
+    @Serial
     private static final long serialVersionUID = -1438148770465406172L;
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.flowable;
 
 import static org.junit.Assert.*;
 
+import java.io.Serial;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.Flow.Publisher;
@@ -36,6 +37,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
     static final class FirehoseNoBackpressure extends AtomicBoolean implements Subscription {
 
+        @Serial
         private static final long serialVersionUID = -669931580197884015L;
         final Subscriber<? super Integer> downstream;
         final AtomicInteger counter;

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -96,7 +96,7 @@ public final class FlowableCollectTest extends RxJavaTest {
                     .assertNotComplete();
 
             assertEquals(1, list.size());
-            assertEquals(e2, list.get(0).getCause());
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -212,7 +212,7 @@ public final class FlowableCollectTest extends RxJavaTest {
                     .assertNotComplete();
 
             assertEquals(1, list.size());
-            assertEquals(e2, list.get(0).getCause());
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
@@ -114,7 +114,7 @@ public class FlowableCovarianceTest extends RxJavaTest {
 
     static Function<List<List<Movie>>, Flowable<Movie>> calculateDelta = listOfLists -> {
         if (listOfLists.size() == 1) {
-            return Flowable.fromIterable(listOfLists.get(0));
+            return Flowable.fromIterable(listOfLists.getFirst());
         } else {
             // diff the two
             List<Movie> newList = listOfLists.get(1);

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -582,7 +582,7 @@ public class FlowableSubscriberTest {
             s.onError(new TestException("Outer"));
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> cel = TestHelper.compositeList(list.get(0));
+            List<Throwable> cel = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(cel, 0, TestException.class, "Outer");
             TestHelper.assertError(cel, 1, TestException.class, "Inner");
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -901,7 +901,7 @@ public class FlowableTests extends RxJavaTest {
                 subscriber.assertNoErrors();
                 subscriber.assertComplete();
                 subscriber.assertValue(value);
-                return subscriber.values().get(0);
+                return subscriber.values().getFirst();
             });
         assertSame(returned, value);
     }
@@ -915,7 +915,7 @@ public class FlowableTests extends RxJavaTest {
                 subscriber.assertNoErrors();
                 subscriber.assertComplete();
                 subscriber.assertValue(value);
-                return subscriber.values().get(0);
+                return subscriber.values().getFirst();
             });
         assertSame(returned, value);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ParallelCollectorTest.java
@@ -53,8 +53,8 @@ public class ParallelCollectorTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertEquals(5, ts.values().get(0).size());
-        assertTrue(ts.values().get(0).containsAll(set(5)));
+        assertEquals(5, ts.values().getFirst().size());
+        assertTrue(ts.values().getFirst().containsAll(set(5)));
     }
 
     @Test
@@ -234,9 +234,9 @@ public class ParallelCollectorTest extends RxJavaTest {
             .assertNoErrors()
             .assertComplete();
 
-            assertEquals(1000, ts.values().get(0).size());
+            assertEquals(1000, ts.values().getFirst().size());
 
-            assertTrue(ts.values().get(0).containsAll(set(1000)));
+            assertTrue(ts.values().getFirst().containsAll(set(1000)));
         }
     }
 
@@ -255,9 +255,9 @@ public class ParallelCollectorTest extends RxJavaTest {
             .assertNoErrors()
             .assertComplete();
 
-            assertEquals(1000, ts.values().get(0).size());
+            assertEquals(1000, ts.values().getFirst().size());
 
-            assertTrue(ts.values().get(0).containsAll(set(1000)));
+            assertTrue(ts.values().getFirst().containsAll(set(1000)));
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/CompletableConsumersTest.java
@@ -93,7 +93,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
 
         processor.onError(new IOException());
 
-        assertTrue(events.toString(), events.get(0) instanceof IOException);
+        assertTrue(events.toString(), events.getFirst() instanceof IOException);
 
         assertEquals(0, composite.size());
     }
@@ -126,7 +126,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
 
         processor.onError(new IOException());
 
-        assertTrue(events.toString(), events.get(0) instanceof IOException);
+        assertTrue(events.toString(), events.getFirst() instanceof IOException);
 
         assertEquals(0, composite.size());
     }
@@ -165,7 +165,7 @@ public class CompletableConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            List<Throwable> inners = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(inners, 0, IllegalArgumentException.class);
             TestHelper.assertError(inners, 1, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.observers;
 
 import static org.junit.Assert.*;
 
+import java.io.Serial;
 import java.util.List;
 
 import org.junit.Test;
@@ -32,6 +33,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     static final class TakeFirst extends DeferredScalarObserver<Integer, Integer> {
 
+        @Serial
         private static final long serialVersionUID = -2793723002312330530L;
 
         TakeFirst(Observer<? super Integer> downstream) {
@@ -183,6 +185,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
 
     static final class TakeLast extends DeferredScalarObserver<Integer, Integer> {
 
+        @Serial
         private static final long serialVersionUID = -2793723002312330530L;
 
         TakeLast(Observer<? super Integer> downstream) {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
@@ -46,7 +46,7 @@ public class LambdaObserverTest extends RxJavaTest {
 
         Observable.just(1).subscribe(o);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(o.isDisposed());
@@ -66,7 +66,7 @@ public class LambdaObserverTest extends RxJavaTest {
 
         Observable.just(1).subscribe(o);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(o.isDisposed());
@@ -94,7 +94,7 @@ public class LambdaObserverTest extends RxJavaTest {
             assertTrue(o.isDisposed());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            List<Throwable> ce = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");
         } finally {
@@ -217,7 +217,7 @@ public class LambdaObserverTest extends RxJavaTest {
         assertFalse("Has observers?!", ps.hasObservers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class LambdaObserverTest extends RxJavaTest {
         assertFalse("Has observers?!", ps.hasObservers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/MaybeConsumersTest.java
@@ -118,7 +118,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
 
         processor.onError(new IOException());
 
-        assertTrue(events.toString(), events.get(0) instanceof IOException);
+        assertTrue(events.toString(), events.getFirst() instanceof IOException);
 
         assertEquals(0, composite.size());
     }
@@ -151,7 +151,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
 
         processor.onError(new IOException());
 
-        assertTrue(events.toString(), events.get(0) instanceof IOException);
+        assertTrue(events.toString(), events.getFirst() instanceof IOException);
 
         assertEquals(0, composite.size());
     }
@@ -208,7 +208,7 @@ public class MaybeConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            List<Throwable> inners = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(inners, 0, IllegalArgumentException.class);
             TestHelper.assertError(inners, 1, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/ObservableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/ObservableConsumersTest.java
@@ -219,7 +219,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
 
             assertTrue(errors.toString(), errors.isEmpty());
 
-            assertTrue(events.toString(), events.get(0) instanceof IOException);
+            assertTrue(events.toString(), events.getFirst() instanceof IOException);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -238,7 +238,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            List<Throwable> inners = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(inners, 0, IllegalArgumentException.class);
             TestHelper.assertError(inners, 1, IOException.class);
         } finally {
@@ -259,7 +259,7 @@ public class ObservableConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
-            assertTrue(errors.get(0).getCause() instanceof IOException);
+            assertTrue(errors.getFirst().getCause() instanceof IOException);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/SingleConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/SingleConsumersTest.java
@@ -113,7 +113,7 @@ public class SingleConsumersTest implements Consumer<Object> {
 
         processor.onError(new IOException());
 
-        assertTrue(events.toString(), events.get(0) instanceof IOException);
+        assertTrue(events.toString(), events.getFirst() instanceof IOException);
 
         assertEquals(0, composite.size());
     }
@@ -149,7 +149,7 @@ public class SingleConsumersTest implements Consumer<Object> {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            List<Throwable> inners = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(inners, 0, IllegalArgumentException.class);
             TestHelper.assertError(inners, 1, IOException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnTest.java
@@ -46,7 +46,7 @@ public class CompletableDoOnTest extends RxJavaTest {
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
@@ -214,7 +214,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                Throwable ex = to.errors().get(0);
+                Throwable ex = to.errors().getFirst();
                 if (ex instanceof CompositeException) {
                     to.assertSubscribed().assertNoValues().assertNotComplete();
 
@@ -256,7 +256,7 @@ public class CompletableMergeTest extends RxJavaTest {
 
             to.assertFailure(CompositeException.class);
 
-            List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+            List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
             TestHelper.assertError(errors, 0, TestException.class);
             TestHelper.assertError(errors, 1, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
@@ -115,7 +115,7 @@ public class CompletableSafeSubscribeTest {
 
             TestHelper.assertError(errors, 0, CompositeException.class);
 
-            CompositeException compositeException = (CompositeException)errors.get(0);
+            CompositeException compositeException = (CompositeException)errors.getFirst();
             TestHelper.assertError(compositeException.getExceptions(), 0, IOException.class);
             TestHelper.assertError(compositeException.getExceptions(), 1, TestException.class);
         });

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableUsingTest.java
@@ -106,7 +106,7 @@ public class CompletableUsingTest extends RxJavaTest {
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");
         TestHelper.assertError(list, 1, TestException.class, "Disposer");
@@ -196,7 +196,7 @@ public class CompletableUsingTest extends RxJavaTest {
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");
         TestHelper.assertError(list, 1, TestException.class, "Disposer");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1051,7 +1051,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
                 TestHelper.race(r1, r2);
 
                 if (ts.errors().size() != 0) {
-                    if (ts.errors().get(0) instanceof CompositeException) {
+                    if (ts.errors().getFirst() instanceof CompositeException) {
                         ts.assertSubscribed()
                         .assertNotComplete()
                         .assertNoValues();
@@ -1445,7 +1445,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
         TestSubscriber<List<Object>> ts = Flowable.combineLatestDelayError(Arrays.asList(pp, Flowable.just(1)), Arrays::asList)
         .doOnNext(v -> {
-            if (((Integer)v.get(0)) == 0) {
+            if (((Integer)v.getFirst()) == 0) {
                 pp.onNext(2);
                 pp.onComplete();
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatDelayErrorTest.java
@@ -203,7 +203,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         ts.assertError(CompositeException.class);
         ts.assertNotComplete();
 
-        CompositeException ce = (CompositeException)ts.errors().get(0);
+        CompositeException ce = (CompositeException)ts.errors().getFirst();
         List<Throwable> cex = ce.getExceptions();
 
         assertEquals(3, cex.size());
@@ -238,7 +238,7 @@ public class FlowableConcatDelayErrorTest extends RxJavaTest {
         ts.assertError(CompositeException.class);
         ts.assertNotComplete();
 
-        assertEquals(2, ((CompositeException)ts.errors().get(0)).getExceptions().size());
+        assertEquals(2, ((CompositeException)ts.errors().getFirst()).getExceptions().size());
     }
 
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -680,7 +680,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
 
                 ts.assertSubscribed().assertNoValues().assertNotComplete();
 
-                Throwable ex = ts.errors().get(0);
+                Throwable ex = ts.errors().getFirst();
 
                 if (ex instanceof CompositeException) {
                     List<Throwable> es = TestHelper.errorList(ts);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -200,7 +200,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -213,7 +213,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -226,7 +226,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -240,7 +240,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -254,7 +254,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -268,7 +268,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -878,7 +878,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -896,7 +896,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -914,7 +914,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(ts.values().toString(), ts.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(ts.values().toString(), ts.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
@@ -808,7 +808,7 @@ public class FlowableConcatTest {
 
         ts.assertFailure(CompositeException.class, 1, 2, 3, 4);
 
-        CompositeException composite = (CompositeException)ts.errors().get(0);
+        CompositeException composite = (CompositeException)ts.errors().getFirst();
         List<Throwable> list = composite.getExceptions();
         assertTrue(list.get(0).toString(), list.get(0) instanceof NullPointerException);
         assertTrue(list.get(1).toString(), list.get(1) instanceof TestException);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnEachTest.java
@@ -159,7 +159,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         ts.assertNotComplete();
         ts.assertError(CompositeException.class);
 
-        CompositeException ex = (CompositeException)ts.errors().get(0);
+        CompositeException ex = (CompositeException)ts.errors().getFirst();
 
         List<Throwable> exceptions = ex.getExceptions();
         assertEquals(2, exceptions.size());
@@ -376,7 +376,7 @@ public class FlowableDoOnEachTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -113,7 +113,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -127,7 +127,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         for (int i = 0; i < 10; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -224,7 +224,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -238,7 +238,7 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 10; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -140,7 +140,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -131,7 +131,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
@@ -136,7 +136,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
 
-        Assert.assertEquals("create: " + MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().get(0).getMessage());
+        Assert.assertEquals("create: " + MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().getFirst().getMessage());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -1448,8 +1448,8 @@ public class FlowableGroupByTest extends RxJavaTest {
             V v;
             if (maxSize > 0 && list.size() == maxSize) {
                 //remove first
-                K k = list.get(0);
-                list.remove(0);
+                K k = list.getFirst();
+                list.removeFirst();
                 v = map.remove(k);
             } else {
                 v = null;
@@ -1666,7 +1666,7 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         ts.assertFailure(MissingBackpressureException.class);
 
-        assertTrue("" + ts.errors().get(0).getCause(), ts.errors().get(0).getCause() instanceof TestException);
+        assertTrue("" + ts.errors().getFirst().getCause(), ts.errors().getFirst().getCause() instanceof TestException);
     }
 
     @Test
@@ -1706,7 +1706,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                 }, Functions.emptyConsumer(), () -> done.set(true));
 
         while (!done.get()) {
-            tss.remove(0).cancel();
+            tss.removeFirst().cancel();
         }
 
         assertEquals(1000, counter.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -416,7 +416,7 @@ public class FlowableGroupJoinTest extends RxJavaTest {
 
                 ts.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
 
-                Throwable exc = ts.errors().get(0);
+                Throwable exc = ts.errors().getFirst();
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);
@@ -464,7 +464,7 @@ public class FlowableGroupJoinTest extends RxJavaTest {
 
                 ts.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
 
-                Throwable exc = ts.errors().get(0);
+                Throwable exc = ts.errors().getFirst();
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMaterializeTest.java
@@ -107,7 +107,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
         ts.assertNoValues();
         ts.request(1);
         ts.assertValueCount(1);
-        assertTrue(ts.values().get(0).isOnComplete());
+        assertTrue(ts.values().getFirst().isOnComplete());
         ts.assertComplete();
     }
 
@@ -165,7 +165,7 @@ public class FlowableMaterializeTest extends RxJavaTest {
         ts.assertNoValues();
         ts.request(1);
         ts.assertValueCount(1);
-        assertTrue(ts.values().get(0).isOnNext());
+        assertTrue(ts.values().getFirst().isOnNext());
         ts.request(1);
         ts.assertValueCount(2);
         assertTrue(ts.values().get(1).isOnError());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -570,7 +570,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         ts.assertError(CompositeException.class);
         ts.assertNotComplete();
 
-        CompositeException ce = (CompositeException)ts.errors().get(0);
+        CompositeException ce = (CompositeException)ts.errors().getFirst();
 
         assertEquals(2, ce.getExceptions().size());
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -629,7 +629,7 @@ public class FlowableMergeTest extends RxJavaTest {
         Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).subscribe(testSubscriber);
         testSubscriber.awaitDone(5, TimeUnit.SECONDS);
         if (testSubscriber.errors().size() > 0) {
-            testSubscriber.errors().get(0).printStackTrace();
+            testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
         System.err.println(testSubscriber.values());
@@ -671,7 +671,7 @@ public class FlowableMergeTest extends RxJavaTest {
         System.out.println(onNextEvents);
 
         if (testSubscriber.errors().size() > 0) {
-            testSubscriber.errors().get(0).printStackTrace();
+            testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
         assertEquals(Flowable.bufferSize() * 2 + 1, onNextEvents.size());
@@ -711,7 +711,7 @@ public class FlowableMergeTest extends RxJavaTest {
         Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
         if (testSubscriber.errors().size() > 0) {
-            testSubscriber.errors().get(0).printStackTrace();
+            testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
         System.err.println(testSubscriber.values());
@@ -747,7 +747,7 @@ public class FlowableMergeTest extends RxJavaTest {
         Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
         if (testSubscriber.errors().size() > 0) {
-            testSubscriber.errors().get(0).printStackTrace();
+            testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
         System.out.println("Generated 1: " + generated1.get());
@@ -795,7 +795,7 @@ public class FlowableMergeTest extends RxJavaTest {
         Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
         if (testSubscriber.errors().size() > 0) {
-            testSubscriber.errors().get(0).printStackTrace();
+            testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
         System.out.println("Generated 1: " + generated1.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -508,7 +508,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         List<Throwable> errors = testSubscriber.errors();
         assertEquals(1, errors.size());
         System.out.println("Errors: " + errors);
-        Throwable t = errors.get(0);
+        Throwable t = errors.getFirst();
         if (t instanceof QueueOverflowException) {
             // success, we expect this
         } else {
@@ -570,7 +570,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             // assert that the values are sequential, that cutting in didn't allow skipping some but emitting others.
             // example [0, 1, 2] not [0, 1, 4]
             List<Long> onNextEvents = ts.values();
-            assertTrue(onNextEvents.isEmpty() || onNextEvents.size() == onNextEvents.get(onNextEvents.size() - 1) + 1);
+            assertTrue(onNextEvents.isEmpty() || onNextEvents.size() == onNextEvents.getLast() + 1);
             // we should emit the error without emitting the full buffer size
             assertTrue(onNextEvents.size() < Flowable.bufferSize());
         }
@@ -596,7 +596,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         ts.awaitDone(5, TimeUnit.SECONDS);
         System.out.println("Errors: " + ts.errors());
         assertEquals(1, ts.errors().size());
-        assertEquals(MissingBackpressureException.class, ts.errors().get(0).getClass());
+        assertEquals(MissingBackpressureException.class, ts.errors().getFirst().getClass());
     }
 
     @Test
@@ -621,7 +621,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(1, ts.errors().size());
-        assertEquals(MissingBackpressureException.class, ts.errors().get(0).getClass());
+        assertEquals(MissingBackpressureException.class, ts.errors().getFirst().getClass());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -93,7 +93,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(500, ts.values().size());
         ts.assertNoErrors();
-        assertEquals(0, ts.values().get(0).intValue());
+        assertEquals(0, ts.values().getFirst().intValue());
         assertEquals(499, ts.values().get(499).intValue());
     }
 
@@ -376,6 +376,6 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
 
         ts.assertFailure(MissingBackpressureException.class);
 
-        assertTrue(ts.errors().get(0).getCause() instanceof TestException);
+        assertTrue(ts.errors().getFirst().getCause() instanceof TestException);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -86,7 +86,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
         ts.awaitDone(5, TimeUnit.SECONDS);
         assertEquals(500, ts.values().size());
         ts.assertNoErrors();
-        assertEquals(0, ts.values().get(0).intValue());
+        assertEquals(0, ts.values().getFirst().intValue());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -190,7 +190,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
         ts.assertNotComplete();
 
         Assert.assertEquals(MissingBackpressureException.DEFAULT_MESSAGE,
-                ts.errors().get(0).getMessage());
+                ts.errors().getFirst().getMessage());
         Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 
@@ -212,7 +212,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
         ts.assertError(MissingBackpressureException.class);
         ts.assertNotComplete();
 
-        Assert.assertEquals(MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().get(0).getMessage());
+        Assert.assertEquals(MissingBackpressureException.DEFAULT_MESSAGE, ts.errors().getFirst().getMessage());
         Assert.assertFalse("Source has subscribers?", pp.hasSubscribers());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
@@ -1143,7 +1143,7 @@ public class FlowablePublishTest extends RxJavaTest {
                             Arrays::asList
         )
         .toFlowable())
-        .takeWhile(v -> v.get(0) < 20)
+        .takeWhile(v -> v.getFirst() < 20)
         .test();
 
         ts
@@ -1180,7 +1180,7 @@ public class FlowablePublishTest extends RxJavaTest {
                             Arrays::asList
         )
         .toFlowable())
-        .takeWhile(v -> v.get(0) < 20)
+        .takeWhile(v -> v.getFirst() < 20)
         .test();
 
         ts

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.util.*;
 import java.util.concurrent.*;
@@ -227,7 +227,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         if (!unsubscribeLatch.await(3000, TimeUnit.MILLISECONDS)) {
             System.out.println("Errors: " + s.errors());
             if (s.errors().size() > 0) {
-                s.errors().get(0).printStackTrace();
+                s.errors().getFirst().printStackTrace();
             }
             fail("timed out waiting for unsubscribe");
         }
@@ -270,7 +270,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         System.out.println("DONE sending unsubscribe ... now waiting");
         System.out.println("Errors: " + s.errors());
         if (s.errors().size() > 0) {
-            s.errors().get(0).printStackTrace();
+            s.errors().getFirst().printStackTrace();
         }
         s.assertNoErrors();
     }
@@ -601,6 +601,7 @@ public class FlowableRefCountTest extends RxJavaTest {
     }
 
     static final class ExceptionData extends Exception {
+        @Serial
         private static final long serialVersionUID = -6763898015338136119L;
 
         public final Object data;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -665,6 +666,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void boundedReplayBuffer() {
         BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -668,6 +668,7 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test
     public void boundedReplayBuffer() {
         BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override
@@ -705,6 +706,7 @@ public class FlowableReplayTest extends RxJavaTest {
     @Test(expected = IllegalStateException.class)
     public void boundedRemoveFirstOneItemOnly() {
         BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -351,7 +351,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -398,7 +398,7 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -375,8 +375,8 @@ public class FlowableScanTest extends RxJavaTest {
             .assertError(e);
 
             assertEquals("" + list, 1, list.size());
-            assertTrue("" + list, list.get(0) instanceof UndeliverableException);
-            assertEquals(e2, list.get(0).getCause());
+            assertTrue("" + list, list.getFirst() instanceof UndeliverableException);
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -448,8 +448,8 @@ public class FlowableScanTest extends RxJavaTest {
             .assertError(e);
 
             assertEquals("" + list, 1, list.size());
-            assertTrue("" + list, list.get(0) instanceof UndeliverableException);
-            assertEquals(e2, list.get(0).getCause());
+            assertTrue("" + list, list.getFirst() instanceof UndeliverableException);
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -521,7 +521,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         .assertNotComplete()
         .assertError(CompositeException.class);
 
-        List<Throwable> errors = ExceptionHelper.flatten(ts.errors().get(0));
+        List<Throwable> errors = ExceptionHelper.flatten(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Forced failure 1");
         TestHelper.assertError(errors, 1, TestException.class, "Forced failure 2");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest2.java
@@ -54,7 +54,7 @@ public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Actio
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
-        assertEquals(6, requests.get(0).intValue());
+        assertEquals(6, requests.getFirst().intValue());
     }
 
     @Test
@@ -79,7 +79,7 @@ public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Actio
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
-        assertEquals(5, requests.get(0).intValue());
+        assertEquals(5, requests.getFirst().intValue());
     }
 
     @Test
@@ -100,7 +100,7 @@ public class FlowableTakeTest2 extends RxJavaTest implements LongConsumer, Actio
         .assertResult();
 
         assertEquals(1, requests.size());
-        assertEquals(CANCELLED, requests.get(0));
+        assertEquals(CANCELLED, requests.getFirst());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTests.java
@@ -482,7 +482,7 @@ public class FlowableTimeoutTests extends RxJavaTest {
             if (ts.isTerminated()) {
                 int c = ts.values().size();
                 if (c == 1) {
-                    int v = ts.values().get(0);
+                    int v = ts.values().getFirst();
                     assertTrue("" + v, v == 1 || v == 2);
                 } else {
                     ts.assertResult(1, 2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.util.*;
 
 import org.junit.*;
@@ -135,6 +136,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -3296811238780863394L;
 
             @Override
@@ -274,6 +276,7 @@ public class FlowableToMapTest extends RxJavaTest {
 
         Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -3296811238780863394L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.util.*;
 
 import org.junit.*;
@@ -79,6 +80,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -2084477070717362859L;
 
             @Override
@@ -270,6 +272,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
 
         Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -2084477070717362859L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableUsingTest.java
@@ -366,7 +366,7 @@ public class FlowableUsingTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");
@@ -382,7 +382,7 @@ public class FlowableUsingTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -189,7 +189,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         assertEquals(1, values.size());
 
-        Subscriber<Object> mo = values.get(0);
+        Subscriber<Object> mo = values.getFirst();
 
         verify(mo).onNext(0);
         verify(mo).onNext(1);
@@ -239,7 +239,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         assertEquals(1, values.size());
 
-        Subscriber<Object> mo = values.get(0);
+        Subscriber<Object> mo = values.getFirst();
 
         verify(mo).onNext(0);
         verify(mo).onNext(1);
@@ -263,7 +263,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -65,7 +65,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(95, TimeUnit.MILLISECONDS);
         assertEquals(1, lists.size());
-        assertEquals(lists.get(0), list("one", "two"));
+        assertEquals(lists.getFirst(), list("one", "two"));
 
         scheduler.advanceTimeTo(195, TimeUnit.MILLISECONDS);
         assertEquals(3, lists.size());
@@ -98,7 +98,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(101, TimeUnit.MILLISECONDS);
         assertEquals(1, lists.size());
-        assertEquals(lists.get(0), list("one", "two", "three"));
+        assertEquals(lists.getFirst(), list("one", "two", "three"));
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
         assertEquals(2, lists.size());
@@ -670,7 +670,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         .assertNoErrors()
         .assertNotComplete();
 
-        ts.values().get(0).test().assertResult();
+        ts.values().getFirst().test().assertResult();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -1186,7 +1186,7 @@ public class FlowableZipTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class, "11", "22");
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
         TestHelper.assertError(errors, 0, TestException.class, "One");
         TestHelper.assertError(errors, 1, TestException.class, "Two");
         assertEquals(2, errors.size());
@@ -1204,7 +1204,7 @@ public class FlowableZipTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class, "11", "22");
 
-        List<Throwable> errors = TestHelper.compositeList(ts.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(ts.errors().getFirst());
         TestHelper.assertError(errors, 0, TestException.class, "One");
         TestHelper.assertError(errors, 1, TestException.class, "Two");
         assertEquals(2, errors.size());
@@ -1449,7 +1449,7 @@ public class FlowableZipTest extends RxJavaTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(1);
 
-            List<Object> list = ts.values().get(0);
+            List<Object> list = ts.values().getFirst();
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -87,7 +87,7 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
             TestHelper.assertError(errors, 0, CompositeException.class);
 
-            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            List<Throwable> ce = TestHelper.compositeList(errors.getFirst());
 
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayOtherTest.java
@@ -191,7 +191,7 @@ public class MaybeDelayOtherTest extends RxJavaTest {
 
         to.assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
         assertEquals(2, list.size());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnTerminateTest.java
@@ -74,7 +74,7 @@ public class MaybeDoOnTerminateTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapNotificationTest.java
@@ -58,7 +58,7 @@ public class MaybeFlatMapNotificationTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(ce, 0, TestException.class);
         TestHelper.assertError(ce, 1, NullPointerException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFromRunnableTest.java
@@ -126,7 +126,7 @@ public class MaybeFromRunnableTest extends RxJavaTest {
 
             TestHelper.assertUndeliverable(errors, 0, RuntimeException.class);
 
-            assertTrue(errors.get(0).toString(), errors.get(0).getCause().getCause() instanceof InterruptedException);
+            assertTrue(errors.getFirst().toString(), errors.getFirst().getCause().getCause() instanceof InterruptedException);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybePeekTest.java
@@ -100,7 +100,7 @@ public class MaybePeekTest extends RxJavaTest {
 
         to.assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Main");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
@@ -163,7 +163,7 @@ public class MaybeSafeSubscribeTest {
 
             TestHelper.assertError(errors, 0, CompositeException.class);
 
-            CompositeException compositeException = (CompositeException)errors.get(0);
+            CompositeException compositeException = (CompositeException)errors.getFirst();
             TestHelper.assertError(compositeException.getExceptions(), 0, IOException.class);
             TestHelper.assertError(compositeException.getExceptions(), 1, TestException.class);
         });

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUsingTest.java
@@ -117,7 +117,7 @@ public class MaybeUsingTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");
         TestHelper.assertError(list, 1, TestException.class, "Disposer");
@@ -203,7 +203,7 @@ public class MaybeUsingTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(list, 0, TestException.class, "Main");
         TestHelper.assertError(list, 1, TestException.class, "Disposer");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapCompletableTest.java
@@ -95,7 +95,7 @@ public class FlowableConcatMapCompletableTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        assertEquals(5, ((CompositeException)to.errors().get(0)).getExceptions().size());
+        assertEquals(5, ((CompositeException)to.errors().getFirst()).getExceptions().size());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -285,7 +285,7 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        CompositeException ce = (CompositeException)ts.errors().get(0);
+        CompositeException ce = (CompositeException)ts.errors().getFirst();
         assertEquals(5, ce.getExceptions().size());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -217,7 +217,7 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        CompositeException ce = (CompositeException)ts.errors().get(0);
+        CompositeException ce = (CompositeException)ts.errors().getFirst();
         assertEquals(5, ce.getExceptions().size());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
@@ -85,7 +85,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        assertEquals(5, ((CompositeException)to.errors().get(0)).getExceptions().size());
+        assertEquals(5, ((CompositeException)to.errors().getFirst()).getExceptions().size());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -252,7 +252,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        CompositeException ce = (CompositeException)to.errors().get(0);
+        CompositeException ce = (CompositeException)to.errors().getFirst();
         assertEquals(5, ce.getExceptions().size());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -184,7 +184,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         .assertFailure(CompositeException.class)
         ;
 
-        CompositeException ce = (CompositeException)to.errors().get(0);
+        CompositeException ce = (CompositeException)to.errors().getFirst();
         assertEquals(5, ce.getExceptions().size());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -79,7 +79,7 @@ public final class ObservableCollectTest extends RxJavaTest {
                     .assertNotComplete();
 
             assertEquals(1, list.size());
-            assertEquals(e2, list.get(0).getCause());
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }
@@ -179,7 +179,7 @@ public final class ObservableCollectTest extends RxJavaTest {
                     .assertNotComplete();
 
             assertEquals(1, list.size());
-            assertEquals(e2, list.get(0).getCause());
+            assertEquals(e2, list.getFirst().getCause());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -829,7 +829,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
                 TestHelper.race(r1, r2);
 
                 if (to.errors().size() != 0) {
-                    if (to.errors().get(0) instanceof CompositeException) {
+                    if (to.errors().getFirst() instanceof CompositeException) {
                         to.assertSubscribed()
                         .assertNotComplete()
                         .assertNoValues();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -150,7 +150,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -176,7 +176,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -215,7 +215,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -783,7 +783,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -801,7 +801,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test
@@ -819,7 +819,7 @@ public class ObservableConcatMapSchedulerTest {
         .assertNoErrors()
         .assertComplete();
 
-        assertTrue(to.values().toString(), to.values().get(0).startsWith("RxSingleScheduler-"));
+        assertTrue(to.values().toString(), to.values().getFirst().startsWith("RxSingleScheduler-"));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoOnEachTest.java
@@ -155,7 +155,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         to.assertNotComplete();
         to.assertError(CompositeException.class);
 
-        CompositeException ex = (CompositeException)to.errors().get(0);
+        CompositeException ex = (CompositeException)to.errors().getFirst();
 
         List<Throwable> exceptions = ex.getExceptions();
         assertEquals(2, exceptions.size());
@@ -346,7 +346,7 @@ public class ObservableDoOnEachTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -101,7 +101,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -115,7 +115,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 10; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -218,7 +218,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);
@@ -232,7 +232,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 10; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -114,7 +114,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -105,7 +105,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         for (int i = 0; i < 11; i++) {
             TestHelper.assertError(errors, i, TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableForEachTest.java
@@ -79,7 +79,7 @@ public class ObservableForEachTest extends RxJavaTest {
             });
 
             TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
-            Throwable c = errors.get(0).getCause();
+            Throwable c = errors.getFirst().getCause();
             assertTrue("" + c, c instanceof TestException);
         } finally {
             RxJavaPlugins.reset();
@@ -97,7 +97,7 @@ public class ObservableForEachTest extends RxJavaTest {
 
             TestHelper.assertError(errors, 0, CompositeException.class);
 
-            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            List<Throwable> ce = TestHelper.compositeList(errors.getFirst());
 
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
@@ -409,7 +409,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertValueCount(1);
 
-                Throwable exc = to.errors().get(0);
+                Throwable exc = to.errors().getFirst();
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);
@@ -457,7 +457,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
 
                 to.assertError(Throwable.class).assertSubscribed().assertNotComplete().assertNoValues();
 
-                Throwable exc = to.errors().get(0);
+                Throwable exc = to.errors().getFirst();
 
                 if (exc instanceof CompositeException) {
                     List<Throwable> es = TestHelper.compositeList(exc);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -654,7 +654,7 @@ public class ObservableMergeTest extends RxJavaTest {
         System.out.println(onNextEvents);
 
         if (testObserver.errors().size() > 0) {
-            testObserver.errors().get(0).printStackTrace();
+            testObserver.errors().getFirst().printStackTrace();
         }
         testObserver.assertNoErrors();
         assertEquals(Flowable.bufferSize() * 2 + 1, onNextEvents.size());
@@ -746,7 +746,7 @@ public class ObservableMergeTest extends RxJavaTest {
         Observable.merge(o1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
         if (to.errors().size() > 0) {
-            to.errors().get(0).printStackTrace();
+            to.errors().getFirst().printStackTrace();
         }
         to.assertNoErrors();
         System.out.println("Generated 1: " + generated1.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
+import java.io.*;
 import java.lang.management.ManagementFactory;
 import java.util.*;
 import java.util.concurrent.*;
@@ -212,7 +212,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         if (!unsubscribeLatch.await(3000, TimeUnit.MILLISECONDS)) {
             System.out.println("Errors: " + observer.errors());
             if (observer.errors().size() > 0) {
-                observer.errors().get(0).printStackTrace();
+                observer.errors().getFirst().printStackTrace();
             }
             fail("timed out waiting for unsubscribe");
         }
@@ -262,7 +262,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         System.out.println("DONE sending unsubscribe ... now waiting");
         System.out.println("Errors: " + observer.errors());
         if (observer.errors().size() > 0) {
-            observer.errors().get(0).printStackTrace();
+            observer.errors().getFirst().printStackTrace();
         }
         observer.assertNoErrors();
     }
@@ -567,6 +567,7 @@ public class ObservableRefCountTest extends RxJavaTest {
     }
 
     static final class ExceptionData extends Exception {
+        @Serial
         private static final long serialVersionUID = -6763898015338136119L;
 
         public final Object data;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -649,6 +650,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     @Test
     public void boundedReplayBuffer() {
         BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = -5182053207244406872L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
@@ -649,6 +650,7 @@ public class ObservableReplayTest extends RxJavaTest {
     @Test
     public void boundedReplayBuffer() {
         BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = -5182053207244406872L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -330,7 +330,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -374,7 +374,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -421,7 +421,7 @@ public class ObservableSwitchTest extends RxJavaTest {
         .assertNotComplete()
         .assertError(CompositeException.class);
 
-        List<Throwable> errors = ExceptionHelper.flatten(to.errors().get(0));
+        List<Throwable> errors = ExceptionHelper.flatten(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Forced failure 1");
         TestHelper.assertError(errors, 1, TestException.class, "Forced failure 2");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
@@ -479,7 +479,7 @@ public class ObservableTimeoutTests extends RxJavaTest {
             if (to.isTerminated()) {
                 int c = to.values().size();
                 if (c == 1) {
-                    int v = to.values().get(0);
+                    int v = to.values().getFirst();
                     assertTrue("" + v, v == 1 || v == 2);
                 } else {
                     to.assertResult(1, 2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.internal.operators.observable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.util.*;
 
 import org.junit.*;
@@ -136,6 +137,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -3296811238780863394L;
 
             @Override
@@ -275,6 +277,7 @@ public class ObservableToMapTest extends RxJavaTest {
 
         Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -3296811238780863394L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.internal.operators.observable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.io.Serial;
 import java.util.*;
 
 import org.junit.*;
@@ -79,6 +80,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -2084477070717362859L;
 
             @Override
@@ -270,6 +272,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
 
         Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
 
+            @Serial
             private static final long serialVersionUID = -2084477070717362859L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUnsubscribeOnTest.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.operators.observable;
 
 import static org.junit.Assert.*;
 
+import java.io.Serial;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -127,6 +128,7 @@ public class ObservableUnsubscribeOnTest extends RxJavaTest {
 
     private static class ThreadSubscription extends AtomicBoolean implements Disposable {
 
+        @Serial
         private static final long serialVersionUID = -5011338112974328771L;
 
         private volatile Thread thread;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableUsingTest.java
@@ -322,7 +322,7 @@ public class ObservableUsingTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");
@@ -337,7 +337,7 @@ public class ObservableUsingTest extends RxJavaTest {
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "First");
         TestHelper.assertError(errors, 1, TestException.class, "Second");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -189,7 +189,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         assertEquals(1, values.size());
 
-        Observer<Object> mo = values.get(0);
+        Observer<Object> mo = values.getFirst();
 
         verify(mo).onNext(0);
         verify(mo).onNext(1);
@@ -239,7 +239,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         assertEquals(1, values.size());
 
-        Observer<Object> mo = values.get(0);
+        Observer<Object> mo = values.getFirst();
 
         verify(mo).onNext(0);
         verify(mo).onNext(1);
@@ -263,7 +263,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -64,7 +64,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(95, TimeUnit.MILLISECONDS);
         assertEquals(1, lists.size());
-        assertEquals(lists.get(0), list("one", "two"));
+        assertEquals(lists.getFirst(), list("one", "two"));
 
         scheduler.advanceTimeTo(195, TimeUnit.MILLISECONDS);
         assertEquals(3, lists.size());
@@ -97,7 +97,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         scheduler.advanceTimeTo(101, TimeUnit.MILLISECONDS);
         assertEquals(1, lists.size());
-        assertEquals(lists.get(0), list("one", "two", "three"));
+        assertEquals(lists.getFirst(), list("one", "two", "three"));
 
         scheduler.advanceTimeTo(201, TimeUnit.MILLISECONDS);
         assertEquals(2, lists.size());
@@ -546,7 +546,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         .assertNoErrors()
         .assertNotComplete();
 
-        to.values().get(0).test().assertResult();
+        to.values().getFirst().test().assertResult();
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
@@ -1129,7 +1129,7 @@ public class ObservableZipTest extends RxJavaTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertValueCount(1);
 
-            List<Object> list = to.values().get(0);
+            List<Object> list = to.values().getFirst();
 
             assertTrue(list.toString(), list.contains("RxSi"));
             assertTrue(list.toString(), list.contains("RxCo"));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTerminateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTerminateTest.java
@@ -64,7 +64,7 @@ public class SingleDoOnTerminateTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnTest.java
@@ -138,7 +138,7 @@ public class SingleDoOnTest extends RxJavaTest {
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");
@@ -163,7 +163,7 @@ public class SingleDoOnTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Main");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
@@ -59,7 +59,7 @@ public class SingleFlatMapNotificationTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(ce, 0, TestException.class);
         TestHelper.assertError(ce, 1, NullPointerException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorXTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorXTest.java
@@ -40,7 +40,7 @@ public class SingleOnErrorXTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> errors = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> errors = TestHelper.compositeList(to.errors().getFirst());
 
         TestHelper.assertError(errors, 0, TestException.class, "Outer");
         TestHelper.assertError(errors, 1, TestException.class, "Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
@@ -146,7 +146,7 @@ public class SingleSafeSubscribeTest {
 
             TestHelper.assertError(errors, 0, CompositeException.class);
 
-            CompositeException compositeException = (CompositeException)errors.get(0);
+            CompositeException compositeException = (CompositeException)errors.getFirst();
             TestHelper.assertError(compositeException.getExceptions(), 0, IOException.class);
             TestHelper.assertError(compositeException.getExceptions(), 1, TestException.class);
         });

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
@@ -86,7 +86,7 @@ public class SingleUsingTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().getFirst());
         TestHelper.assertError(ce, 0, TestException.class, "Mapper");
         TestHelper.assertError(ce, 1, TestException.class, "Disposer");
     }
@@ -168,7 +168,7 @@ public class SingleUsingTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> ce = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> ce = TestHelper.compositeList(to.errors().getFirst());
         TestHelper.assertError(ce, 0, TestException.class, "Mapper-run");
         TestHelper.assertError(ce, 1, TestException.class, "Disposer");
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import static org.junit.Assert.*;
 
+import java.io.Serial;
 import java.util.concurrent.FutureTask;
 
 import org.junit.Test;
@@ -29,6 +30,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void cancelSetFuture() {
         @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -61,6 +63,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void cancelSetFutureCurrentThread() {
         @SuppressWarnings("resource")
         var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -95,6 +98,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void setFutureCancel() {
         @SuppressWarnings("resource")
         var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -124,6 +128,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void setFutureCancelSameThread() {
         @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -154,6 +159,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void finished() {
         @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -184,6 +190,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     public void finishedCancel() {
         @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+            @Serial
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
@@ -219,6 +226,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             @SuppressWarnings("resource")
             final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
+                @Serial
                 private static final long serialVersionUID = 208585707945686116L;
             };
 
@@ -240,6 +248,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     }
 
     static class TestDirectTask extends AbstractDirectTask {
+        @Serial
         private static final long serialVersionUID = 587679821055711738L;
 
         TestDirectTask() {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
@@ -44,7 +44,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(subscriber);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(subscriber.isDisposed());
@@ -62,7 +62,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(subscriber);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(subscriber.isDisposed());
@@ -88,7 +88,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
             assertTrue(subscriber.isDisposed());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            List<Throwable> ce = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");
         } finally {
@@ -143,7 +143,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
         assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class BoundedSubscriberTest extends RxJavaTest {
         assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -15,6 +15,7 @@ package io.reactivex.rxjava4.internal.subscribers;
 
 import static org.junit.Assert.*;
 
+import java.io.Serial;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -388,6 +389,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     static final class TestingDeferredScalarSubscriber extends DeferredScalarSubscriber<Integer, Integer> {
 
+        @Serial
         private static final long serialVersionUID = 6285096158319517837L;
 
         TestingDeferredScalarSubscriber(Subscriber<? super Integer> downstream) {
@@ -416,6 +418,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.doubleOnSubscribe(new DeferredScalarSubscriber<Integer, Integer>(new TestSubscriber<>()) {
+            @Serial
             private static final long serialVersionUID = -4445381578878059054L;
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/FlowableConsumersTest.java
@@ -220,7 +220,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
 
             assertTrue(errors.toString(), errors.isEmpty());
 
-            assertTrue(events.toString(), events.get(0) instanceof IOException);
+            assertTrue(events.toString(), events.getFirst() instanceof IOException);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -239,7 +239,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> inners = TestHelper.compositeList(errors.get(0));
+            List<Throwable> inners = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(inners, 0, IllegalArgumentException.class);
             TestHelper.assertError(inners, 1, IOException.class);
         } finally {
@@ -260,7 +260,7 @@ public class FlowableConsumersTest implements Consumer<Object>, Action {
             assertTrue(events.toString(), events.isEmpty());
 
             TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
-            assertTrue(errors.get(0).getCause() instanceof IOException);
+            assertTrue(errors.getFirst().getCause() instanceof IOException);
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
@@ -43,7 +43,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(subscriber);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(subscriber.isDisposed());
@@ -62,7 +62,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
         Flowable.just(1).subscribe(subscriber);
 
-        assertTrue(received.toString(), received.get(0) instanceof TestException);
+        assertTrue(received.toString(), received.getFirst() instanceof TestException);
         assertEquals(received.toString(), 1, received.size());
 
         assertTrue(subscriber.isDisposed());
@@ -89,7 +89,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
             assertTrue(subscriber.isDisposed());
 
             TestHelper.assertError(errors, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(errors.get(0));
+            List<Throwable> ce = TestHelper.compositeList(errors.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "Outer");
             TestHelper.assertError(ce, 1, TestException.class, "Inner");
         } finally {
@@ -190,7 +190,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
         assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test
@@ -208,7 +208,7 @@ public class LambdaSubscriberTest extends RxJavaTest {
         assertFalse("Has observers?!", pp.hasSubscribers());
         assertFalse("No errors?!", errors.isEmpty());
 
-        assertTrue(errors.toString(), errors.get(0) instanceof TestException);
+        assertTrue(errors.toString(), errors.getFirst() instanceof TestException);
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -20,6 +20,8 @@ import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
+import java.io.Serial;
+
 public class SinglePostCompleteSubscriberTest extends RxJavaTest {
 
     @Test
@@ -28,6 +30,7 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
             final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) /* NFI */ {
+                @Serial
                 private static final long serialVersionUID = -2848918821531562637L;
 
                 @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
@@ -61,7 +61,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         }.subscribe(sub);
 
-        assertTrue(list.toString(), list.get(0) instanceof StrictSubscriber);
+        assertTrue(list.toString(), list.getFirst() instanceof StrictSubscriber);
     }
 
     static final class SubscriberWrapper<T> implements Subscriber<T> {
@@ -189,8 +189,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
         Flowable.range(1, 5).subscribe(sub);
 
-        assertTrue(list.toString(), list.get(0) instanceof IllegalArgumentException);
-        assertTrue(list.toString(), list.get(0).toString().contains("3.9"));
+        assertTrue(list.toString(), list.getFirst() instanceof IllegalArgumentException);
+        assertTrue(list.toString(), list.getFirst().toString().contains("3.9"));
     }
 
     @Test
@@ -221,8 +221,8 @@ public class StrictSubscriberTest extends RxJavaTest {
 
         Flowable.range(1, 5).subscribe(sub);
 
-        assertTrue(list.toString(), list.get(0) instanceof IllegalArgumentException);
-        assertTrue(list.toString(), list.get(0).toString().contains("3.9"));
+        assertTrue(list.toString(), list.getFirst() instanceof IllegalArgumentException);
+        assertTrue(list.toString(), list.getFirst().toString().contains("3.9"));
     }
 
     @Test
@@ -329,6 +329,6 @@ public class StrictSubscriberTest extends RxJavaTest {
         }.subscribe(wrapper);
 
         ts.assertFailure(IllegalStateException.class);
-        assertTrue(ts.errors().toString(), ts.errors().get(0).getMessage().contains("2.12"));
+        assertTrue(ts.errors().toString(), ts.errors().getFirst().getMessage().contains("2.12"));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/QueueSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/QueueSubscriptionTest.java
@@ -21,9 +21,12 @@ import io.reactivex.rxjava4.annotations.Nullable;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
+import java.io.Serial;
+
 public class QueueSubscriptionTest extends RxJavaTest {
     static final class EmptyQS extends BasicQueueSubscription<Integer> {
 
+        @Serial
         private static final long serialVersionUID = -5312809687598840520L;
 
         @Override
@@ -61,6 +64,7 @@ public class QueueSubscriptionTest extends RxJavaTest {
 
     static final class EmptyIntQS extends BasicIntQueueSubscription<Integer> {
 
+        @Serial
         private static final long serialVersionUID = -1374033403007296252L;
 
         @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
@@ -80,7 +80,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isCancelled());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -119,7 +119,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
 
         // with this consumer, the class name should be predictable
-        assertEquals(EndConsumerHelper.composeMessage("io.reactivex.rxjava4.internal.util.EndConsumerHelperTest$EndDefaultSubscriber"), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage("io.reactivex.rxjava4.internal.util.EndConsumerHelperTest$EndDefaultSubscriber"), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -155,7 +155,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isCancelled());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -191,7 +191,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isCancelled());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -226,7 +226,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -262,7 +262,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -298,7 +298,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -330,7 +330,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -362,7 +362,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -398,7 +398,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -434,7 +434,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -466,7 +466,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 
@@ -498,7 +498,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
         assertTrue(sub2.isDisposed());
 
         TestHelper.assertError(errors, 0, ProtocolViolationException.class);
-        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.get(0).getMessage());
+        assertEquals(EndConsumerHelper.composeMessage(consumer.getClass().getName()), errors.getFirst().getMessage());
         assertEquals(errors.toString(), 1, errors.size());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/VolatileSizeArrayListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/VolatileSizeArrayListTest.java
@@ -104,7 +104,7 @@ public class VolatileSizeArrayListTest extends RxJavaTest {
         assertEquals(list.hashCode(), list3.hashCode());
         assertEquals(list.toString(), list3.toString());
 
-        list.remove(0);
+        list.removeFirst();
         assertEquals(6, list.size());
 
         list.clear();

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -408,7 +408,7 @@ public class MaybeTest extends RxJavaTest {
         .assertValueCount(1)
         ;
 
-        assertNotEquals("1: " + main, to.values().get(0));
+        assertNotEquals("1: " + main, to.values().getFirst());
     }
 
     @Test
@@ -451,7 +451,7 @@ public class MaybeTest extends RxJavaTest {
         .assertValueCount(1)
         ;
 
-        assertNotEquals(main, to.values().get(0));
+        assertNotEquals(main, to.values().getFirst());
     }
 
     @Test
@@ -1873,7 +1873,7 @@ public class MaybeTest extends RxJavaTest {
             .subscribe().isDisposed());
 
             TestHelper.assertError(errors, 0, OnErrorNotImplementedException.class);
-            Throwable c = errors.get(0).getCause();
+            Throwable c = errors.getFirst().getCause();
             assertTrue("" + c, c instanceof TestException);
         } finally {
             RxJavaPlugins.reset();
@@ -2023,7 +2023,7 @@ public class MaybeTest extends RxJavaTest {
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
-        List<Throwable> list = TestHelper.compositeList(to.errors().get(0));
+        List<Throwable> list = TestHelper.compositeList(to.errors().getFirst());
         TestHelper.assertError(list, 0, TestException.class, "Outer");
         TestHelper.assertError(list, 1, TestException.class, "Inner");
         assertEquals(2, list.size());

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
@@ -113,7 +113,7 @@ public class ObservableCovarianceTest extends RxJavaTest {
 
     static Function<List<List<Movie>>, Observable<Movie>> calculateDelta = listOfLists -> {
         if (listOfLists.size() == 1) {
-            return Observable.fromIterable(listOfLists.get(0));
+            return Observable.fromIterable(listOfLists.getFirst());
         } else {
             // diff the two
             List<Movie> newList = listOfLists.get(1);

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
@@ -910,7 +910,7 @@ public class ObservableTest extends RxJavaTest {
                 to.assertNoErrors();
                 to.assertComplete();
                 to.assertValue(value);
-                return to.values().get(0);
+                return to.values().getFirst();
             });
         assertSame(returned, value);
     }
@@ -924,7 +924,7 @@ public class ObservableTest extends RxJavaTest {
             to.assertNoErrors();
             to.assertComplete();
             to.assertValue(value);
-            return to.values().get(0);
+            return to.values().getFirst();
         });
         assertSame(returned, value);
     }

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableMaybeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableMaybeObserverTest.java
@@ -74,7 +74,7 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
 
         assertFalse(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
         assertEquals(0, tc.complete);
     }

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableObserverTest.java
@@ -74,7 +74,7 @@ public class DisposableObserverTest extends RxJavaTest {
 
         assertFalse(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableSingleObserverTest.java
@@ -67,7 +67,7 @@ public class DisposableSingleObserverTest extends RxJavaTest {
 
         assertFalse(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/observers/ResourceObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/ResourceObserverTest.java
@@ -151,7 +151,7 @@ public class ResourceObserverTest extends RxJavaTest {
 
         assertTrue(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
@@ -415,7 +415,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.rxjava4.exceptions.TestException: onNext(1))");
         } finally {
@@ -477,7 +477,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onSubscribe(cd);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "dispose()");
         } finally {
@@ -497,7 +497,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
         } finally {
@@ -529,7 +529,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
         } finally {
@@ -560,7 +560,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onError(new TestException());
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
         } finally {
@@ -580,7 +580,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onError(new TestException());
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 2, TestException.class);
@@ -619,7 +619,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onComplete();
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
         } finally {
@@ -639,7 +639,7 @@ public class SafeObserverTest extends RxJavaTest {
             so.onComplete();
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -172,7 +172,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
             sums.add(v);
         }
 
-        long expected = sums.get(0);
+        long expected = sums.getFirst();
         boolean success = true;
         for (long l : sums) {
             if (l != expected) {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -172,7 +172,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
             sums.add(v);
         }
 
-        long expected = sums.get(0);
+        long expected = sums.getFirst();
         boolean success = true;
         for (long l : sums) {
             if (l != expected) {

--- a/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleSubscribeTest.java
@@ -143,7 +143,7 @@ public class SingleSubscribeTest extends RxJavaTest {
                     });
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> cel = TestHelper.compositeList(list.get(0));
+            List<Throwable> cel = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");
         } finally {
@@ -177,7 +177,7 @@ public class SingleSubscribeTest extends RxJavaTest {
                     });
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> cel = TestHelper.compositeList(list.get(0));
+            List<Throwable> cel = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(cel, 0, TestException.class, "Outer failure");
             TestHelper.assertError(cel, 1, TestException.class, "Inner failure");
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -176,7 +176,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
             sums.add(v);
         }
 
-        long expected = sums.get(0);
+        long expected = sums.getFirst();
         boolean success = true;
         for (long l : sums) {
             if (l != expected) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -176,7 +176,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
             sums.add(v);
         }
 
-        long expected = sums.get(0);
+        long expected = sums.getFirst();
         boolean success = true;
         for (long l : sums) {
             if (l != expected) {

--- a/src/test/java/io/reactivex/rxjava4/subscribers/DisposableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/DisposableSubscriberTest.java
@@ -73,7 +73,7 @@ public class DisposableSubscriberTest extends RxJavaTest {
 
         assertFalse(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
@@ -155,7 +155,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
         assertTrue(tc.isDisposed());
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
     }
 
@@ -218,7 +218,7 @@ public class ResourceSubscriberTest extends RxJavaTest {
         tc.requestMore(1);
 
         assertEquals(1, tc.start);
-        assertEquals(1, tc.values.get(0).intValue());
+        assertEquals(1, tc.values.getFirst().intValue());
         assertTrue(tc.errors.isEmpty());
         assertEquals(1, tc.complete);
     }

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
@@ -558,7 +558,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "onNext(1)");
             TestHelper.assertError(ce, 1, TestException.class, "onError(io.reactivex.rxjava4.exceptions.TestException: onNext(1))");
         } finally {
@@ -620,7 +620,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onSubscribe(cd);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "onSubscribe()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");
         } finally {
@@ -639,7 +639,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
         } finally {
@@ -670,7 +670,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onNext(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onError(java.lang.NullPointerException: Subscription not set!)");
         } finally {
@@ -700,7 +700,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onError(new TestException());
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
         } finally {
@@ -719,7 +719,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onError(new TestException());
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class);
             TestHelper.assertError(ce, 1, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 2, TestException.class);
@@ -757,7 +757,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onComplete();
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class, "onSubscribe()");
         } finally {
@@ -776,7 +776,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.onComplete();
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, NullPointerException.class, "Subscription not set!");
             TestHelper.assertError(ce, 1, TestException.class);
         } finally {
@@ -830,7 +830,7 @@ public class SafeSubscriberTest extends RxJavaTest {
             so.request(1);
 
             TestHelper.assertError(list, 0, CompositeException.class);
-            List<Throwable> ce = TestHelper.compositeList(list.get(0));
+            List<Throwable> ce = TestHelper.compositeList(list.getFirst());
             TestHelper.assertError(ce, 0, TestException.class, "request()");
             TestHelper.assertError(ce, 1, TestException.class, "cancel()");
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/tck/RefCountProcessor.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/RefCountProcessor.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.tck;
 
+import java.io.Serial;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -170,6 +171,7 @@ import io.reactivex.rxjava4.processors.FlowableProcessor;
 
     static final class RefCountSubscriber<T> extends AtomicBoolean implements FlowableSubscriber<T>, Subscription {
 
+        @Serial
         private static final long serialVersionUID = -4317488092687530631L;
 
         final Subscriber<? super T> downstream;

--- a/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
@@ -157,7 +157,7 @@ extends BaseTestConsumer<T, U> {
             throw fail("No errors");
         } else
         if (s == 1) {
-            Throwable e = errors.get(0);
+            Throwable e = errors.getFirst();
             String errorMessage = e.getMessage();
             if (!Objects.equals(message, errorMessage)) {
                 throw fail("\nexpected: " + message + "\ngot: " + errorMessage

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
-import java.io.File;
+import java.io.*;
 import java.lang.management.*;
 import java.lang.reflect.*;
 import java.net.URL;
@@ -219,10 +219,9 @@ public enum TestHelper {
     }
 
     public static void assertError(TestObserverEx<?> to, int index, Class<? extends Throwable> clazz) {
-        Throwable ex = to.errors().get(0);
+        Throwable ex = to.errors().getFirst();
         try {
-            if (ex instanceof CompositeException) {
-                CompositeException ce = (CompositeException) ex;
+            if (ex instanceof CompositeException ce) {
                 List<Throwable> cel = ce.getExceptions();
                 assertTrue(cel.get(index).toString(), clazz.isInstance(cel.get(index)));
             } else {
@@ -235,9 +234,8 @@ public enum TestHelper {
     }
 
     public static void assertError(TestSubscriberEx<?> ts, int index, Class<? extends Throwable> clazz) {
-        Throwable ex = ts.errors().get(0);
-        if (ex instanceof CompositeException) {
-            CompositeException ce = (CompositeException) ex;
+        Throwable ex = ts.errors().getFirst();
+        if (ex instanceof CompositeException ce) {
             List<Throwable> cel = ce.getExceptions();
             assertTrue(cel.get(index).toString(), clazz.isInstance(cel.get(index)));
         } else {
@@ -246,9 +244,8 @@ public enum TestHelper {
     }
 
     public static void assertError(TestObserverEx<?> to, int index, Class<? extends Throwable> clazz, String message) {
-        Throwable ex = to.errors().get(0);
-        if (ex instanceof CompositeException) {
-            CompositeException ce = (CompositeException) ex;
+        Throwable ex = to.errors().getFirst();
+        if (ex instanceof CompositeException ce) {
             List<Throwable> cel = ce.getExceptions();
             assertTrue(cel.get(index).toString(), clazz.isInstance(cel.get(index)));
             assertEquals(message, cel.get(index).getMessage());
@@ -258,9 +255,8 @@ public enum TestHelper {
     }
 
     public static void assertError(TestSubscriberEx<?> ts, int index, Class<? extends Throwable> clazz, String message) {
-        Throwable ex = ts.errors().get(0);
-        if (ex instanceof CompositeException) {
-            CompositeException ce = (CompositeException) ex;
+        Throwable ex = ts.errors().getFirst();
+        if (ex instanceof CompositeException ce) {
             List<Throwable> cel = ce.getExceptions();
             assertTrue(cel.get(index).toString(), clazz.isInstance(cel.get(index)));
             assertEquals(message, cel.get(index).getMessage());
@@ -346,8 +342,8 @@ public enum TestHelper {
                 throw new AssertionError(ex.getMessage());
             }
 
-            assertTrue(list.toString(), list.get(0) instanceof IllegalArgumentException);
-            assertEquals("n > 0 required but it was -99", list.get(0).getMessage());
+            assertTrue(list.toString(), list.getFirst() instanceof IllegalArgumentException);
+            assertEquals("n > 0 required but it was -99", list.getFirst().getMessage());
         } finally {
             RxJavaPlugins.setErrorHandler(null);
         }
@@ -407,8 +403,8 @@ public enum TestHelper {
                 throw new AssertionError(ex.getMessage());
             }
 
-            assertTrue(list.toString(), list.get(0) instanceof IllegalArgumentException);
-            assertEquals("n > 0 required but it was -99", list.get(0).getMessage());
+            assertTrue(list.toString(), list.getFirst() instanceof IllegalArgumentException);
+            assertEquals("n > 0 required but it was -99", list.getFirst().getMessage());
         } finally {
             RxJavaPlugins.setErrorHandler(null);
         }
@@ -2415,7 +2411,7 @@ public enum TestHelper {
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(ts.errors().get(0));
+        List<Throwable> list = compositeList(ts.errors().getFirst());
 
         assertEquals(classes.length, list.size());
 
@@ -2437,7 +2433,7 @@ public enum TestHelper {
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        assertCompositeExceptionListOf(ts.errors().get(0), classesAndMessages);
+        assertCompositeExceptionListOf(ts.errors().getFirst(), classesAndMessages);
     }
 
     /**
@@ -2453,7 +2449,7 @@ public enum TestHelper {
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        List<Throwable> list = compositeList(to.errors().get(0));
+        List<Throwable> list = compositeList(to.errors().getFirst());
 
         assertEquals(classes.length, list.size());
 
@@ -2475,7 +2471,7 @@ public enum TestHelper {
         .assertError(CompositeException.class)
         .assertNotComplete();
 
-        assertCompositeExceptionListOf(to.errors().get(0), classesAndMessages);
+        assertCompositeExceptionListOf(to.errors().getFirst(), classesAndMessages);
     }
 
     @SuppressWarnings("unchecked")
@@ -2655,7 +2651,7 @@ public enum TestHelper {
      * @return the list
      */
     public static List<Throwable> errorList(TestObserverEx<?> to) {
-        return compositeList(to.errors().get(0));
+        return compositeList(to.errors().getFirst());
     }
 
     /**
@@ -2664,7 +2660,7 @@ public enum TestHelper {
      * @return the list
      */
     public static List<Throwable> errorList(TestSubscriberEx<?> ts) {
-        return compositeList(ts.errors().get(0));
+        return compositeList(ts.errors().getFirst());
     }
 
     /**
@@ -2712,8 +2708,7 @@ public enum TestHelper {
 
             Object o = mapper.apply(bad);
 
-            if (o instanceof ObservableSource) {
-                ObservableSource<?> os = (ObservableSource<?>) o;
+            if (o instanceof ObservableSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2734,8 +2729,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof Publisher) {
-                Publisher<?> os = (Publisher<?>) o;
+            if (o instanceof Publisher<?> os) {
                 TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
                 os.subscribe(ts);
@@ -2756,8 +2750,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof SingleSource) {
-                SingleSource<?> os = (SingleSource<?>) o;
+            if (o instanceof SingleSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2778,8 +2771,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof MaybeSource) {
-                MaybeSource<?> os = (MaybeSource<?>) o;
+            if (o instanceof MaybeSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2800,8 +2792,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof CompletableSource) {
-                CompletableSource os = (CompletableSource) o;
+            if (o instanceof CompletableSource os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2871,8 +2862,7 @@ public enum TestHelper {
 
             Object o = mapper.apply(bad);
 
-            if (o instanceof ObservableSource) {
-                ObservableSource<?> os = (ObservableSource<?>) o;
+            if (o instanceof ObservableSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2893,8 +2883,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof Publisher) {
-                Publisher<?> os = (Publisher<?>) o;
+            if (o instanceof Publisher<?> os) {
                 TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
 
                 os.subscribe(ts);
@@ -2915,8 +2904,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof SingleSource) {
-                SingleSource<?> os = (SingleSource<?>) o;
+            if (o instanceof SingleSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2937,8 +2925,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof MaybeSource) {
-                MaybeSource<?> os = (MaybeSource<?>) o;
+            if (o instanceof MaybeSource<?> os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -2959,8 +2946,7 @@ public enum TestHelper {
                 }
             }
 
-            if (o instanceof CompletableSource) {
-                CompletableSource os = (CompletableSource) o;
+            if (o instanceof CompletableSource os) {
                 TestObserverEx<Object> to = new TestObserverEx<>();
 
                 os.subscribe(to);
@@ -3809,6 +3795,7 @@ public enum TestHelper {
      * Exception thrown if obstruction was detected.
      */
     public static final class ObstructionException extends RuntimeException {
+        @Serial
         private static final long serialVersionUID = -6380717994471291795L;
         public ObstructionException(String message) {
             super(message);
@@ -3822,6 +3809,7 @@ public enum TestHelper {
      */
     static final class ForwardingConditionalSubscriber<T> extends BasicQueueSubscription<T> implements ConditionalSubscriber<T> {
 
+        @Serial
         private static final long serialVersionUID = 365317603608134078L;
 
         final Subscriber<? super T> downstream;

--- a/src/test/java/io/reactivex/rxjava4/validators/OperatorsUseInterfaces.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/OperatorsUseInterfaces.java
@@ -99,8 +99,7 @@ public class OperatorsUseInterfaces {
                             if (argType instanceof GenericArrayType) {
                                 argType = ((GenericArrayType)argType).getGenericComponentType();
                             }
-                            if (argType instanceof ParameterizedType) {
-                                ParameterizedType lastArg = (ParameterizedType)argType;
+                            if (argType instanceof ParameterizedType lastArg) {
 
                                 if (CLASSES.contains(lastArg.getRawType())) {
                                     errors++;


### PR DESCRIPTION
IntelliJ inspections:

- Add `@Serial` to `serialVersionUID` fields.
- Replace `get(0)` with `getFirst()` where possible.
- Use `x instanceof Y z` pattern.
