### PR TITLE
4.x Cleanup: isEmpty, general intellij cleanups

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ jmh {
 
 def isCI = System.getenv("CI") != null
 def parallelForks = Runtime.getRuntime().availableProcessors();
-def testLoggingConfig = ["skipped", "failed", "started"]
+def testLoggingConfig = ["skipped", "failed", "started", "passed"]
 if (!isCI) {
     testLoggingConfig = ["failed"]
     parallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1;

--- a/build.gradle
+++ b/build.gradle
@@ -179,10 +179,12 @@ jmh {
 
 def isCI = System.getenv("CI") != null
 def parallelForks = Runtime.getRuntime().availableProcessors();
-def testLoggingConfig = ["skipped", "failed", "started", "passed"]
+def testLoggingConfig = ["skipped", "failed" /*, "started", "passed" */]
 if (!isCI) {
     testLoggingConfig = ["failed"]
     parallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1;
+} else {
+    parallelForks = 1 // for now
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ javadoc {
 moduleConfig {
     moduleInfoPath = 'src/main/module/module-info.java'
     multiReleaseVersion = 9
-	version = project.version
+    version = project.version
 }
 
 import aQute.bnd.gradle.Bundle   // ← important import
@@ -178,18 +178,17 @@ jmh {
 }
 
 def isCI = System.getenv("CI") != null
-def testLoggingConfig = ["skipped", "failed"]
+def parallelForks = Runtime.getRuntime().availableProcessors();
+def testLoggingConfig = ["skipped", "failed", "started"]
 if (!isCI) {
     testLoggingConfig = ["failed"]
+    parallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1;
 }
 
 test {
     maxHeapSize = "1200m"
-    if (System.getenv("CI") != null) {
-        maxParallelForks = Runtime.runtime.availableProcessors()
-    } else {
-        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    }
+    timeout = Duration.ofMinutes(15)   // or 30, whatever is reasonable for your suite
+    maxParallelForks = parallelForks
     useJUnitPlatform()
 }
 
@@ -206,19 +205,8 @@ tasks.register('testNG', Test) {
     useTestNG()
 
     maxHeapSize = "1200m"
-    if (System.getenv("CI") != null) {
-        maxParallelForks = Runtime.runtime.availableProcessors()
-    } else {
-        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-    }
+    maxParallelForks = parallelForks
     // maxParallelForks = 1
-
-    // Ensure JUnit-compatible XML output in the standard location
-    reports {
-        html.required = true
-        junitXml.required = true
-        junitXml.outputLocation = file("${buildDir}/test-results/test")   // ← important
-    }
 
     // Ensure JUnit-compatible XML output in the standard location
     reports {

--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -122,7 +122,6 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     public static Completable ambArray(@NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
@@ -190,7 +189,6 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     public static Completable concatArray(@NonNull CompletableSource... sources) {
         return concatArray(CompletableConcatConfig.DEFAULT, sources);
     }
@@ -212,7 +210,6 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     public static Completable concatArray(@NonNull CompletableConcatConfig config, @NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(config, "config is null");
@@ -775,7 +772,6 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     public static Completable mergeArray(@NonNull CompletableSource... sources) {
         return mergeArray(CompletableMergeConfig.DEFAULT, sources);
     }
@@ -906,7 +902,6 @@ public abstract class Completable implements CompletableSource {
     @CheckReturnValue
     @NonNull
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     public static Completable mergeArray(@NonNull CompletableMergeConfig config, @NonNull CompletableSource... sources) {
         Objects.requireNonNull(sources, "sources is null");
         Objects.requireNonNull(config, "config is null");

--- a/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
@@ -86,7 +86,7 @@ public final class CompletionStageDisposable<T> implements AutoCloseable {
      * Await the completion of the current stage.
      */
     public void await() {
-        state.lazySet(true);;
+        state.lazySet(true);
         AwaitCoordinatorStatic.await(stage);
     }
 
@@ -95,7 +95,7 @@ public final class CompletionStageDisposable<T> implements AutoCloseable {
      * @param canceller the canceller link
      */
     public void await(DisposableContainer canceller) {
-        state.lazySet(true);;
+        state.lazySet(true);
         AwaitCoordinatorStatic.await(stage, canceller);
     }
 
@@ -103,7 +103,7 @@ public final class CompletionStageDisposable<T> implements AutoCloseable {
      * Indicate this instance is deliberately not awaiting its stage.
      */
     public void ignore() {
-        state.lazySet(true);;
+        state.lazySet(true);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -2467,18 +2467,13 @@ FlowableDocBasic<T>
         Objects.requireNonNull(source, "source is null");
         Objects.requireNonNull(strategy, "strategy is null");
         Flowable<T> f = new FlowableFromObservable<>(source);
-        switch (strategy) {
-            case DROP:
-                return f.onBackpressureDrop();
-            case LATEST:
-                return f.onBackpressureLatest();
-            case MISSING:
-                return f;
-            case ERROR:
-                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<>(f));
-            default:
-                return f.onBackpressureBuffer();
-        }
+        return switch (strategy) {
+            case DROP -> f.onBackpressureDrop();
+            case LATEST -> f.onBackpressureLatest();
+            case MISSING -> f;
+            case ERROR -> RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<>(f));
+            default -> f.onBackpressureBuffer();
+        };
     }
 
     /**
@@ -9412,7 +9407,7 @@ FlowableDocBasic<T>
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Flowable<T> distinct() {
-        return distinct(Functions.identity(), Functions.<T>createHashSet());
+        return distinct(Functions.identity(), Functions.createHashSet());
     }
 
     /**
@@ -14526,7 +14521,7 @@ FlowableDocBasic<T>
      * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryWhen.f.v3.png" alt="">
      * <p>
      * Example:
-     *
+     * <br>
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
      * <pre><code>
@@ -15632,7 +15627,7 @@ FlowableDocBasic<T>
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), this);
+        return Flowable.concat(Completable.wrap(other).toFlowable(), this);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/core/FlowableSubscriber.java
@@ -35,7 +35,6 @@ public interface FlowableSubscriber<@NonNull T> extends Subscriber<T> {
      * calling {@link Subscription#request(long)}. In practice this means
      * no initialization should happen after the {@code request()} call and
      * additional behavior is thread safe in respect to {@code onNext}.
-     *
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -4358,7 +4358,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * <img width="640" height="405" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.retryWhen.png" alt="">
      * <p>
      * Example:
-     *
+     * <br>
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
      * <pre><code>
@@ -4476,7 +4476,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+        return Flowable.concat(Completable.wrap(other).toFlowable(), toFlowable());
     }
 
     /**
@@ -5391,7 +5391,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     /**
      * Waits until this and the other {@link MaybeSource} signal a success value then applies the given {@link BiFunction}
      * to those values and emits the {@code BiFunction}'s resulting value to downstream.
-     *
+     * <br>
      * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zipWith.png" alt="">
      *
      * <p>If either this or the other {@code MaybeSource} is empty or signals an error, the resulting {@code Maybe} will

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -11899,7 +11899,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     public final Observable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Observable.concatArray(Completable.wrap(other).<T>toObservable(), this);
+        return Observable.concatArray(Completable.wrap(other).toObservable(), this);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/Observer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observer.java
@@ -60,7 +60,7 @@ import io.reactivex.rxjava4.disposables.Disposable;
  * </ul>
  * From the {@code Observable}'s perspective, an {@code Observer} is the end consumer thus it is the {@code Observer}'s
  * responsibility to handle the error case and signal it "further down". This means unreliable code in the {@code onXXX}
- * methods should be wrapped into `try-catch`es, specifically in {@link #onError(Throwable)} or {@link #onComplete()}, and handled there
+ * methods should be wrapped into `try-catches, specifically in {@link #onError(Throwable)} or {@link #onComplete()}, and handled there
  * (for example, by logging it or presenting the user with an error dialog). However, if the error would be thrown from
  * {@link #onNext(Object)}, <a href="https://github.com/reactive-streams/reactive-streams-jvm#2.13">Rule 2.13</a> mandates
  * the implementation calls {@link Disposable#dispose()} and signals the exception in a way that is adequate to the target context,

--- a/src/main/java/io/reactivex/rxjava4/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Single.java
@@ -4135,7 +4135,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     @BackpressureSupport(BackpressureKind.FULL)
     public final Flowable<T> startWith(@NonNull CompletableSource other) {
         Objects.requireNonNull(other, "other is null");
-        return Flowable.concat(Completable.wrap(other).<T>toFlowable(), toFlowable());
+        return Flowable.concat(Completable.wrap(other).toFlowable(), toFlowable());
     }
 
     /**
@@ -4488,7 +4488,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} fails, the resulting {@code Single} will
      * pass along the signal to the downstream. To measure the time to error,
-     * use {@link #materialize()} and apply {@link #timeInterval()}.
+     * use {@link #materialize()} and apply {@code timeInterval()}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeInterval} uses the {@code computation} {@link Scheduler}
@@ -4514,7 +4514,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} fails, the resulting {@code Single} will
      * pass along the signal to the downstream. To measure the time to error,
-     * use {@link #materialize()} and apply {@link #timeInterval(Scheduler)}.
+     * use {@link #materialize()} and apply {@code timeInterval(Scheduler)}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeInterval} uses the provided {@link Scheduler}
@@ -4570,7 +4570,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} is empty or fails, the resulting {@code Single} will
      * pass along the signals to the downstream. To measure the time to termination,
-     * use {@link #materialize()} and apply {@link #timeInterval(TimeUnit, Scheduler)}.
+     * use {@link #materialize()} and apply {@code #timeInterval(TimeUnit, Scheduler)}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timeInterval} uses the provided {@link Scheduler}
@@ -4601,7 +4601,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} is empty or fails, the resulting {@code Single} will
      * pass along the signals to the downstream. To get the timestamp of the error,
-     * use {@link #materialize()} and apply {@link #timestamp()}.
+     * use {@link #materialize()} and apply {@code timestamp()}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timestamp} uses the {@code computation} {@code Scheduler}
@@ -4627,7 +4627,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} is empty or fails, the resulting {@code Single} will
      * pass along the signals to the downstream. To get the timestamp of the error,
-     * use {@link #materialize()} and apply {@link #timestamp(Scheduler)}.
+     * use {@link #materialize()} and apply {@code #timestamp(Scheduler)}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timestamp} uses the provided {@code Scheduler}
@@ -4655,7 +4655,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} is empty or fails, the resulting {@code Single} will
      * pass along the signals to the downstream. To get the timestamp of the error,
-     * use {@link #materialize()} and apply {@link #timestamp(TimeUnit)}.
+     * use {@link #materialize()} and apply {@code timestamp(TimeUnit)}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timestamp} uses the {@code computation} {@code Scheduler},
@@ -4683,7 +4683,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * If the current {@code Single} is empty or fails, the resulting {@code Single} will
      * pass along the signals to the downstream. To get the timestamp of the error,
-     * use {@link #materialize()} and apply {@link #timestamp(TimeUnit, Scheduler)}.
+     * use {@link #materialize()} and apply {@code timestamp(TimeUnit, Scheduler)}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code timestamp} uses the provided {@code Scheduler},

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -115,7 +115,7 @@ public interface Streamable<@NonNull T> {
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
         Objects.requireNonNull(source, "source is null");
-        return new StreamableFromPublisher<T>(source, executor);
+        return new StreamableFromPublisher<>(source, executor);
     }
 
     /**
@@ -186,7 +186,7 @@ public interface Streamable<@NonNull T> {
             for(var stage : stages) {
                 list.add(stage);
             }
-            while (list.size() != 0) {
+            while (!list.isEmpty()) {
                 var winner = AwaitCoordinatorStatic.awaitFirstIndex(list, emitter.canceller());
                 emitter.emit((CompletionStage<T>)list.remove(winner));
             }
@@ -361,7 +361,7 @@ public interface Streamable<@NonNull T> {
             return null;
         });
         canceller.add(Disposable.fromFuture(future));
-        return new CompletionStageDisposable<Void>(StreamableHelper.toCompletionStage((Future<Void>)(Future<?>)future), canceller);
+        return new CompletionStageDisposable<>(StreamableHelper.toCompletionStage((Future<Void>)(Future<?>)future), canceller);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -22,7 +22,7 @@ import io.reactivex.rxjava4.internal.util.AwaitCoordinator;
 
 /**
  * A realized stream which can then be consumed asynchronously in steps.
- * Think of it as the {@IAsyncEnumerator} of the Java world. Runs best on Virtual Threads.
+ * Think of it as the {@code IAsyncEnumerator} of the Java world. Runs best on Virtual Threads.
  * <p>
  * To make sure you can run finish, use {@link DisposableContainer#clear()} or {@link DisposableContainer#reset()}
  * to get rid of all previous registered disposables. finish() will create its own, and if that
@@ -93,8 +93,10 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
      */
     default Streamer<T> finishVia(@NonNull DisposableContainer canceller) {
         Objects.requireNonNull(canceller, "canceller is null");
-        if (this instanceof StreamerFinishViaDisposableContainerCanceller<T> augment) {
-            if (augment.streamer == this && augment.canceller == canceller) {
+        if (this instanceof StreamerFinishViaDisposableContainerCanceller<T>(
+                Streamer<T> streamer, DisposableContainer canceller1
+        )) {
+            if (streamer == this && canceller1 == canceller) {
                 // DO not rewrap!
                 return this;
             }
@@ -107,7 +109,7 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
      * Augments the base streamer with a canceller so that it can be injected at the various await calls.
      * @param <T> the element type of the stream
      */
-    static record StreamerFinishViaDisposableContainerCanceller<T>(
+    record StreamerFinishViaDisposableContainerCanceller<T>(
             @NonNull Streamer<T> streamer, @NonNull DisposableContainer canceller)
     implements Streamer<T> {
 
@@ -141,7 +143,7 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
      * Hides the identity of the Streamer for debug or deoptimization purposes.
      * @param <T> the element type of the streamer
      */
-    static record HiddenStreamer<T>(@NonNull Streamer<T> streamer) implements Streamer<T> {
+    record HiddenStreamer<T>(@NonNull Streamer<T> streamer) implements Streamer<T> {
 
         @Override
         public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
@@ -47,14 +47,11 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
     public static <T, R> Subscriber<T> subscribe(Subscriber<? super R> s, Function<? super T, ? extends Publisher<? extends R>> mapper,
             int prefetch, ErrorMode errorMode) {
-        switch (errorMode) {
-        case BOUNDARY:
-            return new ConcatMapDelayed<>(s, mapper, prefetch, false);
-        case END:
-            return new ConcatMapDelayed<>(s, mapper, prefetch, true);
-        default:
-            return new ConcatMapImmediate<>(s, mapper, prefetch);
-        }
+        return switch (errorMode) {
+            case BOUNDARY -> new ConcatMapDelayed<>(s, mapper, prefetch, false);
+            case END -> new ConcatMapDelayed<>(s, mapper, prefetch, true);
+            default -> new ConcatMapImmediate<>(s, mapper, prefetch);
+        };
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -297,7 +297,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
 
                         continue;
                     }
-                    else if (openDone && windows.size() == 0) {
+                    else if (openDone && windows.isEmpty()) {
                         upstream.cancel();
                         startSubscriber.cancel();
                         resources.dispose();

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -282,7 +282,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
 
                         continue;
                     }
-                    else if (openDone && windows.size() == 0) {
+                    else if (openDone && windows.isEmpty()) {
                         upstream.dispose();
                         startObserver.dispose();
                         resources.dispose();

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -59,7 +59,7 @@ public final class FlowableCollectTest extends RxJavaTest {
             .collect(
                     StringBuilder::new,
                 (sb, v) -> {
-                if (sb.length() > 0) {
+                if (!sb.isEmpty()) {
                     sb.append("-");
                 }
                 sb.append(v);
@@ -177,7 +177,7 @@ public final class FlowableCollectTest extends RxJavaTest {
             .collect(
                     StringBuilder::new,
                 (sb, v) -> {
-                if (sb.length() > 0) {
+                if (!sb.isEmpty()) {
                     sb.append("-");
                 }
                 sb.append(v);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1050,7 +1050,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (ts.errors().size() != 0) {
+                if (!ts.errors().isEmpty()) {
                     if (ts.errors().getFirst() instanceof CompositeException) {
                         ts.assertSubscribed()
                         .assertNotComplete()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -628,7 +628,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).subscribe(testSubscriber);
         testSubscriber.awaitDone(5, TimeUnit.SECONDS);
-        if (testSubscriber.errors().size() > 0) {
+        if (!testSubscriber.errors().isEmpty()) {
             testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
@@ -670,7 +670,7 @@ public class FlowableMergeTest extends RxJavaTest {
         System.out.println("Generated 1: " + generated1.get() + " / received: " + onNextEvents.size());
         System.out.println(onNextEvents);
 
-        if (testSubscriber.errors().size() > 0) {
+        if (!testSubscriber.errors().isEmpty()) {
             testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
@@ -710,7 +710,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         Flowable.merge(f1.take(Flowable.bufferSize() * 2), f2.take(Flowable.bufferSize() * 2)).observeOn(Schedulers.computation()).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
-        if (testSubscriber.errors().size() > 0) {
+        if (!testSubscriber.errors().isEmpty()) {
             testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
@@ -746,7 +746,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
-        if (testSubscriber.errors().size() > 0) {
+        if (!testSubscriber.errors().isEmpty()) {
             testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();
@@ -794,7 +794,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
         Flowable.merge(f1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(testSubscriber);
         testSubscriber.awaitDone(10, TimeUnit.SECONDS);
-        if (testSubscriber.errors().size() > 0) {
+        if (!testSubscriber.errors().isEmpty()) {
             testSubscriber.errors().getFirst().printStackTrace();
         }
         testSubscriber.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -72,7 +72,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         obs.observeOn(Schedulers.computation()).subscribe(ts);
 
         ts.awaitDone(1000, TimeUnit.MILLISECONDS);
-        if (ts.errors().size() > 0) {
+        if (!ts.errors().isEmpty()) {
             for (Throwable t : ts.errors()) {
                 t.printStackTrace();
             }
@@ -1612,7 +1612,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
             ts.assertFusionMode(QueueFuseable.ASYNC);
 
-            if (ts.values().size() != 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertResult(1);
             }
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -191,8 +191,8 @@ public class FlowableRefCountTest extends RxJavaTest {
             ts2.cancel();
             ts1.assertNoErrors();
             ts2.assertNoErrors();
-            assertTrue(ts1.values().size() > 0);
-            assertTrue(ts2.values().size() > 0);
+            assertTrue(!ts1.values().isEmpty());
+            assertTrue(!ts2.values().isEmpty());
         }
 
         assertEquals(10, subscribeCount.get());
@@ -226,7 +226,7 @@ public class FlowableRefCountTest extends RxJavaTest {
         System.out.println("DONE sending unsubscribe ... now waiting");
         if (!unsubscribeLatch.await(3000, TimeUnit.MILLISECONDS)) {
             System.out.println("Errors: " + s.errors());
-            if (s.errors().size() > 0) {
+            if (!s.errors().isEmpty()) {
                 s.errors().getFirst().printStackTrace();
             }
             fail("timed out waiting for unsubscribe");
@@ -269,7 +269,7 @@ public class FlowableRefCountTest extends RxJavaTest {
 
         System.out.println("DONE sending unsubscribe ... now waiting");
         System.out.println("Errors: " + s.errors());
-        if (s.errors().size() > 0) {
+        if (!s.errors().isEmpty()) {
             s.errors().getFirst().printStackTrace();
         }
         s.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -707,7 +707,7 @@ public class FlowableRetryTest extends RxJavaTest {
                 }
                 cdl.await();
                 assertEquals(0, timeouts.get());
-                if (data.size() > 0) {
+                if (!data.isEmpty()) {
                     fail("Data content mismatch: " + allSequenceFrequency(data));
                 }
             }
@@ -718,7 +718,7 @@ public class FlowableRetryTest extends RxJavaTest {
     static <T> StringBuilder allSequenceFrequency(Map<Integer, List<T>> its) {
         StringBuilder b = new StringBuilder();
         for (Map.Entry<Integer, List<T>> e : its.entrySet()) {
-            if (b.length() > 0) {
+            if (!b.isEmpty()) {
                 b.append(", ");
             }
             b.append(e.getKey()).append("={");
@@ -734,7 +734,7 @@ public class FlowableRetryTest extends RxJavaTest {
         int cnt = 0;
 
         for (Object curr : it) {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 if (!curr.equals(prev)) {
                     if (cnt > 1) {
                         sb.append(" x ").append(cnt);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -476,7 +476,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         ts.request(Long.MAX_VALUE - 1);
         ts.request(2);
         ts.awaitDone(5, TimeUnit.SECONDS);
-        assertTrue(ts.values().size() > 0);
+        assertTrue(!ts.values().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
@@ -293,7 +293,7 @@ public class FlowableToListTest extends RxJavaTest {
 
             TestHelper.race(r1, r2);
 
-            if (ts.values().size() != 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValue(List.of(1))
                 .assertNoErrors();
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -181,7 +181,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         ts.awaitDone(5, TimeUnit.SECONDS);
         ts.assertComplete();
-        Assert.assertTrue(ts.values().size() != 0);
+        Assert.assertTrue(!ts.values().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutPublisherTest.java
@@ -195,7 +195,7 @@ public class MaybeTimeoutPublisherTest extends RxJavaTest {
 
             to.assertSubscribed().assertNoValues();
 
-            if (to.errors().size() != 0) {
+            if (!to.errors().isEmpty()) {
                 to.assertError(TimeoutException.class).assertNotComplete();
             } else {
                 to.assertNoErrors().assertComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeTimeoutTest.java
@@ -317,7 +317,7 @@ public class MaybeTimeoutTest extends RxJavaTest {
 
             to.assertSubscribed().assertNoValues();
 
-            if (to.errors().size() != 0) {
+            if (!to.errors().isEmpty()) {
                 to.assertError(TimeoutException.class).assertNotComplete();
             } else {
                 to.assertNoErrors().assertComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -407,7 +407,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (ts.errors().size() != 0) {
+                if (!ts.errors().isEmpty()) {
                     assertTrue(errors.isEmpty());
                     ts.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -368,7 +368,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (ts.errors().size() != 0) {
+                if (!ts.errors().isEmpty()) {
                     assertTrue(errors.isEmpty());
                     ts.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -387,7 +387,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (to.errors().size() != 0) {
+                if (!to.errors().isEmpty()) {
                     assertTrue(errors.isEmpty());
                     to.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -365,7 +365,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (to.errors().size() != 0) {
+                if (!to.errors().isEmpty()) {
                     assertTrue(errors.isEmpty());
                     to.assertFailure(TestException.class);
                 } else if (!errors.isEmpty()) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -54,7 +54,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectToStringObservable() {
         String value = Observable.just(1, 2, 3).collect(StringBuilder::new, (sb, v) -> {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 sb.append("-");
             }
             sb.append(v);
@@ -155,7 +155,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     @Test
     public void collectToString() {
         String value = Observable.just(1, 2, 3).collect(StringBuilder::new, (sb, v) -> {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 sb.append("-");
             }
             sb.append(v);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -828,7 +828,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
                 TestHelper.race(r1, r2);
 
-                if (to.errors().size() != 0) {
+                if (!to.errors().isEmpty()) {
                     if (to.errors().getFirst() instanceof CompositeException) {
                         to.assertSubscribed()
                         .assertNotComplete()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -653,7 +653,7 @@ public class ObservableMergeTest extends RxJavaTest {
         System.out.println("Generated 1: " + generated1.get() + " / received: " + onNextEvents.size());
         System.out.println(onNextEvents);
 
-        if (testObserver.errors().size() > 0) {
+        if (!testObserver.errors().isEmpty()) {
             testObserver.errors().getFirst().printStackTrace();
         }
         testObserver.assertNoErrors();
@@ -745,7 +745,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
         Observable.merge(o1).observeOn(Schedulers.computation()).take(Flowable.bufferSize() * 2).subscribe(to);
         to.awaitDone(5, TimeUnit.SECONDS);
-        if (to.errors().size() > 0) {
+        if (!to.errors().isEmpty()) {
             to.errors().getFirst().printStackTrace();
         }
         to.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
@@ -74,7 +74,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         obs.observeOn(Schedulers.computation()).subscribe(to);
 
         to.awaitDone(1000, TimeUnit.MILLISECONDS);
-        if (to.errors().size() > 0) {
+        if (!to.errors().isEmpty()) {
             for (Throwable t : to.errors()) {
                 t.printStackTrace();
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -176,8 +176,8 @@ public class ObservableRefCountTest extends RxJavaTest {
             to2.dispose();
             to1.assertNoErrors();
             to2.assertNoErrors();
-            assertTrue(to1.values().size() > 0);
-            assertTrue(to2.values().size() > 0);
+            assertTrue(!to1.values().isEmpty());
+            assertTrue(!to2.values().isEmpty());
         }
 
         assertEquals(10, subscribeCount.get());
@@ -211,7 +211,7 @@ public class ObservableRefCountTest extends RxJavaTest {
         System.out.println("DONE sending unsubscribe ... now waiting");
         if (!unsubscribeLatch.await(3000, TimeUnit.MILLISECONDS)) {
             System.out.println("Errors: " + observer.errors());
-            if (observer.errors().size() > 0) {
+            if (!observer.errors().isEmpty()) {
                 observer.errors().getFirst().printStackTrace();
             }
             fail("timed out waiting for unsubscribe");
@@ -261,7 +261,7 @@ public class ObservableRefCountTest extends RxJavaTest {
 
         System.out.println("DONE sending unsubscribe ... now waiting");
         System.out.println("Errors: " + observer.errors());
-        if (observer.errors().size() > 0) {
+        if (!observer.errors().isEmpty()) {
             observer.errors().getFirst().printStackTrace();
         }
         observer.assertNoErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
@@ -646,7 +646,7 @@ public class ObservableRetryTest extends RxJavaTest {
                 }
                 cdl.await();
                 assertEquals(0, timeouts.get());
-                if (data.size() > 0) {
+                if (!data.isEmpty()) {
                     fail("Data content mismatch: " + allSequenceFrequency(data));
                 }
             }
@@ -657,7 +657,7 @@ public class ObservableRetryTest extends RxJavaTest {
     static <T> StringBuilder allSequenceFrequency(Map<Integer, List<T>> its) {
         StringBuilder b = new StringBuilder();
         for (Map.Entry<Integer, List<T>> e : its.entrySet()) {
-            if (b.length() > 0) {
+            if (!b.isEmpty()) {
                 b.append(", ");
             }
             b.append(e.getKey()).append("={");
@@ -673,7 +673,7 @@ public class ObservableRetryTest extends RxJavaTest {
         int cnt = 0;
 
         for (Object curr : it) {
-            if (sb.length() > 0) {
+            if (!sb.isEmpty()) {
                 if (!curr.equals(prev)) {
                     if (cnt > 1) {
                         sb.append(" x ").append(cnt);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTests.java
@@ -447,8 +447,8 @@ public class ObservableTimeoutTests extends RxJavaTest {
 
             TestHelper.race(r1, r2);
 
-            if (to.values().size() != 0) {
-                if (to.errors().size() != 0) {
+            if (!to.values().isEmpty()) {
+                if (!to.errors().isEmpty()) {
                     to.assertFailure(TimeoutException.class, 1);
                     to.assertErrorMessage(timeoutMessage(1, TimeUnit.SECONDS));
                 } else {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -180,7 +180,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         to.awaitDone(5, TimeUnit.SECONDS);
         to.assertComplete();
-        Assert.assertTrue(to.values().size() != 0);
+        Assert.assertTrue(!to.values().isEmpty());
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
@@ -61,7 +61,7 @@ public abstract class StreamableBaseTest {
         for (var c : cleaners) {
             c.clean();
         }
-        if (errors.size() != 0) {
+        if (!errors.isEmpty()) {
             throw new AssertionError("Undeliverable exceptions during test detected: " + testInfo.getDisplayName(),
                     new CompositeException(errors));
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
@@ -71,4 +71,18 @@ public class SchedulerToExecutorServiceTest {
             // expected
         }
     }
+
+    @Test
+    public void invokeAnyWithEmptyTasksShouldThrow2() throws Exception {
+        Scheduler scheduler = Schedulers.trampoline();
+        try (var executor = scheduler.toExecutorService(true)) {
+
+            try {
+                executor.invokeAny(Arrays.asList());
+                fail("invokeAny with empty tasks should throw IllegalArgumentException");
+            } catch (IllegalArgumentException expected) {
+                // expected
+            }
+        }
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/DeferredScalarSubscriptionTest.java
@@ -80,7 +80,7 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
 
             TestHelper.race(r1, r2);
 
-            if (ts.values().size() >= 1) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValue(1);
             }
         }
@@ -101,7 +101,7 @@ public class DeferredScalarSubscriptionTest extends RxJavaTest {
 
             TestHelper.race(r1, r2);
 
-            if (ts.values().size() >= 1) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValue(1);
             }
         }

--- a/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
@@ -421,7 +421,7 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
 
             TestHelper.race(r1, r2);
 
-            if (ts1.errors().size() != 0) {
+            if (!ts1.errors().isEmpty()) {
                 ts1.assertFailure(TestException.class);
             } else {
                 ts1.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -748,7 +748,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             TestHelper.race(r1, r2);
 
-            if (ts.values().size() > 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValuesOnly(0);
             } else {
                 ts.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
@@ -617,7 +617,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
             TestHelper.race(r1, r2);
 
-            if (ts.values().size() > 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValuesOnly(0);
             } else {
                 ts.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
@@ -458,7 +458,7 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             ts.assertError(ex).assertNotComplete();
 
-            if (ts.values().size() != 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValue(1);
             }
         }
@@ -479,7 +479,7 @@ public class SerializedProcessorTest extends RxJavaTest {
 
             ts.assertComplete().assertNoErrors();
 
-            if (ts.values().size() != 0) {
+            if (!ts.values().isEmpty()) {
                 ts.assertValue(1);
             }
         }

--- a/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
@@ -298,10 +298,10 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
 
             TestHelper.race(r1, r2);
 
-            if (ts1.errors().size() == 0) {
+            if (ts1.errors().isEmpty()) {
                 ts2.assertFailure(IllegalStateException.class);
             } else
-            if (ts2.errors().size() == 0) {
+            if (ts2.errors().isEmpty()) {
                 ts1.assertFailure(IllegalStateException.class);
             } else {
                 fail("Neither TestObserver failed");

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
@@ -51,7 +51,7 @@ public class SchedulerLifecycleTest extends RxJavaTest {
                 }
             }
         }
-        if (b.length() > 0) {
+        if (!b.isEmpty()) {
             System.out.print(b);
             System.out.println("testShutdown >> Restarting schedulers...");
             Schedulers.start(); // restart them anyways

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -208,7 +208,7 @@ public class SchedulerTest extends RxJavaTest {
 
             Thread.sleep(250);
 
-            assertTrue(list.size() >= 1);
+            assertTrue(!list.isEmpty());
             TestHelper.assertUndeliverable(list, 0, TestException.class, null);
 
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
@@ -415,7 +415,7 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
 
             TestHelper.race(r1, r2);
 
-            if (to1.errors().size() != 0) {
+            if (!to1.errors().isEmpty()) {
                 to1.assertFailure(TestException.class);
             } else {
                 to1.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
@@ -459,7 +459,7 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             to.assertError(ex).assertNotComplete();
 
-            if (to.values().size() != 0) {
+            if (!to.values().isEmpty()) {
                 to.assertValue(1);
             }
         }
@@ -480,7 +480,7 @@ public class SerializedSubjectTest extends RxJavaTest {
 
             to.assertComplete().assertNoErrors();
 
-            if (to.values().size() != 0) {
+            if (!to.values().isEmpty()) {
                 to.assertValue(1);
             }
         }

--- a/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
@@ -362,10 +362,10 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
 
             TestHelper.race(r1, r2);
 
-            if (to1.errors().size() == 0) {
+            if (to1.errors().isEmpty()) {
                 to2.assertFailure(IllegalStateException.class);
             } else
-            if (to2.errors().size() == 0) {
+            if (to2.errors().isEmpty()) {
                 to1.assertFailure(IllegalStateException.class);
             } else {
                 fail("Neither TestObserver failed");

--- a/src/test/java/io/reactivex/rxjava4/subscribers/DefaultSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/DefaultSubscriberTest.java
@@ -17,9 +17,8 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.*;
 
-import org.junit.Test;
-
 import io.reactivex.rxjava4.core.*;
+import org.junit.jupiter.api.Test;
 
 public class DefaultSubscriberTest extends RxJavaTest {
 

--- a/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
@@ -297,11 +297,11 @@ extends BaseTestConsumer<T, U> {
     }
 
     static String fusionModeToString(int mode) {
-        switch (mode) {
-        case QueueFuseable.NONE : return "NONE";
-        case QueueFuseable.SYNC : return "SYNC";
-        case QueueFuseable.ASYNC : return "ASYNC";
-        default: return "Unknown(" + mode + ")";
-        }
+        return switch (mode) {
+            case QueueFuseable.NONE -> "NONE";
+            case QueueFuseable.SYNC -> "SYNC";
+            case QueueFuseable.ASYNC -> "ASYNC";
+            default -> "Unknown(" + mode + ")";
+        };
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/validators/BaseTypeAnnotations.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/BaseTypeAnnotations.java
@@ -75,7 +75,7 @@ public class BaseTypeAnnotations {
             }
         }
 
-        if (b.length() != 0) {
+        if (!b.isEmpty()) {
             System.out.println(clazz);
             System.out.println("------------------------");
             System.out.println(b);
@@ -123,7 +123,7 @@ public class BaseTypeAnnotations {
             }
         }
 
-        if (b.length() != 0) {
+        if (!b.isEmpty()) {
             System.out.println(clazz);
             System.out.println("------------------------");
             System.out.println(b);
@@ -178,7 +178,7 @@ public class BaseTypeAnnotations {
             }
         }
 
-        if (b.length() != 0) {
+        if (!b.isEmpty()) {
             System.out.println(clazz);
             System.out.println("------------------------");
             System.out.println(b);

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckAnonymousClassForLambda.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckAnonymousClassForLambda.java
@@ -101,7 +101,7 @@ public class CheckAnonymousClassForLambda {
             }
         }
 
-        if (fail.length() != 0) {
+        if (!fail.isEmpty()) {
             System.out.println(fail);
             System.out.println(total);
             throw new AssertionError(fail.toString());

--- a/src/test/java/io/reactivex/rxjava4/validators/FixLicenseHeaders.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/FixLicenseHeaders.java
@@ -126,7 +126,7 @@ public class FixLicenseHeaders {
             }
         }
 
-        if (fail.length() != 0) {
+        if (!fail.isEmpty()) {
             System.out.println(fail);
             throw new AssertionError(fail.toString());
         }

--- a/src/test/java/io/reactivex/rxjava4/validators/MaybeNo2Dot0Since.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/MaybeNo2Dot0Since.java
@@ -67,7 +67,7 @@ public class MaybeNo2Dot0Since {
             in.close();
         }
 
-        if (b.length() != 0) {
+        if (!b.isEmpty()) {
             System.out.println(b);
 
             fail(b.toString());

--- a/src/test/java/io/reactivex/rxjava4/validators/OperatorsAreFinal.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/OperatorsAreFinal.java
@@ -61,7 +61,7 @@ public class OperatorsAreFinal {
             }
         }
 
-        if (e.length() != 0) {
+        if (!e.isEmpty()) {
             System.out.println(e);
 
             throw new AssertionError(e.toString());

--- a/src/test/java/io/reactivex/rxjava4/validators/SourceAnnotationCheck.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/SourceAnnotationCheck.java
@@ -365,7 +365,8 @@ public class SourceAnnotationCheck {
 
                 }
 
-                if (strippedArgumentsStr.contains("...") && !hasSafeVarargsAnnotation) {
+                if (strippedArgumentsStr.contains("...") && !hasSafeVarargsAnnotation
+                        && !strippedArgumentsStr.contains("CompletableSource...")) {
                     errorCount++;
                     errors.append("L")
                     .append(j)

--- a/src/test/java/io/reactivex/rxjava4/validators/TextualAorAn.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/TextualAorAn.java
@@ -78,7 +78,7 @@ public class TextualAorAn {
             }
         }
 
-        if (fail.length() != 0) {
+        if (!fail.isEmpty()) {
             System.out.println(fail);
             throw new AssertionError(fail.toString());
         }

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+junit.jupiter.execution.timeout.test.method.default=30s
+# Or other formats: 500ms, 2m, 1h, etc.
+
+junit.jupiter.execution.timeout.mode=disabled_on_debug
+# (or disabled)


### PR DESCRIPTION
- Remove `@SafeVarargs` from varargs with non-generic element types.
- Remove unnecessary semicolons.
- Use switch expression.
- Remove inferrable generic type declarations.
- Javadocs cleanup