### PR TITLE
4.x: Disposable no longer impls AutoCloseable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -297,7 +297,7 @@ if (project.hasProperty("releaseMode")) {
   }
   mavenPublishing {
       // or when publishing to https://central.sonatype.com/
-      publishToMavenCentral(true, DeploymentValidation.PUBLISHED)
+      publishToMavenCentral(true, com.vanniktech.maven.publish.DeploymentValidation.PUBLISHED)
 
       // signAllPublications()
   }

--- a/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
@@ -38,14 +38,6 @@ public interface Disposable {
     boolean isDisposed();
 
     /**
-     * Dispose the resource, the operation should be idempotent.
-     * @since 4.0.0
-     */
-    default void close() {
-        dispose();
-    }
-
-    /**
      * Construct a {@code Disposable} by wrapping a {@link Runnable} that is
      * executed exactly once when the {@code Disposable} is disposed.
      * @param run the {@code Runnable} to wrap

--- a/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
@@ -25,7 +25,7 @@ import io.reactivex.rxjava4.internal.functions.Functions;
 /**
  * Represents a disposable resource.
  */
-public interface Disposable extends AutoCloseable {
+public interface Disposable {
     /**
      * Dispose the resource, the operation should be idempotent.
      */
@@ -75,9 +75,9 @@ public interface Disposable extends AutoCloseable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Future} that is
-     * cancelled exactly once when the {@code Disposable} is disposed.
+     * canceled exactly once when the {@code Disposable} is disposed.
      * <p>
-     * The {@code Future} is cancelled with {@code mayInterruptIfRunning == true}.
+     * The {@code Future} is canceled with {@code mayInterruptIfRunning == true}.
      * @param future the {@code Future} to wrap
      * @return the new {@code Disposable} instance
      * @throws NullPointerException if {@code future} is {@code null}
@@ -92,7 +92,7 @@ public interface Disposable extends AutoCloseable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Future} that is
-     * cancelled exactly once when the {@code Disposable} is disposed.
+     * canceled exactly once when the {@code Disposable} is disposed.
      * @param future the {@code Future} to wrap
      * @param allowInterrupt if true, the future cancel happens via {@code Future.cancel(true)}
      * @return the new {@code Disposable} instance
@@ -107,7 +107,7 @@ public interface Disposable extends AutoCloseable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Subscription} that is
-     * cancelled exactly once when the {@code Disposable} is disposed.
+     * canceled exactly once when the {@code Disposable} is disposed.
      * @param subscription the {@code Runnable} to wrap
      * @return the new {@code Disposable} instance
      * @throws NullPointerException if {@code subscription} is {@code null}
@@ -145,6 +145,17 @@ public interface Disposable extends AutoCloseable {
     static AutoCloseable toAutoCloseable(@NonNull Disposable disposable) {
         Objects.requireNonNull(disposable, "disposable is null");
         return disposable::dispose;
+    }
+
+    /**
+     * Wraps this {@code Disposable} into an {@link AutoCloseable} instance
+     * that can be used with try-with-resources constructs.
+     * @return the new {@code AutoCloseable} instance
+     * @since 4.0.0
+     */
+    @NonNull
+    default AutoCloseable asAutoCloseable() {
+        return this::dispose;
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/DisposableContainer.java
@@ -95,13 +95,13 @@ public interface DisposableContainer extends Disposable {
      * cases where the dispose signal has no side effects to work with.
      * @since 4.0.0
      */
-    static DisposableContainer NEVER = new NeverDisposableContainer();
+    DisposableContainer NEVER = new NeverDisposableContainer();
 
     /**
      * Implementation of a never disposable container.
      * @since 4.0.0
      */
-    static record NeverDisposableContainer() implements DisposableContainer {
+    record NeverDisposableContainer() implements DisposableContainer {
 
         @Override
         public void dispose() {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCount.java
@@ -92,7 +92,6 @@ public final class FlowableRefCount<T> extends Flowable<T> {
         }
     }
 
-    @SuppressWarnings("resource")
     void cancel(RefConnection rc) {
         SequentialDisposable sd;
         synchronized (this) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmb.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableAmb.java
@@ -69,7 +69,6 @@ public final class ObservableAmb<T> extends Observable<T> {
             return;
         }
 
-        @SuppressWarnings("resource")
         AmbCoordinator<T> ac = new AmbCoordinator<>(observer, count);
         ac.subscribe(sources);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatest.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatest.java
@@ -73,7 +73,6 @@ public final class ObservableCombineLatest<T, R> extends Observable<R> {
             return;
         }
 
-        @SuppressWarnings("resource")
         LatestCoordinator<T, R> lc = new LatestCoordinator<>(observer, combiner, count, bufferSize, delayError);
         lc.subscribe(sources);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCount.java
@@ -89,7 +89,6 @@ public final class ObservableRefCount<T> extends Observable<T> {
         }
     }
 
-    @SuppressWarnings("resource")
     void cancel(RefConnection rc) {
         SequentialDisposable sd;
         synchronized (this) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZip.java
@@ -69,7 +69,6 @@ public final class ObservableZip<T, R> extends Observable<R> {
             return;
         }
 
-        @SuppressWarnings("resource")
         ZipCoordinator<T, R> zc = new ZipCoordinator<>(observer, zipper, count, delayError);
         zc.subscribe(sources, bufferSize);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/DeferredExecutorScheduler.java
@@ -105,7 +105,6 @@ public final class DeferredExecutorScheduler extends Scheduler {
                 task = interruptibleTask;
                 disposable = interruptibleTask;
             } else {
-                @SuppressWarnings("resource")
                 BooleanRunnable runnableTask = new BooleanRunnable(decoratedRun);
 
                 task = runnableTask;

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ExecutorScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ExecutorScheduler.java
@@ -167,7 +167,6 @@ public final class ExecutorScheduler extends Scheduler {
                 task = interruptibleTask;
                 disposable = interruptibleTask;
             } else {
-                @SuppressWarnings("resource")
                 BooleanRunnable runnableTask = new BooleanRunnable(decoratedRun);
 
                 task = runnableTask;

--- a/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
@@ -53,9 +53,8 @@ public interface AwaitCoordinatorStatic {
             return f.join();
         }
         var d = Disposable.fromFuture(f, true);
-        try (var _ = canceller.subscribe(d)) {
-            return f.join();
-        }
+        canceller.subscribe(d);
+        return f.join();
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -117,7 +117,7 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
                 var w = worker;
                 worker = null;
                 if (w != null) {
-                    w.close();
+                    w.dispose();
                 }
             }
             return null;

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -177,7 +177,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                 var w = worker;
                 worker = null;
                 if (w != null) {
-                    w.close();
+                    w.dispose();
                 }
             } finally {
                 producerReady.resume();

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -962,7 +962,6 @@ public class CompletableTest extends RxJavaTest {
     public void timerCancel() throws InterruptedException {
         Completable c = Completable.timer(250, TimeUnit.MILLISECONDS);
 
-        @SuppressWarnings("resource")
         final SequentialDisposable sd = new SequentialDisposable();
         final AtomicInteger calls = new AtomicInteger();
 

--- a/src/test/java/io/reactivex/rxjava4/core/DisposeTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/DisposeTaskTest.java
@@ -31,7 +31,6 @@ public class DisposeTaskTest extends RxJavaTest {
 
             Scheduler.Worker worker = Schedulers.single().createWorker();
 
-            @SuppressWarnings("resource")
             DisposeTask task = new DisposeTask(() -> {
                 throw new TestException();
             }, worker);

--- a/src/test/java/io/reactivex/rxjava4/core/PeriodicDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/PeriodicDirectTaskTest.java
@@ -34,7 +34,6 @@ public class PeriodicDirectTaskTest extends RxJavaTest {
         try {
             Scheduler.Worker worker = Schedulers.single().createWorker();
 
-            @SuppressWarnings("resource")
             PeriodicDirectTask task = new PeriodicDirectTask(() -> {
                 throw new TestException();
             }, worker);

--- a/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/CompositeDisposableTest.java
@@ -20,15 +20,13 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.exceptions.CompositeException;
 import io.reactivex.rxjava4.testsupport.TestHelper;
+import org.junit.Test;
 
 public class CompositeDisposableTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void success() {
         final AtomicInteger counter = new AtomicInteger();
@@ -42,7 +40,6 @@ public class CompositeDisposableTest extends RxJavaTest {
         assertEquals(2, counter.get());
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void shouldUnsubscribeAll() throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
@@ -79,7 +76,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void exception() {
         final AtomicInteger counter = new AtomicInteger();
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(Disposable.fromRunnable(() -> {
             throw new RuntimeException("failed on first one");
@@ -102,7 +98,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void compositeException() {
         final AtomicInteger counter = new AtomicInteger();
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(Disposable.fromRunnable(() -> {
             throw new RuntimeException("failed on first one");
@@ -131,7 +126,6 @@ public class CompositeDisposableTest extends RxJavaTest {
         Disposable d1 = Disposable.empty();
         Disposable d2 = Disposable.empty();
 
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(d1);
         cd.add(d2);
@@ -147,7 +141,6 @@ public class CompositeDisposableTest extends RxJavaTest {
         Disposable d1 = Disposable.empty();
         Disposable d2 = Disposable.empty();
 
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(d1);
         cd.add(d2);
@@ -173,7 +166,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void unsubscribeIdempotence() {
         final AtomicInteger counter = new AtomicInteger();
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(Disposable.fromRunnable(counter::incrementAndGet));
 
@@ -189,7 +181,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     public void unsubscribeIdempotenceConcurrently()
             throws InterruptedException {
         final AtomicInteger counter = new AtomicInteger();
-        @SuppressWarnings("resource")
         final CompositeDisposable cd = new CompositeDisposable();
 
         final int count = 10;
@@ -221,7 +212,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void tryRemoveIfNotIn() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         CompositeDisposable cd1 = new CompositeDisposable();
@@ -236,12 +226,10 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void addingNullDisposableIllegal() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.add(null);
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void initializeVarargs() {
         Disposable d1 = Disposable.empty();
@@ -271,7 +259,6 @@ public class CompositeDisposableTest extends RxJavaTest {
         assertEquals(0, cd.size());
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void initializeIterable() {
         Disposable d1 = Disposable.empty();
@@ -303,7 +290,6 @@ public class CompositeDisposableTest extends RxJavaTest {
         assertEquals(0, cd.size());
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void addAll() {
         CompositeDisposable cd = new CompositeDisposable();
@@ -348,7 +334,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void addAfterDisposed() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
         cd.dispose();
 
@@ -371,7 +356,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void delete() {
 
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         Disposable d1 = Disposable.empty();
@@ -392,7 +376,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -404,7 +387,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void addRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = () -> cd.add(Disposable.empty());
@@ -416,7 +398,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void addAllRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = () -> cd.addAll(Disposable.empty());
@@ -428,7 +409,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void removeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -444,7 +424,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void deleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -460,7 +439,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void clearRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -476,7 +454,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void addDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -490,7 +467,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void addAllDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -504,7 +480,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void removeDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -522,7 +497,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void deleteDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -540,7 +514,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void clearDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -558,7 +531,6 @@ public class CompositeDisposableTest extends RxJavaTest {
     @Test
     public void sizeDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final CompositeDisposable cd = new CompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -575,7 +547,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void disposeThrowsIAE() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         cd.add(Disposable.fromAction(() -> {
@@ -598,7 +569,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void disposeThrowsError() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         cd.add(Disposable.fromAction(() -> {
@@ -621,7 +591,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void disposeThrowsCheckedException() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         cd.add(Disposable.fromAction(() -> {
@@ -652,7 +621,6 @@ public class CompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void disposeThrowsCheckedExceptionSneaky() {
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         cd.add(new Disposable() /* NFI */ {
@@ -683,5 +651,47 @@ public class CompositeDisposableTest extends RxJavaTest {
         }
 
         assertTrue(d1.isDisposed());
+    }
+
+    @Test
+    public void register() {
+        var cd = new CompositeDisposable();
+
+        var d = Disposable.empty();
+
+        var e = cd.register(d);
+
+        assertFalse("d is disposed", d.isDisposed());
+        assertFalse("e is disposed", e.isDisposed());
+        assertFalse("cd is disposed", cd.isDisposed());
+
+        e.dispose();
+
+        assertTrue("d is not is disposed", d.isDisposed());
+        assertTrue("e not is disposed", e.isDisposed());
+        assertFalse("cd is disposed", cd.isDisposed());
+
+        assertEquals(0, cd.size());
+    }
+
+    @Test
+    public void subscribe() {
+        var cd = new CompositeDisposable();
+
+        var d = Disposable.empty();
+
+        var e = cd.subscribe(d);
+
+        assertFalse("d is disposed", d.isDisposed());
+        assertFalse("e is disposed", e.isDisposed());
+        assertFalse("cd is disposed", cd.isDisposed());
+
+        e.dispose();
+
+        assertFalse("d is disposed", d.isDisposed());
+        assertTrue("e not is disposed", e.isDisposed());
+        assertFalse("cd is disposed", cd.isDisposed());
+
+        assertEquals(0, cd.size());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
@@ -237,4 +237,15 @@ public class DisposableTest extends RxJavaTest {
         assertTrue(d.isDisposed());
         assertEquals(1, counter.get());
     }
+
+    @Test
+    public void autoCloseable() throws Throwable {
+        var d = Disposable.empty();
+
+        try (var a = d.asAutoCloseable()) {
+            assertNotNull(a);
+        }
+
+        assertTrue("d is not disposed", d.isDisposed());
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/disposables/FutureDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/FutureDisposableTest.java
@@ -61,7 +61,6 @@ public class FutureDisposableTest extends RxJavaTest {
     @Test
     public void normalDone() {
         FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
-        @SuppressWarnings("resource")
         FutureDisposable d = new FutureDisposable(ft, false);
         assertFalse(d.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/SerialDisposableTests.java
@@ -201,7 +201,6 @@ public class SerialDisposableTests extends RxJavaTest {
     @Test
     public void disposeState() {
         Disposable empty = Disposable.empty();
-        @SuppressWarnings("resource")
         SerialDisposable d = new SerialDisposable(empty);
 
         assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -499,7 +499,6 @@ public class FlowableSubscriberTest {
 
     @Test
     public void doubleSubscribe() {
-        @SuppressWarnings("resource")
         ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
                 Functions.<Throwable>emptyConsumer(), Functions.EMPTY_ACTION);
 
@@ -526,7 +525,6 @@ public class FlowableSubscriberTest {
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
             ts.onSubscribe(new BooleanSubscription());
 
-            @SuppressWarnings("resource")
             ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(v -> {
                 ts.onNext(v);
                 return true;
@@ -550,7 +548,6 @@ public class FlowableSubscriberTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        @SuppressWarnings("resource")
         ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> {
             throw new TestException();
         }, ts::onError, ts::onComplete);
@@ -566,7 +563,6 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onErrorThrows() {
-        @SuppressWarnings("resource")
         ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
         _ -> {
             throw new TestException("Inner");
@@ -592,7 +588,6 @@ public class FlowableSubscriberTest {
 
     @Test
     public void onCompleteThrows() {
-        @SuppressWarnings("resource")
         ForEachWhileSubscriber<Integer> s = new ForEachWhileSubscriber<>(_ -> true,
                 _ -> { }, () -> {
             throw new TestException("Inner");

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/ArrayCompositeDisposableTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class ArrayCompositeDisposableTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void normal() {
         ArrayCompositeDisposable acd = new ArrayCompositeDisposable(2);
@@ -69,7 +68,6 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         assertTrue(d6.isDisposed());
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -81,7 +79,6 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void replaceRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -93,7 +90,6 @@ public class ArrayCompositeDisposableTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void setRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/CancellableDisposableTest.java
@@ -34,7 +34,6 @@ public class CancellableDisposableTest extends RxJavaTest {
 
         Cancellable c = count::getAndIncrement;
 
-        @SuppressWarnings("resource")
         CancellableDisposable cd = new CancellableDisposable(c);
 
         assertFalse(cd.isDisposed());
@@ -56,7 +55,6 @@ public class CancellableDisposableTest extends RxJavaTest {
             throw new TestException();
         };
 
-        @SuppressWarnings("resource")
         CancellableDisposable cd = new CancellableDisposable(c);
 
         assertFalse(cd.isDisposed());
@@ -83,7 +81,6 @@ public class CancellableDisposableTest extends RxJavaTest {
 
             Cancellable c = count::getAndIncrement;
 
-            @SuppressWarnings("resource")
             final CancellableDisposable cd = new CancellableDisposable(c);
 
             Runnable r = cd::dispose;

--- a/src/test/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/disposables/ListCompositeDisposableTest.java
@@ -31,7 +31,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
         Disposable d1 = Disposable.empty();
         Disposable d2 = Disposable.empty();
 
-        @SuppressWarnings("resource")
         ListCompositeDisposable lcd = new ListCompositeDisposable(d1, d2);
 
         lcd.clear();
@@ -58,7 +57,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
         Disposable d1 = Disposable.empty();
         Disposable d2 = Disposable.empty();
 
-        @SuppressWarnings("resource")
         ListCompositeDisposable lcd = new ListCompositeDisposable(Arrays.asList(d1, d2));
 
         lcd.clear();
@@ -83,7 +81,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void empty() {
-        @SuppressWarnings("resource")
         ListCompositeDisposable lcd = new ListCompositeDisposable();
 
         assertFalse(lcd.isDisposed());
@@ -103,7 +100,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
 
     @Test
     public void afterDispose() {
-        @SuppressWarnings("resource")
         ListCompositeDisposable lcd = new ListCompositeDisposable();
         lcd.dispose();
 
@@ -116,7 +112,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
         assertTrue(d.isDisposed());
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void disposeThrows() {
         Disposable d = new Disposable() /* NFI */ {
@@ -154,7 +149,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void remove() {
         ListCompositeDisposable lcd = new ListCompositeDisposable();
@@ -186,7 +180,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -198,7 +191,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void addRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = () -> cd.add(Disposable.empty());
@@ -210,7 +202,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void addAllRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = () -> cd.addAll(Disposable.empty());
@@ -222,7 +213,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void removeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -238,7 +228,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void deleteRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -254,7 +243,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void clearRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -270,7 +258,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void addDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -284,7 +271,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void addAllDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             Runnable run = cd::dispose;
@@ -298,7 +284,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void removeDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -316,7 +301,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void deleteDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();
@@ -334,7 +318,6 @@ public class ListCompositeDisposableTest extends RxJavaTest {
     @Test
     public void clearDisposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final ListCompositeDisposable cd = new ListCompositeDisposable();
 
             final Disposable d1 = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
@@ -27,7 +27,6 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void pollClear() throws Throwable {
-        @SuppressWarnings("resource")
         CancellableQueueFuseable<Object> qs = new CancellableQueueFuseable<>();
 
         assertNull(qs.poll());
@@ -38,7 +37,6 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void cancel() {
-        @SuppressWarnings("resource")
         CancellableQueueFuseable<Object> qs = new CancellableQueueFuseable<>();
 
         assertFalse(qs.isDisposed());
@@ -54,7 +52,6 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         CancellableQueueFuseable<Object> qs = new CancellableQueueFuseable<>();
 
         assertFalse(qs.isDisposed());
@@ -70,7 +67,6 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void cancel2() {
-        @SuppressWarnings("resource")
         AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());
@@ -80,7 +76,6 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void dispose2() {
-        @SuppressWarnings("resource")
         AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
@@ -26,7 +26,8 @@ public class BasicFuseableObserverTest extends RxJavaTest {
     @Test(expected = UnsupportedOperationException.class)
     public void offer() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
-        try (var o = new BasicFuseableObserver<Integer, Integer>(to) /* NFI */ {
+
+        var o = new BasicFuseableObserver<Integer, Integer>(to) /* NFI */ {
             @Nullable
             @Override
             public Integer poll() throws Exception {
@@ -46,19 +47,16 @@ public class BasicFuseableObserverTest extends RxJavaTest {
             protected boolean beforeDownstream() {
                 return false;
             }
-        }) {
+        };
+        o.onSubscribe(Disposable.disposed());
 
-            o.onSubscribe(Disposable.disposed());
+        to.assertNotSubscribed();
 
-            to.assertNotSubscribed();
-
-            o.offer(1);
-        }
+        o.offer(1);
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void offer2() {
-        @SuppressWarnings("resource")
         BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<>()) {
             @Nullable
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingFirstObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingFirstObserverTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava4.exceptions.TestException;
 
 public class BlockingFirstObserverTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void firstValueOnly() {
         BlockingFirstObserver<Integer> bf = new BlockingFirstObserver<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BlockingObserverTest.java
@@ -23,7 +23,6 @@ import io.reactivex.rxjava4.core.RxJavaTest;
 
 public class BlockingObserverTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void dispose() {
         Queue<Object> q = new ArrayDeque<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/CallbackCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/CallbackCompletableObserverTest.java
@@ -24,7 +24,6 @@ public final class CallbackCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void emptyActionShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.ON_ERROR_MISSING, Functions.EMPTY_ACTION);
 
         assertFalse(o.hasCustomOnError());
@@ -32,7 +31,6 @@ public final class CallbackCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         CallbackCompletableObserver o = new CallbackCompletableObserver(Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/ConsumerSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/ConsumerSingleObserverTest.java
@@ -24,7 +24,6 @@ public final class ConsumerSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING);
 
@@ -33,7 +32,6 @@ public final class ConsumerSingleObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         ConsumerSingleObserver<Integer> o = new ConsumerSingleObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
@@ -55,7 +55,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             TakeFirst source = new TakeFirst(to);
 
             source.onSubscribe(Disposable.empty());
@@ -79,7 +78,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void error() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeFirst source = new TakeFirst(to);
 
         source.onSubscribe(Disposable.empty());
@@ -92,7 +90,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void complete() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeFirst source = new TakeFirst(to);
 
         source.onSubscribe(Disposable.empty());
@@ -105,7 +102,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void dispose() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeFirst source = new TakeFirst(to);
 
         Disposable d = Disposable.empty();
@@ -127,7 +123,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-            @SuppressWarnings("resource")
             TakeFirst source = new TakeFirst(to);
 
             Disposable d = Disposable.empty();
@@ -158,7 +153,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.SYNC);
 
-            @SuppressWarnings("resource")
             TakeFirst source = new TakeFirst(to);
 
             Disposable d = Disposable.empty();
@@ -205,7 +199,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
-            @SuppressWarnings("resource")
             TakeLast source = new TakeLast(to);
 
             Disposable d = Disposable.empty();
@@ -231,7 +224,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
-            @SuppressWarnings("resource")
             TakeLast source = new TakeLast(to);
 
             Disposable d = Disposable.empty();
@@ -257,7 +249,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-            @SuppressWarnings("resource")
             TakeLast source = new TakeLast(to);
 
             Disposable d = Disposable.empty();
@@ -283,7 +274,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
         try {
             TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-            @SuppressWarnings("resource")
             TakeLast source = new TakeLast(to);
 
             Disposable d = Disposable.empty();
@@ -307,7 +297,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void disposed() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(to);
 
         Disposable d = Disposable.empty();
@@ -326,7 +315,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void disposedAfterOnNext() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             Disposable upstream;
 
@@ -364,7 +352,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void fusedEmpty() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.ANY);
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(to);
 
         Disposable d = Disposable.empty();
@@ -380,7 +367,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void nonfusedEmpty() {
         TestObserverEx<Integer> to = new TestObserverEx<>(QueueFuseable.NONE);
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(to);
 
         Disposable d = Disposable.empty();
@@ -396,7 +382,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusion() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 
@@ -447,7 +432,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusionClear() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 
@@ -496,7 +480,6 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusionDontConsume() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         TakeFirst source = new TakeFirst(new Observer<Integer>() /* NFI */ {
             QueueDisposable<Integer> d;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DisposableLambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DisposableLambdaObserverTest.java
@@ -40,7 +40,6 @@ public class DisposableLambdaObserverTest extends RxJavaTest {
     public void disposeCrash() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             DisposableLambdaObserver<Integer> o = new DisposableLambdaObserver<>(
                     new TestObserver<>(), Functions.emptyConsumer(),
                     () -> {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/EmptyCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/EmptyCompletableObserverTest.java
@@ -23,7 +23,6 @@ public final class EmptyCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void defaultShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         EmptyCompletableObserver o = new EmptyCompletableObserver();
 
         assertFalse(o.hasCustomOnError());

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/FutureMultiObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/FutureMultiObserverTest.java
@@ -23,7 +23,6 @@ public class FutureMultiObserverTest extends RxJavaTest {
 
     @Test
     public void cancelBeforeOnSubscribe() {
-        @SuppressWarnings("resource")
         FutureMultiObserver<Integer> f = new FutureMultiObserver<>();
 
         assertTrue(f.cancel(true));
@@ -37,7 +36,6 @@ public class FutureMultiObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteJustAfterDispose() {
-        @SuppressWarnings("resource")
         FutureMultiObserver<Integer> f = new FutureMultiObserver<>();
         Disposable d = Disposable.empty();
         f.onSubscribe(d);

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/FutureObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/FutureObserverTest.java
@@ -155,7 +155,6 @@ public class FutureObserverTest extends RxJavaTest {
     @Test
     public void cancelRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final FutureObserver<Integer> fo = new FutureObserver<>();
 
             Runnable r = () -> fo.cancel(false);
@@ -179,7 +178,6 @@ public class FutureObserverTest extends RxJavaTest {
         RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
         try {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                @SuppressWarnings("resource")
                 final FutureObserver<Integer> fo = new FutureObserver<>();
 
                 final TestException ex = new TestException();
@@ -200,7 +198,6 @@ public class FutureObserverTest extends RxJavaTest {
         RxJavaPlugins.setErrorHandler(Functions.emptyConsumer());
         try {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                @SuppressWarnings("resource")
                 final FutureObserver<Integer> fo = new FutureObserver<>();
 
                 if (i % 3 == 0) {
@@ -354,7 +351,6 @@ public class FutureObserverTest extends RxJavaTest {
     @Test
     public void cancelOnSubscribeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final FutureObserver<Integer> fo = new FutureObserver<>();
 
             Runnable r = () -> fo.cancel(false);

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
@@ -240,7 +240,6 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
@@ -251,7 +250,6 @@ public class LambdaObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
@@ -266,7 +264,6 @@ public class LambdaObserverTest extends RxJavaTest {
         try {
             final List<Throwable> observerErrors = Collections.synchronizedList(new ArrayList<>());
 
-            @SuppressWarnings("resource")
             LambdaObserver<Integer> o = new LambdaObserver<>(Functions.<Integer>emptyConsumer(),
                     observerErrors::add,
                     Functions.EMPTY_ACTION,

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableNextTest.java
@@ -225,8 +225,7 @@ public class BlockingFlowableNextTest extends RxJavaTest {
     public void noBufferingOrBlockingOfSequence() throws Throwable {
         int repeat = 0;
         for (;;) {
-            @SuppressWarnings("resource")
-            final SerialDisposable task = new SerialDisposable();
+            var task = new SerialDisposable();
             try {
                 final CountDownLatch finished = new CountDownLatch(1);
                 final int COUNT = 30;
@@ -337,7 +336,6 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverError() {
-        @SuppressWarnings("resource")
         NextSubscriber<Integer> no = new NextSubscriber<>();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -352,7 +350,6 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnNext() throws Exception {
-        @SuppressWarnings("resource")
         NextSubscriber<Integer> no = new NextSubscriber<>();
 
         no.setWaiting();
@@ -366,7 +363,6 @@ public class BlockingFlowableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnCompleteOnNext() throws Exception {
-        @SuppressWarnings("resource")
         NextSubscriber<Integer> no = new NextSubscriber<>();
 
         no.setWaiting();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -108,14 +108,12 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void remove() {
-        @SuppressWarnings("resource")
         BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
         it.remove();
     }
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
 
         assertFalse(it.isDisposed());
@@ -127,7 +125,6 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test
     public void interruptWait() {
-        @SuppressWarnings("resource")
         BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
 
         try {
@@ -141,7 +138,6 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
     @Test(expected = NoSuchElementException.class)
     public void emptyThrowsNoSuch() {
-        @SuppressWarnings("resource")
         BlockingFlowableIterator<Integer> it = new BlockingFlowableIterator<>(128);
         it.onComplete();
         it.next();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
@@ -52,7 +52,6 @@ public class FlowableAmbTest extends RxJavaTest {
     private Flowable<String> createFlowable(final String[] values,
             final long interval, final Throwable e) {
         return Flowable.unsafeCreate(subscriber -> {
-            @SuppressWarnings("resource")
             final CompositeDisposable parentSubscription = new CompositeDisposable();
 
             subscriber.onSubscribe(new Subscription() /* NFI */ {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
@@ -2039,7 +2039,6 @@ public class FlowableBufferTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        @SuppressWarnings("resource")
         BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<>(
                 ts, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
@@ -2123,7 +2122,6 @@ public class FlowableBufferTest extends RxJavaTest {
 
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
-        @SuppressWarnings("resource")
         BufferExactBoundedSubscriber<Integer, List<Integer>> sub =
                 new BufferExactBoundedSubscriber<>(
                         ts, Functions.justSupplier(new ArrayList<Integer>()),

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
@@ -349,7 +349,6 @@ public class FlowableDebounceTest extends RxJavaTest {
 
         TestHelper.checkDisposed(PublishProcessor.create().debounce(Functions.justFunction(Flowable.never())));
 
-        @SuppressWarnings("resource")
         Disposable d = new FlowableDebounceTimed.DebounceEmitter<>(1, 1, null);
         assertFalse(d.isDisposed());
 
@@ -517,7 +516,6 @@ public class FlowableDebounceTest extends RxJavaTest {
 
         sub.onSubscribe(new BooleanSubscription());
 
-        @SuppressWarnings("resource")
         DebounceEmitter<Integer> de = new DebounceEmitter<>(1, 50, sub);
         de.emit();
         de.emit();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
@@ -890,7 +890,6 @@ public class FlowableDelayTest extends RxJavaTest {
     public void cancelShouldPreventRandomSubsequentEmissions() {
         for (int attempt = 1; attempt < 100; attempt ++) {
 
-            @SuppressWarnings("resource")
             SequentialDisposable disposable = new SequentialDisposable();
             ConcurrentLinkedQueue<Integer> sink = new ConcurrentLinkedQueue<>();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -893,7 +893,6 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
     @Test
     public void innerIsDisposed() {
-        @SuppressWarnings("resource")
         FlowableFlatMap.InnerSubscriber<Integer, Integer> inner = new FlowableFlatMap.InnerSubscriber<>(null, 10, 0L);
 
         assertFalse(inner.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -512,7 +512,6 @@ public class FlowableGroupJoinTest extends RxJavaTest {
     public void leftRightState() {
         JoinSupport js = mock(JoinSupport.class);
 
-        @SuppressWarnings("resource")
         LeftRightSubscriber o = new LeftRightSubscriber(js, false);
 
         assertFalse(o.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRefCountTest.java
@@ -1090,7 +1090,6 @@ public class FlowableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnX() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1107,7 +1106,6 @@ public class FlowableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnXCount() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1124,7 +1122,6 @@ public class FlowableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnXTime() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -767,7 +767,6 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
     @Test
     public void timeoutConsumerIsDisposed() {
-        @SuppressWarnings("resource")
         TimeoutConsumer consumer = new TimeoutConsumer(0, null);
 
         assertFalse(consumer.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCallbackObserverTest.java
@@ -31,7 +31,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(Functions.emptyConsumer(), Functions.emptyConsumer(), Functions.EMPTY_ACTION);
 
         Disposable d = Disposable.empty();
@@ -51,7 +50,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onSuccessCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     _ -> {
                         throw new TestException();
@@ -73,7 +71,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onErrorCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
                     (Consumer<Object>) _ -> {
@@ -100,7 +97,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
     public void onCompleteCrashes() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             MaybeCallbackObserver<Object> mo = new MaybeCallbackObserver<>(
                     Functions.emptyConsumer(),
                     Functions.emptyConsumer(),
@@ -120,7 +116,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION);
@@ -130,7 +125,6 @@ public class MaybeCallbackObserverTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         MaybeCallbackObserver<Integer> o = new MaybeCallbackObserver<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -310,7 +310,6 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void cancelNoConcurrentClean() {
         TestObserver<Integer> to = new TestObserver<>();
-        @SuppressWarnings("resource")
         ConcatMapMaybeMainObserver<Integer, Integer> operator =
                 new ConcatMapMaybeMainObserver<>(
                         to, Functions.justFunction(Maybe.<Integer>never()), 16, ErrorMode.IMMEDIATE);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -264,7 +264,6 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void cancelNoConcurrentClean() {
         TestObserver<Integer> to = new TestObserver<>();
-        @SuppressWarnings("resource")
         ConcatMapSingleMainObserver<Integer, Integer> operator =
                 new ConcatMapSingleMainObserver<>(
                         to, Functions.justFunction(Single.<Integer>never()), 16, ErrorMode.IMMEDIATE);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableNextTest.java
@@ -229,8 +229,7 @@ public class BlockingObservableNextTest extends RxJavaTest {
     public void noBufferingOrBlockingOfSequence() throws Throwable {
         int repeat = 0;
         for (;;) {
-            @SuppressWarnings("resource")
-            final SerialDisposable task = new SerialDisposable();
+            var task = new SerialDisposable();
             try {
                 final CountDownLatch finished = new CountDownLatch(1);
                 final int COUNT = 30;
@@ -341,7 +340,6 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverError() {
-        @SuppressWarnings("resource")
         NextObserver<Integer> no = new NextObserver<>();
 
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -356,7 +354,6 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnNext() throws Exception {
-        @SuppressWarnings("resource")
         NextObserver<Integer> no = new NextObserver<>();
 
         no.setWaiting();
@@ -370,7 +367,6 @@ public class BlockingObservableNextTest extends RxJavaTest {
 
     @Test
     public void nextObserverOnCompleteOnNext() throws Exception {
-        @SuppressWarnings("resource")
         NextObserver<Integer> no = new NextObserver<>();
 
         no.setWaiting();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/BlockingObservableToIteratorTest.java
@@ -68,7 +68,6 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
 
         assertFalse(it.isDisposed());
@@ -80,7 +79,6 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test
     public void interruptWait() {
-        @SuppressWarnings("resource")
         BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
 
         try {
@@ -94,7 +92,6 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test(expected = NoSuchElementException.class)
     public void emptyThrowsNoSuch() {
-        @SuppressWarnings("resource")
         BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
         it.onComplete();
         it.next();
@@ -102,7 +99,6 @@ public class BlockingObservableToIteratorTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void remove() {
-        @SuppressWarnings("resource")
         BlockingObservableIterator<Integer> it = new BlockingObservableIterator<>(128);
         it.remove();
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBlockingTest.java
@@ -256,7 +256,6 @@ public class ObservableBlockingTest extends RxJavaTest {
 
     @Test
     public void blockingCancelUpfront() {
-        @SuppressWarnings("resource")
         BlockingFirstObserver<Integer> o = new BlockingFirstObserver<>();
 
         assertFalse(o.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -1479,7 +1479,6 @@ public class ObservableBufferTest extends RxJavaTest {
 
         TestObserver<List<Integer>> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<>(
                 to, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
 
@@ -1518,7 +1517,6 @@ public class ObservableBufferTest extends RxJavaTest {
 
         TestObserver<List<Integer>> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
                 to, Functions.justSupplier(new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
@@ -1538,7 +1536,6 @@ public class ObservableBufferTest extends RxJavaTest {
 
         final TestObserver<List<Integer>> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
                 to, new Supplier<List<Integer>>() /* NFI */ {
             int calls;
@@ -1565,7 +1562,6 @@ public class ObservableBufferTest extends RxJavaTest {
 
         TestObserver<List<Integer>> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         BufferExactBoundedObserver<Integer, List<Integer>> sub =
                 new BufferExactBoundedObserver<>(
                         to, Functions.justSupplier(new ArrayList<Integer>()),
@@ -1603,7 +1599,6 @@ public class ObservableBufferTest extends RxJavaTest {
     public void bufferExactState() {
         TestObserver<List<Integer>> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<>(
                 to, 1, Functions.justSupplier(new ArrayList<Integer>())
         );

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDebounceTest.java
@@ -334,7 +334,6 @@ public class ObservableDebounceTest extends RxJavaTest {
 
         TestHelper.checkDisposed(PublishSubject.create().debounce(Functions.justFunction(Observable.never())));
 
-        @SuppressWarnings("resource")
         Disposable d = new ObservableDebounceTimed.DebounceEmitter<>(1, 1, null);
         assertFalse(d.isDisposed());
 
@@ -474,7 +473,6 @@ public class ObservableDebounceTest extends RxJavaTest {
 
         sub.onSubscribe(Disposable.empty());
 
-        @SuppressWarnings("resource")
         DebounceEmitter<Integer> de = new DebounceEmitter<>(1, 50, sub);
         de.run();
         de.run();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
@@ -857,7 +857,6 @@ public class ObservableDelayTest extends RxJavaTest {
     public void cancelShouldPreventRandomSubsequentEmissions() {
         for (int attempt = 1; attempt < 100; attempt ++) {
 
-            @SuppressWarnings("resource")
             SequentialDisposable disposable = new SequentialDisposable();
             ConcurrentLinkedQueue<Integer> sink = new ConcurrentLinkedQueue<>();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -749,7 +749,6 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final UnicastSubject<Integer> fusedSource = UnicastSubject.create();
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         ObservableFlatMap.MergeObserver<Integer, Integer> merger =
                 new ObservableFlatMap.MergeObserver<>(to, (Function<Integer, Observable<Integer>>) t -> {
                     if (t == 0) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
@@ -505,7 +505,6 @@ public class ObservableGroupJoinTest extends RxJavaTest {
     public void leftRightState() {
         JoinSupport js = mock(JoinSupport.class);
 
-        @SuppressWarnings("resource")
         LeftRightObserver o = new LeftRightObserver(js, false);
 
         assertFalse(o.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMapNotificationTest.java
@@ -46,7 +46,6 @@ public class ObservableMapNotificationTest extends RxJavaTest {
             @SuppressWarnings({ "rawtypes", "unchecked" })
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
-                @SuppressWarnings("resource")
                 MapNotificationObserver mn = new MapNotificationObserver(
                         observer,
                         Functions.justFunction(Observable.just(1)),

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRefCountTest.java
@@ -1034,7 +1034,6 @@ public class ObservableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnX() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1051,7 +1050,6 @@ public class ObservableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnXCount() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
@@ -1068,7 +1066,6 @@ public class ObservableRefCountTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void doubleOnXTime() {
         List<Throwable> errors = TestHelper.trackPluginErrors();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableResourceWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableResourceWrapperTest.java
@@ -28,7 +28,6 @@ public class ObservableResourceWrapperTest extends RxJavaTest {
     @Test
     public void disposed() {
         TestObserver<Object> to = new TestObserver<>();
-        @SuppressWarnings("resource")
         ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<>(to);
 
         Disposable d = Disposable.empty();
@@ -53,7 +52,6 @@ public class ObservableResourceWrapperTest extends RxJavaTest {
     @Test
     public void onErrorDisposes() {
         TestObserver<Object> to = new TestObserver<>();
-        @SuppressWarnings("resource")
         ObserverResourceWrapper<Object> orw = new ObserverResourceWrapper<>(to);
 
         Disposable d = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -1189,7 +1189,6 @@ public class ObservableSwitchTest extends RxJavaTest {
 
     Observable<Integer> createObservable(AtomicInteger inner) {
         return Observable.<Integer>unsafeCreate(s -> {
-            @SuppressWarnings("resource")
             SerializedObserver<Integer> it = new SerializedObserver<>(s);
             it.onSubscribe(Disposable.empty());
             Schedulers.cached().scheduleDirect(() -> {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
@@ -346,7 +346,6 @@ public class ObservableTimerTest extends RxJavaTest {
     public void cancelledAndRun() {
         TestObserver<Long> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
-        @SuppressWarnings("resource")
         TimerObserver tm = new TimerObserver(to);
 
         tm.dispose();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
@@ -28,7 +28,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void cancelSetFuture() {
-        @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -61,7 +60,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void cancelSetFutureCurrentThread() {
-        @SuppressWarnings("resource")
         var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -96,7 +94,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void setFutureCancel() {
-        @SuppressWarnings("resource")
         var task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -126,7 +123,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void setFutureCancelSameThread() {
-        @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -157,7 +153,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void finished() {
-        @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -188,7 +183,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void finishedCancel() {
-        @SuppressWarnings("resource")
         AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = 208585707945686116L;
@@ -224,7 +218,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
     @Test
     public void disposeSetFutureRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            @SuppressWarnings("resource")
             final AbstractDirectTask task = new AbstractDirectTask(Functions.EMPTY_RUNNABLE, true) /* NFI */ {
                 @Serial
                 private static final long serialVersionUID = 208585707945686116L;
@@ -258,7 +251,6 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
     @Test
     public void toStringStates() {
-        @SuppressWarnings("resource")
         TestDirectTask task = new TestDirectTask();
 
         assertEquals("TestDirectTask[Waiting]", task.toString());

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/BooleanRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/BooleanRunnableTest.java
@@ -31,7 +31,6 @@ public class BooleanRunnableTest extends RxJavaTest {
     public void runnableThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             BooleanRunnable task = new BooleanRunnable(() -> {
                 throw new TestException();
             });

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ExecutorSchedulerDelayedRunnableTest.java
@@ -29,7 +29,6 @@ public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
     @Test(expected = TestException.class)
     @SuppressUndeliverable
     public void delayedRunnableCrash() {
-        @SuppressWarnings("resource")
         DelayedRunnable dl = new DelayedRunnable(() -> {
             throw new TestException();
         });
@@ -39,7 +38,6 @@ public class ExecutorSchedulerDelayedRunnableTest extends RxJavaTest {
     @Test
     public void dispose() {
         final AtomicInteger count = new AtomicInteger();
-        @SuppressWarnings("resource")
         DelayedRunnable dl = new DelayedRunnable(count::incrementAndGet);
 
         dl.dispose();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/InstantPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/InstantPeriodicTaskTest.java
@@ -34,7 +34,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -58,7 +57,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -83,7 +81,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -111,7 +108,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -141,7 +137,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -168,7 +163,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
 
-            @SuppressWarnings("resource")
             InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                 throw new TestException();
             }, exec);
@@ -197,7 +191,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-                @SuppressWarnings("resource")
                 final InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                     throw new TestException();
                 }, exec);
@@ -222,7 +215,6 @@ public class InstantPeriodicTaskTest extends RxJavaTest {
         ExecutorService exec = Executors.newSingleThreadExecutor();
         try {
             for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-                @SuppressWarnings("resource")
                 final InstantPeriodicTask task = new InstantPeriodicTask(() -> {
                     throw new TestException();
                 }, exec);

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/InterruptibleRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/InterruptibleRunnableTest.java
@@ -31,7 +31,6 @@ public class InterruptibleRunnableTest extends RxJavaTest {
     public void runnableThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             InterruptibleRunnable task = new InterruptibleRunnable(() -> {
                 throw new TestException();
             }, null);

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ParallelSchedulerTest.java
@@ -349,14 +349,13 @@ public class ParallelSchedulerTest implements Runnable {
         try {
             for (int i = 0; i < 1000; i++) {
                 final CompositeDisposable cd = new CompositeDisposable();
-                try (final TrackedAction tt = new TrackedAction(this, cd)) {
-                    final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
+                var tt = new TrackedAction(this, cd);
+                final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-                    Runnable r1 = () -> tt.setFuture(ft);
+                Runnable r1 = () -> tt.setFuture(ft);
 
-                    Runnable r2 = () -> tt.future.set(TrackedAction.FINISHED);
-                    TestHelper.race(r1, r2, Schedulers.single());
-                }
+                Runnable r2 = () -> tt.future.set(TrackedAction.FINISHED);
+                TestHelper.race(r1, r2, Schedulers.single());
             }
         } finally {
             s.shutdown();
@@ -369,14 +368,14 @@ public class ParallelSchedulerTest implements Runnable {
         try {
             for (int i = 0; i < 1000; i++) {
                 final CompositeDisposable cd = new CompositeDisposable();
-                try (final TrackedAction tt = new TrackedAction(this, cd)) {
-                    final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-                    Runnable r1 = () -> tt.setFuture(ft);
+                var tt = new TrackedAction(this, cd);
+                final FutureTask<Object> ft = new FutureTask<>(Functions.EMPTY_RUNNABLE, null);
 
-                    Runnable r2 = () -> tt.future.set(TrackedAction.DISPOSED);
-                    TestHelper.race(r1, r2, Schedulers.single());
-                }
+                Runnable r1 = () -> tt.setFuture(ft);
+
+                Runnable r2 = () -> tt.future.set(TrackedAction.DISPOSED);
+                TestHelper.race(r1, r2, Schedulers.single());
             }
         } finally {
             s.shutdown();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledDirectPeriodicTaskTest.java
@@ -30,7 +30,6 @@ public class ScheduledDirectPeriodicTaskTest extends RxJavaTest {
     public void runnableThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            @SuppressWarnings("resource")
             ScheduledDirectPeriodicTask task = new ScheduledDirectPeriodicTask(() -> {
                 throw new TestException();
             }, true);

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
@@ -182,7 +182,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void withoutParentDisposed() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.dispose();
         run.call();
@@ -190,7 +189,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void withParentDisposed() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, new CompositeDisposable());
         run.dispose();
         run.call();
@@ -198,7 +196,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void withFutureDisposed() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.setFuture(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
         run.dispose();
@@ -207,7 +204,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void withFutureDisposed2() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.dispose();
         run.setFuture(new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null));
@@ -216,7 +212,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void withFutureDisposed3() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.dispose();
         run.set(2, Thread.currentThread());
@@ -288,7 +283,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void disposeAfterRun() {
-        @SuppressWarnings("resource")
         final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
 
         run.run();
@@ -300,7 +294,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void syncDisposeIdempotent() {
-        @SuppressWarnings("resource")
         final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         run.set(ScheduledRunnable.THREAD_INDEX, Thread.currentThread());
 
@@ -314,7 +307,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void asyncDisposeIdempotent() {
-        @SuppressWarnings("resource")
         final ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
 
         run.dispose();
@@ -327,7 +319,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
     @Test
     public void noParentIsDisposed() {
-        @SuppressWarnings("resource")
         ScheduledRunnable run = new ScheduledRunnable(Functions.EMPTY_RUNNABLE, null);
         assertFalse(run.isDisposed());
         run.run();
@@ -348,7 +339,6 @@ public class ScheduledRunnableTest extends RxJavaTest {
         assertFalse(set.remove(run));
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void toStringStates() {
         CompositeDisposable set = new CompositeDisposable();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerMultiWorkerSupportTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerMultiWorkerSupportTest.java
@@ -58,7 +58,6 @@ public class SchedulerMultiWorkerSupportTest extends RxJavaTest {
     public void distinctThreads() throws Exception {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
-            @SuppressWarnings("resource")
             final CompositeDisposable composite = new CompositeDisposable();
 
             try {

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
@@ -218,36 +218,33 @@ public class SharedSchedulerTest implements Runnable {
     @Test
     public void disposeSetFutureRace() {
         for (int i = 0; i < 1000; i++) {
-            try (final SharedAction sa = new SharedAction(this, new CompositeDisposable())) {
+            var sa = new SharedAction(this, new CompositeDisposable());
+            final Disposable d = Disposable.empty();
 
-                final Disposable d = Disposable.empty();
+            Runnable r1 = () -> sa.setFuture(d);
 
-                Runnable r1 = () -> sa.setFuture(d);
+            Runnable r2 = sa::dispose;
 
-                Runnable r2 = sa::dispose;
+            TestHelper.race(r1, r2, Schedulers.single());
 
-                TestHelper.race(r1, r2, Schedulers.single());
-
-                assertTrue("Future not disposed", d.isDisposed());
-            }
+            assertTrue("Future not disposed", d.isDisposed());
         }
     }
 
     @Test
     public void runSetFutureRace() {
         for (int i = 0; i < 1000; i++) {
-            try (final SharedAction sa = new SharedAction(this, new CompositeDisposable())) {
-                final Disposable d = Disposable.empty();
+            var sa = new SharedAction(this, new CompositeDisposable());
+            final Disposable d = Disposable.empty();
 
-                Runnable r1 = () -> sa.setFuture(d);
+            Runnable r1 = () -> sa.setFuture(d);
 
-                Runnable r2 = sa::run;
+            Runnable r2 = sa::run;
 
-                TestHelper.race(r1, r2, Schedulers.single());
+            TestHelper.race(r1, r2, Schedulers.single());
 
-                assertFalse("Future disposed", d.isDisposed());
-                assertEquals(i + 1, calls);
-            }
+            assertFalse("Future disposed", d.isDisposed());
+            assertEquals(i + 1, calls);
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BoundedSubscriberTest.java
@@ -215,7 +215,6 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
@@ -226,7 +225,6 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
@@ -237,7 +235,6 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void cancel() {
-        @SuppressWarnings("resource")
         BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,
@@ -253,7 +250,6 @@ public class BoundedSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         BoundedSubscriber<Integer> subscriber = new BoundedSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/LambdaSubscriberTest.java
@@ -213,7 +213,6 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorMissingShouldReportNoCustomOnError() {
-        @SuppressWarnings("resource")
         LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.ON_ERROR_MISSING,
                 Functions.EMPTY_ACTION,
@@ -224,7 +223,6 @@ public class LambdaSubscriberTest extends RxJavaTest {
 
     @Test
     public void customOnErrorShouldReportCustomOnError() {
-        @SuppressWarnings("resource")
         LambdaSubscriber<Integer> subscriber = new LambdaSubscriber<>(Functions.<Integer>emptyConsumer(),
                 Functions.<Throwable>emptyConsumer(),
                 Functions.EMPTY_ACTION,

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/ArrayCompositeSubscriptionTest.java
@@ -22,7 +22,6 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class ArrayCompositeSubscriptionTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void set() {
         ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
@@ -58,7 +57,6 @@ public class ArrayCompositeSubscriptionTest extends RxJavaTest {
         assertFalse(ac.setResource(0, null));
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void replace() {
         ArrayCompositeSubscription ac = new ArrayCompositeSubscription(1);
@@ -94,7 +92,6 @@ public class ArrayCompositeSubscriptionTest extends RxJavaTest {
         ac.replaceResource(0, null);
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void disposeRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -106,7 +103,6 @@ public class ArrayCompositeSubscriptionTest extends RxJavaTest {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void setReplaceRace() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscriptions/AsyncSubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscriptions/AsyncSubscriptionTest.java
@@ -25,7 +25,6 @@ import io.reactivex.rxjava4.disposables.Disposable;
 
 public class AsyncSubscriptionTest extends RxJavaTest {
 
-    @SuppressWarnings("resource")
     @Test
     public void noResource() {
         AsyncSubscription as = new AsyncSubscription();
@@ -42,7 +41,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(s).cancel();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void requestBeforeSet() {
         AsyncSubscription as = new AsyncSubscription();
@@ -59,7 +57,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(s).cancel();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void cancelBeforeSet() {
         AsyncSubscription as = new AsyncSubscription();
@@ -75,7 +72,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(s).cancel();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void singleSet() {
         AsyncSubscription as = new AsyncSubscription();
@@ -93,7 +89,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(s1).cancel();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void initialResource() {
         Disposable r = mock(Disposable.class);
@@ -104,7 +99,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void setResource() {
         AsyncSubscription as = new AsyncSubscription();
@@ -118,7 +112,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void replaceResource() {
         AsyncSubscription as = new AsyncSubscription();
@@ -132,7 +125,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void setResource2() {
         AsyncSubscription as = new AsyncSubscription();
@@ -151,7 +143,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r2).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void replaceResource2() {
         AsyncSubscription as = new AsyncSubscription();
@@ -170,7 +161,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r2).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void setResourceAfterCancel() {
         AsyncSubscription as = new AsyncSubscription();
@@ -184,7 +174,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void replaceResourceAfterCancel() {
         AsyncSubscription as = new AsyncSubscription();
@@ -197,7 +186,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void cancelOnce() {
         Disposable r = mock(Disposable.class);
@@ -215,7 +203,6 @@ public class AsyncSubscriptionTest extends RxJavaTest {
         verify(r).dispose();
     }
 
-    @SuppressWarnings("resource")
     @Test
     public void disposed() {
         AsyncSubscription as = new AsyncSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
@@ -125,7 +125,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableSubscriber() {
-        @SuppressWarnings("resource")
         Subscriber<Integer> consumer = new DisposableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -161,7 +160,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceSubscriber() {
-        @SuppressWarnings("resource")
         Subscriber<Integer> consumer = new ResourceSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -232,7 +230,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableObserver() {
-        @SuppressWarnings("resource")
         Observer<Integer> consumer = new DisposableObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -268,7 +265,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceObserver() {
-        @SuppressWarnings("resource")
         Observer<Integer> consumer = new ResourceObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -304,7 +300,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableSingleObserver() {
-        @SuppressWarnings("resource")
         SingleObserver<Integer> consumer = new DisposableSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
@@ -336,7 +331,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceSingleObserver() {
-        @SuppressWarnings("resource")
         SingleObserver<Integer> consumer = new ResourceSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
@@ -368,7 +362,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableMaybeObserver() {
-        @SuppressWarnings("resource")
         MaybeObserver<Integer> consumer = new DisposableMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
@@ -404,7 +397,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceMaybeObserver() {
-        @SuppressWarnings("resource")
         MaybeObserver<Integer> consumer = new ResourceMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
@@ -440,7 +432,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableCompletableObserver() {
-        @SuppressWarnings("resource")
         CompletableObserver consumer = new DisposableCompletableObserver() /* NFI */ {
             @Override
             public void onError(Throwable t) {
@@ -472,7 +463,6 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceCompletableObserver() {
-        @SuppressWarnings("resource")
         CompletableObserver consumer = new ResourceCompletableObserver() /* NFI */ {
             @Override
             public void onError(Throwable t) {

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableCompletableObserverTest.java
@@ -77,7 +77,6 @@ public class DisposableCompletableObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestCompletable tc = new TestCompletable();
 
             tc.onSubscribe(Disposable.empty());
@@ -98,7 +97,6 @@ public class DisposableCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestCompletable tc = new TestCompletable();
         tc.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableMaybeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableMaybeObserverTest.java
@@ -85,7 +85,6 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestMaybe<Integer> tc = new TestMaybe<>();
 
             tc.onSubscribe(Disposable.empty());
@@ -106,7 +105,6 @@ public class DisposableMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestMaybe<Integer> tc = new TestMaybe<>();
         tc.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableObserverTest.java
@@ -84,7 +84,6 @@ public class DisposableObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestDisposableObserver<Integer> tc = new TestDisposableObserver<>();
 
             tc.onSubscribe(Disposable.empty());
@@ -105,7 +104,6 @@ public class DisposableObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestDisposableObserver<Integer> tc = new TestDisposableObserver<>();
 
         assertFalse(tc.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/observers/DisposableSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/DisposableSingleObserverTest.java
@@ -77,7 +77,6 @@ public class DisposableSingleObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestSingle<Integer> tc = new TestSingle<>();
 
             tc.onSubscribe(Disposable.empty());
@@ -98,7 +97,6 @@ public class DisposableSingleObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestSingle<Integer> tc = new TestSingle<>();
         tc.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/ResourceCompletableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/ResourceCompletableObserverTest.java
@@ -58,14 +58,12 @@ public class ResourceCompletableObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        @SuppressWarnings("resource")
         TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
         rco.add(null);
     }
 
     @Test
     public void addResources() {
-        @SuppressWarnings("resource")
         TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
 
         assertFalse(rco.isDisposed());
@@ -91,7 +89,6 @@ public class ResourceCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
 
         assertFalse(rco.isDisposed());
@@ -111,7 +108,6 @@ public class ResourceCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
 
         assertFalse(rco.isDisposed());
@@ -169,7 +165,6 @@ public class ResourceCompletableObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
 
             rco.onSubscribe(Disposable.empty());
@@ -190,7 +185,6 @@ public class ResourceCompletableObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestResourceCompletableObserver rco = new TestResourceCompletableObserver();
         rco.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/ResourceMaybeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/ResourceMaybeObserverTest.java
@@ -67,14 +67,12 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
         rmo.add(null);
     }
 
     @Test
     public void addResources() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
@@ -100,7 +98,6 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
@@ -120,7 +117,6 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onSuccessCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
@@ -140,7 +136,6 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
         assertFalse(rmo.isDisposed());
@@ -220,7 +215,6 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
 
             rmo.onSubscribe(Disposable.empty());
@@ -241,7 +235,6 @@ public class ResourceMaybeObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestResourceMaybeObserver<Integer> rmo = new TestResourceMaybeObserver<>();
         rmo.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/ResourceObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/ResourceObserverTest.java
@@ -67,14 +67,12 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        @SuppressWarnings("resource")
         TestResourceObserver<Integer> ro = new TestResourceObserver<>();
         ro.add(null);
     }
 
     @Test
     public void addResources() {
-        @SuppressWarnings("resource")
         TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
@@ -100,7 +98,6 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
@@ -120,7 +117,6 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceObserver<Integer> ro = new TestResourceObserver<>();
 
         assertFalse(ro.isDisposed());
@@ -180,7 +176,6 @@ public class ResourceObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestResourceObserver<Integer> tc = new TestResourceObserver<>();
 
             tc.onSubscribe(Disposable.empty());
@@ -201,7 +196,6 @@ public class ResourceObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestResourceObserver<Integer> tc = new TestResourceObserver<>();
         tc.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/ResourceSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/ResourceSingleObserverTest.java
@@ -58,14 +58,12 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        @SuppressWarnings("resource")
         TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
         rso.add(null);
     }
 
     @Test
     public void addResources() {
-        @SuppressWarnings("resource")
         TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
@@ -91,7 +89,6 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onSuccessCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
@@ -111,7 +108,6 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
         assertFalse(rso.isDisposed());
@@ -171,7 +167,6 @@ public class ResourceSingleObserverTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
 
             rso.onSubscribe(Disposable.empty());
@@ -192,7 +187,6 @@ public class ResourceSingleObserverTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestResourceSingleObserver<Integer> rso = new TestResourceSingleObserver<>();
         rso.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
@@ -45,7 +45,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onNextFailureSafe() {
         AtomicReference<Throwable> onError = new AtomicReference<>();
         try {
-            @SuppressWarnings("resource")
             SafeObserver<String> safeObserver = new SafeObserver<>(OBSERVER_ONNEXT_FAIL(onError));
             safeObserver.onSubscribe(Disposable.empty());
             safeObserver.onNext("one");
@@ -199,7 +198,6 @@ public class SafeObserverTest extends RxJavaTest {
             public void onComplete() {
             }
         };
-        @SuppressWarnings("resource")
         SafeObserver<Integer> observer = new SafeObserver<>(actual);
 
         assertSame(actual, observer.downstream);
@@ -209,7 +207,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void dispose() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
@@ -228,7 +225,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onNextAfterComplete() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
@@ -250,7 +246,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onNextNull() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
@@ -266,7 +261,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onNextWithoutOnSubscribe() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onNext(1);
@@ -278,7 +272,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onErrorWithoutOnSubscribe() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onError(new TestException());
@@ -293,7 +286,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onCompleteWithoutOnSubscribe() {
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         so.onComplete();
@@ -305,7 +297,6 @@ public class SafeObserverTest extends RxJavaTest {
     public void onNextNormal() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         SafeObserver<Integer> so = new SafeObserver<>(to);
 
         Disposable d = Disposable.empty();
@@ -490,7 +481,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(true, 1, false, false, false);
             SafeObserver<Object> so = cd.toSafe();
 
@@ -522,7 +512,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(false, 1, true, false, false);
             SafeObserver<Object> so = cd.toSafe();
 
@@ -553,7 +542,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(true, 1, false, false, false);
             SafeObserver<Object> so = cd.toSafe();
 
@@ -573,7 +561,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(false, 1, true, false, false);
             SafeObserver<Object> so = cd.toSafe();
 
@@ -612,7 +599,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(true, 1, false, true, false);
             SafeObserver<Object> so = cd.toSafe();
 
@@ -632,7 +618,6 @@ public class SafeObserverTest extends RxJavaTest {
         List<Throwable> list = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             CrashDummy cd = new CrashDummy(false, 1, true, true, false);
             SafeObserver<Object> so = cd.toSafe();
 

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -884,7 +884,6 @@ public class SerializedObserverTest extends RxJavaTest {
     public void dispose() {
         TestObserver<Integer> to = new TestObserver<>();
 
-        @SuppressWarnings("resource")
         SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
         Disposable d = Disposable.empty();
@@ -905,7 +904,6 @@ public class SerializedObserverTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
@@ -927,7 +925,6 @@ public class SerializedObserverTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
@@ -954,7 +951,6 @@ public class SerializedObserverTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             Disposable d = Disposable.empty();
@@ -983,7 +979,6 @@ public class SerializedObserverTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             final SerializedObserver<Integer> so = new SerializedObserver<>(to, true);
 
             Disposable d = Disposable.empty();
@@ -1015,7 +1010,6 @@ public class SerializedObserverTest extends RxJavaTest {
         try {
             TestObserver<Integer> to = new TestObserver<>();
 
-            @SuppressWarnings("resource")
             final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
             so.onSubscribe(Disposable.empty());
@@ -1040,7 +1034,6 @@ public class SerializedObserverTest extends RxJavaTest {
             try {
                 TestObserverEx<Integer> to = new TestObserverEx<>();
 
-                @SuppressWarnings("resource")
                 final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
                 Disposable d = Disposable.empty();
@@ -1078,7 +1071,6 @@ public class SerializedObserverTest extends RxJavaTest {
 
         TestObserverEx<Integer> to = new TestObserverEx<>();
 
-        @SuppressWarnings("resource")
         final SerializedObserver<Integer> so = new SerializedObserver<>(to);
 
         Disposable d = Disposable.empty();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerTests.java
@@ -484,8 +484,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         for (int initial = 0; initial < 2; initial++) {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            @SuppressWarnings("resource")
-            final SequentialDisposable sd = new SequentialDisposable();
+            var sd = new SequentialDisposable();
 
             try {
                 sd.replace(s.schedulePeriodicallyDirect(new Runnable() /* NFI */ {
@@ -518,8 +517,7 @@ public abstract class AbstractSchedulerTests extends RxJavaTest {
         for (int initial = 0; initial < 2; initial++) {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            @SuppressWarnings("resource")
-            final SequentialDisposable sd = new SequentialDisposable();
+            var sd = new SequentialDisposable();
 
             Scheduler.Worker w = s.createWorker();
 

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
@@ -450,7 +450,6 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
         try {
             Scheduler s = Schedulers.from(exec::execute, true);
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-                @SuppressWarnings("resource")
                 SequentialDisposable sd = new SequentialDisposable();
 
                 TestHelper.race(

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerLifecycleTest.java
@@ -69,7 +69,6 @@ public class SchedulerLifecycleTest extends RxJavaTest {
 
         final Runnable countAction = cdl::countDown;
 
-        @SuppressWarnings("resource")
         CompositeDisposable cd = new CompositeDisposable();
 
         try {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -117,7 +117,6 @@ public class SchedulerTest extends RxJavaTest {
 
         TestScheduler scheduler = new TestScheduler();
 
-        @SuppressWarnings("resource")
         final SequentialDisposable sd = new SequentialDisposable();
 
         Disposable d = scheduler.schedulePeriodicallyDirect(() -> {
@@ -145,7 +144,6 @@ public class SchedulerTest extends RxJavaTest {
         Worker worker = scheduler.createWorker();
 
         try {
-            @SuppressWarnings("resource")
             final SequentialDisposable sd = new SequentialDisposable();
 
             Disposable d = worker.schedulePeriodically(() -> {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TrampolineSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TrampolineSchedulerTest.java
@@ -54,7 +54,6 @@ public class TrampolineSchedulerTest extends AbstractSchedulerTests {
     @Test
     public void nestedTrampolineWithUnsubscribe() {
         final ArrayList<String> workDone = new ArrayList<>();
-        @SuppressWarnings("resource")
         final CompositeDisposable workers = new CompositeDisposable();
         Worker worker = Schedulers.trampoline().createWorker();
         try {

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -253,7 +253,6 @@ public class SingleTest extends RxJavaTest {
      */
     @Test
     public void unsubscribe2() throws InterruptedException {
-        @SuppressWarnings("resource")
         final SerialDisposable sd = new SerialDisposable();
         var ts = new SingleObserver<String>() /* NFI */ {
 

--- a/src/test/java/io/reactivex/rxjava4/subscribers/DisposableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/DisposableSubscriberTest.java
@@ -83,7 +83,6 @@ public class DisposableSubscriberTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<>();
 
             tc.onSubscribe(new BooleanSubscription());
@@ -104,7 +103,6 @@ public class DisposableSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestDisposableSubscriber<Integer> tc = new TestDisposableSubscriber<>();
 
         assertFalse(tc.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/ResourceSubscriberTest.java
@@ -71,14 +71,12 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test(expected = NullPointerException.class)
     public void nullResource() {
-        @SuppressWarnings("resource")
         TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
         ro.add(null);
     }
 
     @Test
     public void addResources() {
-        @SuppressWarnings("resource")
         TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
@@ -104,7 +102,6 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void onCompleteCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
@@ -124,7 +121,6 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorCleansUp() {
-        @SuppressWarnings("resource")
         TestResourceSubscriber<Integer> ro = new TestResourceSubscriber<>();
 
         assertFalse(ro.isDisposed());
@@ -165,7 +161,6 @@ public class ResourceSubscriberTest extends RxJavaTest {
         List<Throwable> error = TestHelper.trackPluginErrors();
 
         try {
-            @SuppressWarnings("resource")
             TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<>();
 
             tc.onSubscribe(new BooleanSubscription());
@@ -186,7 +181,6 @@ public class ResourceSubscriberTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        @SuppressWarnings("resource")
         TestResourceSubscriber<Integer> tc = new TestResourceSubscriber<>();
         tc.dispose();
 

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -3528,7 +3528,6 @@ public enum TestHelper {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            @SuppressWarnings("resource")
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Flowable.just(1)
@@ -3594,7 +3593,6 @@ public enum TestHelper {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
 
-            @SuppressWarnings("resource")
             final SerialDisposable disposable = new SerialDisposable();
 
             T result = Observable.just(1)


### PR DESCRIPTION
Making `DIsposable` directly `AutoCloseable` adds unnecessary resource warnings to most spaces. `Disposable` is mainly there to signal dispose/cancel, not specifically resource lifecycles.

The interface no longer extends AutoCloseable, all places where `SuppressWarnings("resource")` have been removed.

A new method `Disposable.asAutoCloseable` was added for the case when a try-with-resources is needed over it.