### PR TITLE
4.x cleanup: spinwait, grammar, minor syntax simplifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,7 @@ jmh {
 def isCI = System.getenv("CI") != null
 def testLoggingConfig = ["skipped", "failed"]
 def parallelism = Runtime.runtime.availableProcessors()
+def heap = "1400m"
 
 if (!isCI) {
     testLoggingConfig = ["failed"]
@@ -187,7 +188,7 @@ if (!isCI) {
 }
 
 test {
-    maxHeapSize = "1200m"
+    maxHeapSize = heap
     maxParallelForks = parallelism
     timeout = Duration.ofMinutes(30)
 
@@ -206,7 +207,7 @@ tasks.register('testNG', Test) {
     // Tell it to use TestNG explicitly
     useTestNG()
 
-    maxHeapSize = "1200m"
+    maxHeapSize = heap
     maxParallelForks = parallelism
     timeout = Duration.ofMinutes(30)
 

--- a/src/jmh/java/io/reactivex/rxjava4/core/OperatorFlatMapPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/OperatorFlatMapPerf.java
@@ -49,7 +49,7 @@ public class OperatorFlatMapPerf {
         PerfSubscriber latchedObserver = input.newLatchedObserver();
         input.flowable.flatMap((Function<Integer, Publisher<Integer>>) i -> Flowable.just(i).subscribeOn(Schedulers.computation())).subscribe(latchedObserver);
         if (input.size == 1) {
-            while (latchedObserver.latch.getCount() != 0) { }
+            while (latchedObserver.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             latchedObserver.latch.await();
         }

--- a/src/jmh/java/io/reactivex/rxjava4/core/OperatorMergePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/OperatorMergePerf.java
@@ -35,7 +35,7 @@ public class OperatorMergePerf {
         Flowable.merge(os).subscribe(o);
 
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }
@@ -49,7 +49,7 @@ public class OperatorMergePerf {
         Flowable.merge(os).subscribe(o);
 
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }
@@ -61,7 +61,7 @@ public class OperatorMergePerf {
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }
@@ -73,7 +73,7 @@ public class OperatorMergePerf {
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(os).subscribe(o);
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }
@@ -85,7 +85,7 @@ public class OperatorMergePerf {
         Flowable<Integer> ob = Flowable.range(0, input.size).subscribeOn(Schedulers.computation());
         Flowable.merge(ob, ob).subscribe(o);
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }
@@ -96,7 +96,7 @@ public class OperatorMergePerf {
         PerfSubscriber o = input.newLatchedObserver();
         Flowable.merge(input.observables).subscribe(o);
         if (input.size == 1) {
-            while (o.latch.getCount() != 0) { }
+            while (o.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             o.latch.await();
         }

--- a/src/jmh/java/io/reactivex/rxjava4/core/PerfAsyncConsumer.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/PerfAsyncConsumer.java
@@ -73,7 +73,7 @@ SingleObserver<Object>, CompletableObserver, MaybeObserver<Object> {
      */
     public PerfAsyncConsumer await(int count) {
         if (count <= 1000) {
-            while (getCount() != 0) { }
+            while (getCount() != 0) { Thread.onSpinWait(); }
         } else {
             try {
                 await();

--- a/src/jmh/java/io/reactivex/rxjava4/core/RangePerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/RangePerf.java
@@ -63,7 +63,7 @@ public class RangePerf {
         rangeAsync.subscribe(lo);
 
         if (times == 1) {
-            while (lo.latch.getCount() != 0) { }
+            while (lo.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             lo.latch.await();
         }
@@ -76,7 +76,7 @@ public class RangePerf {
         rangeAsyncPipeline.subscribe(lo);
 
         if (times == 1) {
-            while (lo.latch.getCount() != 0) { }
+            while (lo.latch.getCount() != 0) { Thread.onSpinWait(); }
         } else {
             lo.latch.await();
         }

--- a/src/jmh/java/io/reactivex/rxjava4/core/TakeUntilPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/TakeUntilPerf.java
@@ -48,13 +48,13 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         flowable = Flowable.range(1, 1000 * 1000).takeUntil(Flowable.fromCallable((Callable<Object>) () -> {
             int c = count;
-            while (items < c) { }
+            while (items < c) { Thread.onSpinWait(); }
             return 1;
         }).subscribeOn(Schedulers.single()));
 
         observable = Observable.range(1, 1000 * 1000).takeUntil(Observable.fromCallable((Callable<Object>) () -> {
             int c = count;
-            while (items < c) { }
+            while (items < c) { Thread.onSpinWait(); }
             return 1;
         }).subscribeOn(Schedulers.single()));
     }
@@ -65,7 +65,7 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         flowable.subscribe(this, Functions.emptyConsumer(), cdl::countDown);
 
-        while (cdl.getCount() != 0) { }
+        while (cdl.getCount() != 0) { Thread.onSpinWait(); }
     }
 
     @Benchmark
@@ -74,6 +74,6 @@ public class TakeUntilPerf implements Consumer<Integer> {
 
         observable.subscribe(this, Functions.emptyConsumer(), cdl::countDown);
 
-        while (cdl.getCount() != 0) { }
+        while (cdl.getCount() != 0) { Thread.onSpinWait(); }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -14526,7 +14526,7 @@ FlowableDocBasic<T>
      * <img width="640" height="430" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/retryWhen.f.v3.png" alt="">
      * <p>
      * Example:
-     *
+     * <p>
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
      * <pre><code>

--- a/src/main/java/io/reactivex/rxjava4/core/FlowableSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/core/FlowableSubscriber.java
@@ -35,7 +35,7 @@ public interface FlowableSubscriber<@NonNull T> extends Subscriber<T> {
      * calling {@link Subscription#request(long)}. In practice this means
      * no initialization should happen after the {@code request()} call and
      * additional behavior is thread safe in respect to {@code onNext}.
-     *
+     * <p>
      * {@inheritDoc}
      */
     @Override

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -4358,7 +4358,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * <img width="640" height="405" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.retryWhen.png" alt="">
      * <p>
      * Example:
-     *
+     * <p>
      * This retries 3 times, each time incrementing the number of seconds it waits.
      *
      * <pre><code>
@@ -5391,7 +5391,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
     /**
      * Waits until this and the other {@link MaybeSource} signal a success value then applies the given {@link BiFunction}
      * to those values and emits the {@code BiFunction}'s resulting value to downstream.
-     *
+     * <p>
      * <img width="640" height="451" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.zipWith.png" alt="">
      *
      * <p>If either this or the other {@code MaybeSource} is empty or signals an error, the resulting {@code Maybe} will

--- a/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
@@ -21,14 +21,14 @@ import io.reactivex.rxjava4.annotations.NonNull;
 /**
  * Represents an exception that is a composite of one or more other exceptions. A {@code CompositeException}
  * does not modify the structure of any exception it wraps, but at print-time it iterates through the list of
- * Throwables contained in the composite in order to print them all.
- *
+ * {@link Throwable}s contained in the composite in order to print them all.
+ * <p>
  * Its invariant is to contain an immutable, ordered (by insertion order), unique list of non-composite
  * exceptions. You can retrieve individual exceptions in this list with {@link #getExceptions()}.
- *
+ * <p>
  * The {@link #printStackTrace()} implementation handles the StackTrace in a customized way instead of using
  * {@code getCause()} so that it can avoid circular references.
- *
+ * <p>
  * If you invoke {@link #getCause()}, it will lazily create the causal chain but will stop if it finds any
  * Throwable in the chain that it has already seen.
  */
@@ -42,9 +42,9 @@ public final class CompositeException extends RuntimeException {
     private Throwable cause;
 
     /**
-     * Constructs a CompositeException with the given array of Throwables as the
+     * Constructs a CompositeException with the given array of {@link Throwable}s as the
      * list of suppressed exceptions.
-     * @param exceptions the Throwables to have as initially suppressed exceptions
+     * @param exceptions the {@code Throwable}s to have as initially suppressed exceptions
      *
      * @throws IllegalArgumentException if <code>exceptions</code> is empty.
      */
@@ -54,9 +54,9 @@ public final class CompositeException extends RuntimeException {
     }
 
     /**
-     * Constructs a CompositeException with the given array of Throwables as the
+     * Constructs a CompositeException with the given sequence of {@link Throwable}s as the
      * list of suppressed exceptions.
-     * @param errors the Throwables to have as initially suppressed exceptions
+     * @param errors the {@code Throwable}s to have as initially suppressed exceptions
      *
      * @throws IllegalArgumentException if <code>errors</code> is empty.
      */
@@ -64,14 +64,10 @@ public final class CompositeException extends RuntimeException {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<>();
         if (errors != null) {
             for (Throwable ex : errors) {
-                if (ex instanceof CompositeException) {
-                    deDupedExceptions.addAll(((CompositeException) ex).getExceptions());
+                if (ex instanceof CompositeException ce) {
+                    deDupedExceptions.addAll(ce.getExceptions());
                 } else
-                if (ex != null) {
-                    deDupedExceptions.add(ex);
-                } else {
-                    deDupedExceptions.add(new NullPointerException("Throwable was null!"));
-                }
+                    deDupedExceptions.add(Objects.requireNonNullElseGet(ex, () -> new NullPointerException("Throwable was null!")));
             }
         } else {
             deDupedExceptions.add(new NullPointerException("errors was null"));
@@ -104,7 +100,7 @@ public final class CompositeException extends RuntimeException {
     @NonNull
     public synchronized Throwable getCause() { // NOPMD
         if (cause == null) {
-            String separator = System.getProperty("line.separator");
+            String separator = System.lineSeparator();
             if (exceptions.size() > 1) {
                 Map<Throwable, Boolean> seenCauses = new IdentityHashMap<>();
 
@@ -164,9 +160,9 @@ public final class CompositeException extends RuntimeException {
     }
 
     /**
-     * All of the following {@code printStackTrace} functionality is derived from JDK {@link Throwable}
+     * All the following {@code printStackTrace} functionality is derived from JDK {@link Throwable}
      * {@code printStackTrace}. In particular, the {@code PrintStreamOrWriter} abstraction is copied wholesale.
-     *
+     * <p>
      * Changes from the official JDK implementation:<ul>
      * <li>no infinite loop detection</li>
      * <li>smaller critical section holding {@link PrintStream} lock</li>

--- a/src/main/java/io/reactivex/rxjava4/exceptions/Exceptions.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/Exceptions.java
@@ -55,9 +55,9 @@ public final class Exceptions {
      * <li>{@code LinkageError}</li>
      * </ul>
      * This can be useful if you are writing an operator that calls user-supplied code, and you want to
-     * notify subscribers of errors encountered in that code by calling their {@code onError} methods, but only
-     * if the errors are not so catastrophic that such a call would be futile, in which case you simply want to
-     * rethrow the error.
+     * notify subscribers of errors encountered in that code by calling their {@code onError} methods.
+     * But only if the errors are not so catastrophic that such a call would be futile, in which case
+     * you simply want to rethrow the error.
      *
      * @param t
      *         the {@code Throwable} to test and perhaps throw

--- a/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
@@ -31,7 +31,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
 
     /**
      * Customizes the {@code Throwable} with a custom message and wraps it before it
-     * is signalled to the {@code RxJavaPlugins.onError()} handler as {@code OnErrorNotImplementedException}.
+     * is signaled to the {@code RxJavaPlugins.onError()} handler as {@code OnErrorNotImplementedException}.
      *
      * @param message
      *          the message to assign to the {@code Throwable} to signal
@@ -44,7 +44,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
 
     /**
      * Wraps the {@code Throwable} before it
-     * is signalled to the {@code RxJavaPlugins.onError()}
+     * is signaled to the {@code RxJavaPlugins.onError()}
      * handler as {@code OnErrorNotImplementedException}.
      *
      * @param e

--- a/src/main/java/io/reactivex/rxjava4/flowables/ConnectableFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/flowables/ConnectableFlowable.java
@@ -44,8 +44,8 @@ import io.reactivex.rxjava4.schedulers.Schedulers;
  * {@code reset()} in this case.
  * <p>
  * Note that although {@link #connect()} and {@link #reset()} are safe to call from multiple threads, it is recommended
- * a dedicated thread or business logic manages the connection or resetting of a {@code ConnectableFlowable} so that
- * there is no unwanted signal loss due to early {@code connect()} or {@code reset()} calls while {@code Subscriber}s are
+ * a dedicated thread or business logic manages the connection or resetting of a {@code ConnectableFlowable}.
+ * This ensures there is no unwanted signal loss due to early {@code connect()} or {@code reset()} calls while {@code Subscriber}s are
  * still being subscribed to this {@code ConnectableFlowable} to receive signals from the get-go.
  * <p>
  * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Connectable-Observable-Operators">RxJava Wiki: Connectable Observable Operators</a>
@@ -279,7 +279,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * during the lifetime of the returned {@code Flowable}. If this {@code ConnectableFlowable}
      * terminates, the connection is never renewed, no matter how {@code Subscriber}s come
      * and go. Use {@link #refCount()} to renew a connection or dispose an active
-     * connection when all {@code Subscriber}s have cancelled their {@link Subscription}s.
+     * connection when all {@code Subscriber}s have canceled their {@link Subscription}s.
      * <p>
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
@@ -314,7 +314,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * during the lifetime of the returned {@code Flowable}. If this {@code ConnectableFlowable}
      * terminates, the connection is never renewed, no matter how {@code Subscriber}s come
      * and go. Use {@link #refCount()} to renew a connection or dispose an active
-     * connection when all {@code Subscriber}s have cancelled their {@link Subscription}s.
+     * connection when all {@code Subscriber}s have canceled their {@link Subscription}s.
      * <p>
      * This overload does not allow disconnecting the connection established via
      * {@link #connect(Consumer)}. Use the {@link #autoConnect(int, Consumer)} overload
@@ -352,7 +352,7 @@ public abstract class ConnectableFlowable<T> extends Flowable<T> {
      * during the lifetime of the returned {@code Flowable}. If this {@code ConnectableFlowable}
      * terminates, the connection is never renewed, no matter how {@code Subscriber}s come
      * and go. Use {@link #refCount()} to renew a connection or dispose an active
-     * connection when all {@code Subscriber}s have cancelled their {@link Subscription}s.
+     * connection when all {@code Subscriber}s have canceled their {@link Subscription}s.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArray.java
@@ -388,7 +388,7 @@ public final class MaybeMergeArray<T> extends Flowable<T> {
 
         @Override
         public void clear() {
-            while (poll() != null && !isEmpty()) { }
+            while (poll() != null && !isEmpty()) { Thread.onSpinWait(); }
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/queue/MpscLinkedQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/queue/MpscLinkedQueue.java
@@ -98,7 +98,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
         }
         else if (currConsumerNode != lvProducerNode()) {
             // spin, we are no longer wait free
-            while ((nextNode = currConsumerNode.lvNext()) == null) { } // NOPMD
+            while ((nextNode = currConsumerNode.lvNext()) == null) { Thread.onSpinWait(); } // NOPMD
             // got the next node...
 
             // we have to null out the value because we are going to hang on to the node
@@ -120,7 +120,7 @@ public final class MpscLinkedQueue<T> implements SimplePlainQueue<T> {
 
     @Override
     public void clear() {
-        while (poll() != null && !isEmpty()) { } // NOPMD
+        while (poll() != null && !isEmpty()) { Thread.onSpinWait(); } // NOPMD
     }
     LinkedQueueNode<T> lvProducerNode() {
         return producerNode.get();

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/BlockingCurrentThreadScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/BlockingCurrentThreadScheduler.java
@@ -259,7 +259,7 @@ public final class BlockingCurrentThreadScheduler extends Scheduler {
                     }
                 }
             } finally {
-                while (get() == INTERRUPTING) { }
+                while (get() == INTERRUPTING) { Thread.onSpinWait(); }
 
                 if (get() == INTERRUPTED) {
                     Thread.interrupted();
@@ -385,7 +385,7 @@ public final class BlockingCurrentThreadScheduler extends Scheduler {
                         }
                     }
                 } finally {
-                    while (get() == INTERRUPTING) { }
+                    while (get() == INTERRUPTING) { Thread.onSpinWait(); }
 
                     if (get() == INTERRUPTED) {
                         Thread.interrupted();

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/EmptySubscription.java
@@ -87,7 +87,8 @@ public enum EmptySubscription implements QueueSubscription<Object> {
 
     @Override
     public int requestFusion(int mode) {
-        return mode & ASYNC; // accept async mode: an onComplete or onError will be signalled after anyway
+        // accept async mode: an onComplete or onError will be signaled after anyway
+        return mode & ASYNC;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/util/OpenHashSet.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/OpenHashSet.java
@@ -141,16 +141,15 @@ public final class OpenHashSet<T> {
         T[] b = (T[])new Object[newCap];
 
         for (int j = size; j-- != 0; ) {
-            while (true) {
-                if (a[--i] != null) {
-                    break;
-                }
-            }
+            while (a[--i] == null) { } // NOPMD
             int pos = mix(a[i].hashCode()) & m;
             if (b[pos] != null) {
-                do {
+                for (;;) {
                     pos = (pos + 1) & m;
-                } while (b[pos] != null);
+                    if (b[pos] == null) {
+                        break;
+                    }
+                }
             }
             b[pos] = a[i];
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/util/OpenHashSet.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/OpenHashSet.java
@@ -141,15 +141,16 @@ public final class OpenHashSet<T> {
         T[] b = (T[])new Object[newCap];
 
         for (int j = size; j-- != 0; ) {
-            while (a[--i] == null) { } // NOPMD
+            while (true) {
+                if (a[--i] != null) {
+                    break;
+                }
+            }
             int pos = mix(a[i].hashCode()) & m;
             if (b[pos] != null) {
-                for (;;) {
+                do {
                     pos = (pos + 1) & m;
-                    if (b[pos] == null) {
-                        break;
-                    }
-                }
+                } while (b[pos] != null);
             }
             b[pos] = a[i];
         }

--- a/src/main/java/io/reactivex/rxjava4/observables/ConnectableObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/observables/ConnectableObservable.java
@@ -42,8 +42,8 @@ import io.reactivex.rxjava4.schedulers.Schedulers;
  * {@link #reset()} in this case.
  * <p>
  * Note that although {@link #connect()} and {@link #reset()} are safe to call from multiple threads, it is recommended
- * a dedicated thread or business logic manages the connection or resetting of a {@code ConnectableObservable} so that
- * there is no unwanted signal loss due to early {@code connect()} or {@code reset()} calls while {@code Observer}s are
+ * a dedicated thread or business logic manages the connection or resetting of a {@code ConnectableObservable}.
+ * This ensures there is no unwanted signal loss due to early {@code connect()} or {@code reset()} calls while {@code Observer}s are
  * still being subscribed to this {@code ConnectableObservable} to receive signals from the get-go.
  *
  * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Connectable-Observable-Operators">RxJava Wiki: Connectable Observable Operators</a>

--- a/src/main/java/io/reactivex/rxjava4/observers/SafeObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/SafeObserver.java
@@ -116,23 +116,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
     void onNextNoSubscription() {
         done = true;
 
-        Throwable ex = new NullPointerException("Subscription not set!");
-
-        try {
-            downstream.onSubscribe(EmptyDisposable.INSTANCE);
-        } catch (Throwable e) {
-            Exceptions.throwIfFatal(e);
-            // can't call onError because the actual's state may be corrupt at this point
-            RxJavaPlugins.onError(new CompositeException(ex, e));
-            return;
-        }
-        try {
-            downstream.onError(ex);
-        } catch (Throwable e) {
-            Exceptions.throwIfFatal(e);
-            // if onError failed, all that's left is to report the error to plugins
-            RxJavaPlugins.onError(new CompositeException(ex, e));
-        }
+        onCompleteNoSubscription();
     }
 
     @Override
@@ -200,7 +184,7 @@ public final class SafeObserver<T> implements Observer<T>, Disposable {
 
     void onCompleteNoSubscription() {
 
-        Throwable ex = new NullPointerException("Subscription not set!");
+        var ex = new NullPointerException("Subscription not set!");
 
         try {
             downstream.onSubscribe(EmptyDisposable.INSTANCE);

--- a/src/main/java/io/reactivex/rxjava4/operators/SimpleQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/operators/SimpleQueue.java
@@ -31,7 +31,7 @@ public interface SimpleQueue<@NonNull T> {
      * Atomically enqueue a single value.
      * @param value the value to enqueue, not null
      * @return true if successful, false if the value was not enqueued
-     * likely due to reaching the queue capacity)
+     * likely due to reaching the queue capacity
      */
     boolean offer(@NonNull T value);
 
@@ -40,7 +40,7 @@ public interface SimpleQueue<@NonNull T> {
      * @param v1 the first value to enqueue, not null
      * @param v2 the second value to enqueue, not null
      * @return true if successful, false if the value was not enqueued
-     * likely due to reaching the queue capacity)
+     * likely due to reaching the queue capacity
      */
     boolean offer(@NonNull T v1, @NonNull T v2);
 

--- a/src/main/java/io/reactivex/rxjava4/operators/SpscArrayQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/operators/SpscArrayQueue.java
@@ -30,8 +30,8 @@ import io.reactivex.rxjava4.internal.util.Pow2;
  * This implementation is a mashup of the <a href="http://sourceforge.net/projects/mc-fastflow/">Fast Flow</a>
  * algorithm with an optimization of the offer method taken from the <a
  * href="http://staff.ustc.edu.cn/~bhua/publications/IJPP_draft.pdf">BQueue</a> algorithm (a variation on Fast
- * Flow), and adjusted to comply with Queue.offer semantics regarding capacity.<br>
- * For convenience the relevant papers are available in the resources folder:<br>
+ * Flow), and adjusted to comply with {@link java.util.Queue#offer(Object)} semantics regarding capacity.<br>
+ * For convenience the relevant papers are available in the {@code resources} folder:<br>
  * <i>2010 - Pisa - SPSC Queues on Shared Cache Multi-Core Systems.pdf<br>
  * 2012 - Junchang- BQueue- Efficient and Practical Queuing.pdf <br>
  * </i> This implementation is wait free.
@@ -122,7 +122,9 @@ public final class SpscArrayQueue<E> extends AtomicReferenceArray<E> implements 
     @Override
     public void clear() {
         // we have to test isEmpty because of the weaker poll() guarantee
-        while (poll() != null || !isEmpty()) { } // NOPMD
+        while (poll() != null || !isEmpty()) {
+            Thread.onSpinWait();
+        } // NOPMD
     }
 
     int calcElementOffset(long index, int mask) {

--- a/src/main/java/io/reactivex/rxjava4/operators/SpscLinkedArrayQueue.java
+++ b/src/main/java/io/reactivex/rxjava4/operators/SpscLinkedArrayQueue.java
@@ -194,7 +194,9 @@ public final class SpscLinkedArrayQueue<T> implements SimplePlainQueue<T> {
 
     @Override
     public void clear() {
-        while (poll() != null || !isEmpty()) { } // NOPMD
+        while (poll() != null || !isEmpty()) {
+            Thread.onSpinWait();
+        } // NOPMD
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCovarianceTest.java
@@ -27,8 +27,8 @@ import io.reactivex.rxjava4.testsupport.TestSubscriberEx;
 
 /**
  * Test super/extends of generics.
- *
- * See https://github.com/Netflix/RxJava/pull/331
+ * <p>
+ * See <a href="https://github.com/Netflix/RxJava/pull/331">...</a>
  */
 public class FlowableCovarianceTest extends RxJavaTest {
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableReduceTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableReduceTests.java
@@ -44,8 +44,8 @@ public class FlowableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceWithCovariantObjectsFlowable() {
@@ -78,8 +78,8 @@ public class FlowableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceWithCovariantObjects() {
@@ -92,8 +92,8 @@ public class FlowableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceCovariance() {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -265,8 +265,8 @@ public class FlowableTests extends RxJavaTest {
 
     /**
      * A reduce on an empty Observable and a seed should just pass the seed through.
-     *
-     * This is confirmed at https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642456
+     * <p>
+     * This is confirmed at <a href="https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642456">...</a>
      */
     @Test
     public void reduceWithEmptyObservableAndSeed() {
@@ -304,9 +304,9 @@ public class FlowableTests extends RxJavaTest {
 
     /**
      * The error from the user provided Observer is not handled by the subscribe method try/catch.
-     *
+     * <p>
      * It is handled by the AtomicObserver that wraps the provided Observer.
-     *
+     * <p>
      * Result: Passes (if AtomicObserver functionality exists)
      * @throws InterruptedException if the test is interrupted
      */
@@ -356,7 +356,7 @@ public class FlowableTests extends RxJavaTest {
 
     /**
      * The error from the user provided Observer is handled by the subscribe try/catch because this is synchronous.
-     *
+     * <p>
      * Result: Passes
      */
     @Test
@@ -398,7 +398,7 @@ public class FlowableTests extends RxJavaTest {
 
     /**
      * The error from the user provided Observable is handled by the subscribe try/catch because this is synchronous.
-     *
+     * <p>
      * Result: Passes
      */
     @Test

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
@@ -69,7 +69,7 @@ public class FlowableZipTests extends RxJavaTest {
     /**
      * Occasionally zip may be invoked with 0 observables. Test that we don't block indefinitely instead
      * of immediately invoking zip with 0 argument.
-     *
+     * <p>
      * We now expect an NoSuchElementException since last() requires at least one value and nothing will be emitted.
      */
     @Test(expected = NoSuchElementException.class)

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
@@ -416,13 +416,13 @@ public class FlowableFromStreamTest extends RxJavaTest {
                         AtomicInteger sync = new AtomicInteger(2);
                         exec.submit(() -> {
                             if (sync.decrementAndGet() != 0) {
-                                while (sync.get() != 0) { }
+                                while (sync.get() != 0) { Thread.onSpinWait(); }
                             }
                             upstream.request(1);
                         });
 
                         if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
+                            while (sync.get() != 0) { Thread.onSpinWait(); }
                         }
                     }
 
@@ -496,7 +496,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnItemCrash() {
         AtomicInteger calls = new AtomicInteger();
         AtomicInteger counter = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Flowable.fromStream(Stream.generate(() -> {
             int value = counter.getAndIncrement();
             if (value == 1) {
                 throw new TestException();
@@ -538,7 +538,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
     public void closeCalledOnItemCrashConditional() {
         AtomicInteger calls = new AtomicInteger();
         AtomicInteger counter = new AtomicInteger();
-        Flowable.fromStream(Stream.<Integer>generate(() -> {
+        Flowable.fromStream(Stream.generate(() -> {
             int value = counter.getAndIncrement();
             if (value == 1) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBlockingTest.java
@@ -298,7 +298,7 @@ public class FlowableBlockingTest extends RxJavaTest {
     }
 
     @Test
-    public void firstFgnoredCancelAndOnNext() {
+    public void firstIgnoredCancelAndOnNext() {
         Flowable<Integer> source = Flowable.fromPublisher(s -> {
             s.onSubscribe(new BooleanSubscription());
             s.onNext(1);
@@ -407,7 +407,7 @@ public class FlowableBlockingTest extends RxJavaTest {
     }
 
     @Test
-    public void blockinsSubscribeCancelAsync() {
+    public void blockingSubscribeCancelAsync() {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
@@ -421,13 +421,13 @@ public class FlowableBlockingTest extends RxJavaTest {
 
             Schedulers.computation().scheduleDirect(() -> {
                 c.decrementAndGet();
-                while (c.get() != 0 && !pp.hasSubscribers()) { }
+                while (c.get() != 0 && !pp.hasSubscribers()) { Thread.onSpinWait(); }
 
                 TestHelper.race(r1, r2);
             });
 
             c.decrementAndGet();
-            while (c.get() != 0) { }
+            while (c.get() != 0) { Thread.onSpinWait(); }
 
             pp
             .blockingSubscribe(ts);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -985,12 +985,12 @@ public class FlowableGroupByTest extends RxJavaTest {
 
     /**
      * Issue #3425.
-     *
+     * <p>
      * The problem is that a request of 1 may create a new group, emit to the desired group
      * or emit to a completely different group. In this test, the merge requests N which
      * must be produced by the range, however it will create a bunch of groups before the actual
      * group receives a value.
-     * 
+     * <p>
      * 12/03/2019: this test produces abandoned groups and as such keeps producing new groups
      * that have to be ready to be received by observeOn and merge.
      */

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -681,7 +681,7 @@ public class FlowableMergeTest extends RxJavaTest {
 
     /**
      * This is the same as the upstreams ones, but now adds the downstream as well by using observeOn.
-     *
+     * <p>
      * This requires merge to also obey the {@link Subscription#request(long)} values coming from it's child subscriber.
      * @throws InterruptedException if the test is interrupted
      */
@@ -760,10 +760,10 @@ public class FlowableMergeTest extends RxJavaTest {
     /**
      * Currently there is no solution to this ... we can't exert backpressure on the outer Flowable if we
      * can't know if the ones we've received so far are going to emit or not, otherwise we could starve the system.
-     *
+     * <p>
      * For example, 10,000 Flowables are being merged (bad use case to begin with, but ...) and it's only one of them
      * that will ever emit. If backpressure only allowed the first 1,000 to be sent, we would hang and never receive an event.
-     *
+     * <p>
      * Thus, we must allow all Flowables to be sent. The ScalarSynchronousFlowable use case is an exception to this since
      * we can grab the value synchronously.
      *

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -228,7 +228,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
      * Attempts to confirm that when pauses exist between events, the ScheduledObserver
      * does not lose or reorder any events since the scheduler will not block, but will
      * be re-scheduled when it receives new events after each pause.
-     *
+     * <p>
      *
      * This is non-deterministic in proving success, but if it ever fails (non-deterministically)
      * it is a sign of potential issues as thread-races and scheduling should not affect output.
@@ -509,12 +509,8 @@ public class FlowableObserveOnTest extends RxJavaTest {
         assertEquals(1, errors.size());
         System.out.println("Errors: " + errors);
         Throwable t = errors.getFirst();
-        if (t instanceof QueueOverflowException) {
-            // success, we expect this
-        } else {
-            if (t.getCause() instanceof QueueOverflowException) {
-                // this is also okay
-            } else {
+        if (!(t instanceof QueueOverflowException)) {
+            if (!(t.getCause() instanceof QueueOverflowException)) {
                 fail("Expecting QueueOverflowException");
             }
         }
@@ -534,7 +530,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             final PublishProcessor<Long> processor = PublishProcessor.create();
 
             final AtomicLong counter = new AtomicLong();
-            TestSubscriberEx<Long> ts = new TestSubscriberEx<>(new DefaultSubscriber<Long>() /* NFI */ {
+            var ts = new TestSubscriberEx<>(new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReduceTest.java
@@ -313,7 +313,7 @@ public class FlowableReduceTest extends RxJavaTest {
 
     /**
      * Make sure an asynchronous reduce with flatMap works.
-     * Original Reactor-Core test case: https://gist.github.com/jurna/353a2bd8ff83f0b24f0b5bc772077d61
+     * Original Reactor-Core test case: <a href="https://gist.github.com/jurna/353a2bd8ff83f0b24f0b5bc772077d61">...</a>
      */
     @Test
     public void shouldReduceTo10Events() {
@@ -335,7 +335,7 @@ public class FlowableReduceTest extends RxJavaTest {
 
     /**
      * Make sure an asynchronous reduce with flatMap works.
-     * Original Reactor-Core test case: https://gist.github.com/jurna/353a2bd8ff83f0b24f0b5bc772077d61
+     * Original Reactor-Core test case: <a href="https://gist.github.com/jurna/353a2bd8ff83f0b24f0b5bc772077d61">...</a>
      */
     @Test
     public void shouldReduceTo10EventsFlowable() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -664,7 +664,7 @@ public class ObservableMergeTest extends RxJavaTest {
 
     /**
      * This is the same as the upstreams ones, but now adds the downstream as well by using observeOn.
-     *
+     * <p>
      * This requires merge to also obey the {@link java.util.concurrent.Flow.Subscription#request(long)} values coming from its child Observer.
      * @throws InterruptedException if the test is interrupted
      */
@@ -711,10 +711,10 @@ public class ObservableMergeTest extends RxJavaTest {
     /**
      * Currently there is no solution to this ... we can't exert backpressure on the outer Observable if we
      * can't know if the ones we've received so far are going to emit or not, otherwise we could starve the system.
-     *
+     * <p>
      * For example, 10,000 Observables are being merged (bad use case to begin with, but ...) and it's only one of them
      * that will ever emit. If backpressure only allowed the first 1,000 to be sent, we would hang and never receive an event.
-     *
+     * <p>
      * Thus, we must allow all Observables to be sent. The ScalarSynchronousObservable use case is an exception to this since
      * we can grab the value synchronously.
      *

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/ScheduledRunnableTest.java
@@ -247,10 +247,10 @@ public class ScheduledRunnableTest extends RxJavaTest {
             Runnable r0 = () -> {
                 set.dispose();
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 if (syncb.decrementAndGet() != 0) {
-                    while (syncb.get() != 0) { }
+                    while (syncb.get() != 0) { Thread.onSpinWait(); }
                 }
                 for (int j = 0; j < 1000; j++) {
                     if (Thread.currentThread().isInterrupted()) {
@@ -267,11 +267,11 @@ public class ScheduledRunnableTest extends RxJavaTest {
 
             Runnable r2 = () -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 run.setFuture(ft);
                 if (syncb.decrementAndGet() != 0) {
-                    while (syncb.get() != 0) { }
+                    while (syncb.get() != 0) { Thread.onSpinWait(); }
                 }
             };
 

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/TrampolineSchedulerInternalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/TrampolineSchedulerInternalTest.java
@@ -187,12 +187,12 @@ public class TrampolineSchedulerInternalTest extends RxJavaTest {
 
                 Schedulers.single().scheduleDirect(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     d.dispose();
                 });
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
             });
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -317,13 +317,13 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
                 w.schedule(() -> {
                     ready.decrementAndGet();
-                    while (ready.get() != 0) { }
+                    while (ready.get() != 0) { Thread.onSpinWait(); }
 
                     ts.request(1);
                 });
 
                 ready.decrementAndGet();
-                while (ready.get() != 0) { }
+                while (ready.get() != 0) { Thread.onSpinWait(); }
 
                 ds.onComplete();
 
@@ -358,20 +358,20 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
                 w.schedule(() -> {
                     ready.decrementAndGet();
-                    while (ready.get() != 0) { }
+                    while (ready.get() != 0) { Thread.onSpinWait(); }
 
                     ts.request(1);
                 });
 
                 w2.schedule(() -> {
                     ready.decrementAndGet();
-                    while (ready.get() != 0) { }
+                    while (ready.get() != 0) { Thread.onSpinWait(); }
 
                     ts.request(1);
                 });
 
                 ready.decrementAndGet();
-                while (ready.get() != 0) { }
+                while (ready.get() != 0) { Thread.onSpinWait(); }
 
                 ds.onComplete();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
@@ -23,7 +23,7 @@ import io.reactivex.rxjava4.core.Observable;
 
 /**
  * Generate a table of available operators across base classes in {@code Operator-Matrix.md}.
- * 
+ * <p>
  * Should be run with the main project directory as working directory where the {@code docs}
  * folder is.
  */

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualResumableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualResumableTest.java
@@ -47,7 +47,7 @@ public class VirtualResumableTest {
             var t = new Thread(ready1::await);
             t.start();
 
-            while (ready1.get() == null) { }
+            while (ready1.get() == null) { Thread.onSpinWait(); }
             try {
                 ready1.await();
             } catch (IllegalStateException ex) {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableCovarianceTest.java
@@ -27,8 +27,8 @@ import io.reactivex.rxjava4.testsupport.TestObserverEx;
 
 /**
  * Test super/extends of generics.
- *
- * See https://github.com/Netflix/RxJava/pull/331
+ * <p>
+ * See <a href="https://github.com/Netflix/RxJava/pull/331">...</a>
  */
 public class ObservableCovarianceTest extends RxJavaTest {
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableReduceTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableReduceTests.java
@@ -44,8 +44,8 @@ public class ObservableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceWithCovariantObjectsObservable() {
@@ -78,8 +78,8 @@ public class ObservableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceWithCovariantObjects() {
@@ -92,8 +92,8 @@ public class ObservableReduceTests extends RxJavaTest {
 
     /**
      * Reduce consumes and produces T so can't do covariance.
-     *
-     * https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016
+     * <p>
+     * <a href="https://github.com/ReactiveX/RxJava/issues/360#issuecomment-24203016">...</a>
      */
     @Test
     public void reduceCovariance() {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
@@ -261,8 +261,8 @@ public class ObservableTest extends RxJavaTest {
 
     /**
      * A reduce on an empty Observable and a seed should just pass the seed through.
-     *
-     * This is confirmed at https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642456
+     * <p>
+     * This is confirmed at <a href="https://github.com/ReactiveX/RxJava/issues/423#issuecomment-27642456">...</a>
      */
     @Test
     public void reduceWithEmptyObservableAndSeed() {
@@ -312,9 +312,9 @@ public class ObservableTest extends RxJavaTest {
 
     /**
      * The error from the user provided Observer is not handled by the subscribe method try/catch.
-     *
+     * <p>
      * It is handled by the AtomicObserver that wraps the provided Observer.
-     *
+     * <p>
      * Result: Passes (if AtomicObserver functionality exists)
      * @throws InterruptedException if the test is interrupted
      */
@@ -364,7 +364,7 @@ public class ObservableTest extends RxJavaTest {
 
     /**
      * The error from the user provided Observer is handled by the subscribe try/catch because this is synchronous.
-     *
+     * <p>
      * Result: Passes
      */
     @Test
@@ -406,7 +406,7 @@ public class ObservableTest extends RxJavaTest {
 
     /**
      * The error from the user provided Observable is handled by the subscribe try/catch because this is synchronous.
-     *
+     * <p>
      *
      * Result: Passes
      */

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
@@ -74,7 +74,7 @@ public class ObservableZipTests extends RxJavaTest {
     /**
      * Occasionally zip may be invoked with 0 observables. Test that we don't block indefinitely instead
      * of immediately invoking zip with 0 argument.
-     *
+     * <p>
      * We now expect an NoSuchElementException since last() requires at least one value and nothing will be emitted.
      */
     @Test(expected = NoSuchElementException.class)

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -336,18 +336,18 @@ public class SerializedObserverTest extends RxJavaTest {
 
     /**
      * Demonstrates thread starvation problem.
-     *
-     * No solution on this for now. Trade-off in this direction as per https://github.com/ReactiveX/RxJava/issues/998#issuecomment-38959474
+     * <p>
+     * No solution on this for now. Trade-off in this direction as per <a href="https://github.com/ReactiveX/RxJava/issues/998#issuecomment-38959474">...</a>
      * Probably need backpressure for this to work
-     *
+     * <p>
      * When using SynchronizedSubscriber we get this output:
-     *
+     * <p>
      * {@code p1: 18 p2: 68 =>} should be close to each other unless we have thread starvation
-     *
+     * <p>
      * When using SerializedObserver we get:
-     *
+     * <p>
      * {@code p1: 1 p2: 2445261 =>} should be close to each other unless we have thread starvation
-     *
+     * <p>
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.
      *

--- a/src/test/java/io/reactivex/rxjava4/operators/SimpleQueueTest.java
+++ b/src/test/java/io/reactivex/rxjava4/operators/SimpleQueueTest.java
@@ -117,7 +117,7 @@ public class SimpleQueueTest extends RxJavaTest {
             @Override
             public void run() {
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
 
                 while (i++ < 10000) {
                     q.offer(i);
@@ -131,7 +131,7 @@ public class SimpleQueueTest extends RxJavaTest {
             @Override
             public void run() {
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
 
                 while (i++ < 10000) {
                     q.offer(i);
@@ -145,7 +145,7 @@ public class SimpleQueueTest extends RxJavaTest {
             @Override
             public void run() {
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
 
                 while (--i > 0) {
                     q.poll();

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -683,7 +683,9 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             }
 
             for (int i = 1; i <= 10; i++) {
-                while (!pp.offer(i)) { }
+                while (!pp.offer(i)) {
+                    Thread.onSpinWait();
+                }
             }
             pp.onComplete();
         });
@@ -740,7 +742,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
 
             Runnable r1 = () -> {
                 for (int i1 = 0; i1 < 2; i1++) {
-                    while (!pp.offer(i1)) { }
+                    while (!pp.offer(i1)) { Thread.onSpinWait(); }
                 }
             };
 

--- a/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
@@ -588,7 +588,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
             }
 
             for (int i = 1; i <= 10; i++) {
-                while (!pp.offer(i)) { }
+                while (!pp.offer(i)) { Thread.onSpinWait(); }
             }
             pp.onComplete();
         });
@@ -609,7 +609,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
             Runnable r1 = () -> {
                 for (int i1 = 0; i1 < 2; i1++) {
-                    while (!pp.offer(i1)) { }
+                    while (!pp.offer(i1)) { Thread.onSpinWait(); }
                 }
             };
 

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -244,7 +244,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
     /**
      * Make sure emission-subscription races are handled correctly.
-     * https://github.com/ReactiveX/RxJava/issues/1147
+     * <a href="https://github.com/ReactiveX/RxJava/issues/1147">...</a>
      */
     @Test
     public void raceForTerminalState() {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -244,7 +244,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
     /**
      * Make sure emission-subscription races are handled correctly.
-     * https://github.com/ReactiveX/RxJava/issues/1147
+     * <a href="https://github.com/ReactiveX/RxJava/issues/1147">...</a>
      */
     @Test
     public void raceForTerminalState() {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -27,16 +27,16 @@ import io.reactivex.rxjava4.subscribers.*;
 
 /**
  * Base tests for schedulers that involve threads (concurrency).
- *
+ * <p>
  * These can only run on Schedulers that launch threads since they expect async/concurrent behavior.
- *
+ * <p>
  * The Current/Immediate schedulers will not work with these tests.
  */
 public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedulerTests {
 
     /**
      * Make sure canceling through {@code subscribeOn} works.
-     * Bug report: https://github.com/ReactiveX/RxJava/issues/431
+     * Bug report: <a href="https://github.com/ReactiveX/RxJava/issues/431">...</a>
      * @throws InterruptedException if the test is interrupted
      */
     @Test

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerFairTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerFairTest.java
@@ -276,11 +276,11 @@ public class ExecutorSchedulerFairTest extends AbstractSchedulerConcurrencyTests
 
                 w.schedule(() -> {
                     c.decrementAndGet();
-                    while (c.get() != 0) { }
+                    while (c.get() != 0) { Thread.onSpinWait(); }
                 });
 
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
                 w.dispose();
             }
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
@@ -273,11 +273,11 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 w.schedule(() -> {
                     c.decrementAndGet();
-                    while (c.get() != 0) { }
+                    while (c.get() != 0) { Thread.onSpinWait(); }
                 });
 
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
                 w.dispose();
             }
         } finally {
@@ -373,7 +373,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
         Disposable d = scheduler.scheduleDirect(() -> {
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
             try {
                 Thread.sleep(1000);
@@ -383,7 +383,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
         });
 
         if (sync.decrementAndGet() != 0) {
-            while (sync.get() != 0) { }
+            while (sync.get() != 0) { Thread.onSpinWait(); }
         }
 
         Thread.sleep(500);
@@ -411,7 +411,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = worker.schedule(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -421,7 +421,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             });
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -451,7 +451,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = scheduler.scheduleDirect(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -461,7 +461,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             });
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -494,7 +494,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 Disposable d = worker.schedule(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     try {
                         Thread.sleep(1000);
@@ -504,7 +504,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
                 });
 
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
 
                 Thread.sleep(500);
@@ -537,7 +537,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = scheduler.scheduleDirect(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -547,7 +547,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             });
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -580,7 +580,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 Disposable d = worker.schedule(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     try {
                         Thread.sleep(1000);
@@ -590,7 +590,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
                 });
 
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
 
                 Thread.sleep(500);
@@ -623,7 +623,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = scheduler.scheduleDirect(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -633,7 +633,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             });
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -666,7 +666,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 Disposable d = worker.schedule(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     try {
                         Thread.sleep(1000);
@@ -676,7 +676,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
                 });
 
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
 
                 Thread.sleep(500);
@@ -709,7 +709,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = scheduler.scheduleDirect(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -719,7 +719,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             }, 1, TimeUnit.MILLISECONDS);
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -752,7 +752,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 Disposable d = worker.schedule(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     try {
                         Thread.sleep(1000);
@@ -762,7 +762,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
                 }, 1, TimeUnit.MILLISECONDS);
 
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
 
                 Thread.sleep(500);
@@ -795,7 +795,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
             Disposable d = scheduler.scheduleDirect(() -> {
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
                 try {
                     Thread.sleep(1000);
@@ -805,7 +805,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
             }, 1, TimeUnit.MILLISECONDS);
 
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             Thread.sleep(500);
@@ -838,7 +838,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
                 Disposable d = worker.schedule(() -> {
                     if (sync.decrementAndGet() != 0) {
-                        while (sync.get() != 0) { }
+                        while (sync.get() != 0) { Thread.onSpinWait(); }
                     }
                     try {
                         Thread.sleep(1000);
@@ -848,7 +848,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
                 }, 1, TimeUnit.MILLISECONDS);
 
                 if (sync.decrementAndGet() != 0) {
-                    while (sync.get() != 0) { }
+                    while (sync.get() != 0) { Thread.onSpinWait(); }
                 }
 
                 Thread.sleep(500);

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.Scheduler;
@@ -152,7 +153,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
     static final class TestExecutor implements Executor {
         final ConcurrentLinkedQueue<Runnable> queue = new ConcurrentLinkedQueue<>();
         @Override
-        public void execute(Runnable command) {
+        public void execute(@NonNull Runnable command) {
             queue.offer(command);
         }
         public void executeOne() {
@@ -354,11 +355,11 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
                 w.schedule(() -> {
                     c.decrementAndGet();
-                    while (c.get() != 0) { }
+                    while (c.get() != 0) { Thread.onSpinWait(); }
                 });
 
                 c.decrementAndGet();
-                while (c.get() != 0) { }
+                while (c.get() != 0) { Thread.onSpinWait(); }
                 w.dispose();
             }
         } finally {
@@ -446,8 +447,7 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
 
     @Test
     public void interruptibleRunnableRunDisposeRace() {
-        ExecutorService exec = Executors.newSingleThreadExecutor();
-        try {
+        try (var exec = Executors.newSingleThreadExecutor()) {
             Scheduler s = Schedulers.from(exec::execute, true);
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
                 SequentialDisposable sd = new SequentialDisposable();
@@ -457,8 +457,6 @@ public class ExecutorSchedulerTest extends AbstractSchedulerConcurrencyTests {
                         sd::dispose
                 );
             }
-        } finally {
-            exec.shutdown();
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -248,7 +248,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
     /**
      * Make sure emission-subscription races are handled correctly.
-     * https://github.com/ReactiveX/RxJava/issues/1147
+     * <a href="https://github.com/ReactiveX/RxJava/issues/1147">...</a>
      */
     @Test
     public void raceForTerminalState() {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -248,7 +248,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
     /**
      * Make sure emission-subscription races are handled correctly.
-     * https://github.com/ReactiveX/RxJava/issues/1147
+     * <a href="https://github.com/ReactiveX/RxJava/issues/1147">...</a>
      */
     @Test
     public void raceForTerminalState() {

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
@@ -337,18 +337,18 @@ public class SerializedSubscriberTest extends RxJavaTest {
 
     /**
      * Demonstrates thread starvation problem.
-     *
-     * No solution on this for now. Trade-off in this direction as per https://github.com/ReactiveX/RxJava/issues/998#issuecomment-38959474
+     * <p>
+     * No solution on this for now. Trade-off in this direction as per <a href="https://github.com/ReactiveX/RxJava/issues/998#issuecomment-38959474">...</a>
      * Probably need backpressure for this to work
-     *
+     * <p>
      * When using SynchronizedSubscriber we get this output:
-     *
+     * <p>
      * {@code p1: 18 p2: 68 =>} should be close to each other unless we have thread starvation
-     *
+     * <p>
      * When using SerializedSubscriber we get:
-     *
+     * <p>
      * {@code p1: 1 p2: 2445261 =>} should be close to each other unless we have thread starvation
-     *
+     * <p>
      * This demonstrates how SynchronizedSubscriber balances back and forth better, and blocks emission.
      * The real issue in this example is the async buffer-bloat, so we need backpressure.
      *

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -344,7 +344,7 @@ public class TestSubscriberTest extends RxJavaTest {
         ts.onError(new TestException());
         ts.onError(new TestException());
         try {
-            ts.assertError(Functions.<Throwable>alwaysTrue());
+            ts.assertError(Functions.alwaysTrue());
         } catch (AssertionError ex) {
             Throwable e = ex.getCause();
             if (!(e instanceof CompositeException)) {
@@ -403,7 +403,7 @@ public class TestSubscriberTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onError(new RuntimeException());
         try {
-            ts.assertError(Functions.<Throwable>alwaysFalse());
+            ts.assertError(Functions.alwaysFalse());
         } catch (AssertionError ex) {
             // expected
             return;
@@ -454,7 +454,7 @@ public class TestSubscriberTest extends RxJavaTest {
     public void noError3() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         try {
-            ts.assertError(Functions.<Throwable>alwaysTrue());
+            ts.assertError(Functions.alwaysTrue());
         } catch (AssertionError ex) {
             // expected
             return;
@@ -500,7 +500,7 @@ public class TestSubscriberTest extends RxJavaTest {
                 // expected
             }
         } finally {
-            Thread.interrupted(); // clear interrupted flag
+            IO.println(Thread.interrupted()); // clear flag
             w.dispose();
         }
     }
@@ -648,13 +648,13 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorCrashCountsDownLatch() {
-        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts0 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable e) {
                 throw new TestException();
             }
         };
-        TestSubscriber<Integer> ts = new TestSubscriber<>(ts0);
+        var ts = new TestSubscriber<>(ts0);
 
         try {
             ts.onError(new RuntimeException());
@@ -732,7 +732,7 @@ public class TestSubscriberTest extends RxJavaTest {
         }
 
         try {
-            ts.assertError(Functions.<Throwable>alwaysTrue());
+            ts.assertError(Functions.alwaysTrue());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
@@ -759,7 +759,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
         ts.assertError(TestException.class);
 
-        ts.assertError(Functions.<Throwable>alwaysTrue());
+        ts.assertError(Functions.alwaysTrue());
 
         ts.assertError(t -> t.getMessage() != null && t.getMessage().contains("Forced"));
 
@@ -785,7 +785,7 @@ public class TestSubscriberTest extends RxJavaTest {
         }
 
         try {
-            ts.assertError(Functions.<Throwable>alwaysFalse());
+            ts.assertError(Functions.alwaysFalse());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError exc) {
             // expected
@@ -1139,7 +1139,7 @@ public class TestSubscriberTest extends RxJavaTest {
         ts.onNext(2);
 
         try {
-            ts.assertValueSequence(Collections.<Integer>emptyList());
+            ts.assertValueSequence(Collections.emptyList());
             throw new RuntimeException("Should have thrown");
         } catch (AssertionError ex) {
             // expected
@@ -1260,7 +1260,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1296,7 +1296,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1350,14 +1350,15 @@ public class TestSubscriberTest extends RxJavaTest {
         ts.assertValue(o -> o == 1);
     }
 
-    static void assertThrowsWithMessage(String message, Class<? extends Throwable> clazz, ThrowingRunnable run) {
-        assertEquals(message, assertThrows(clazz, run).getMessage());
+    static void assertThrowsWithMessage(String message,
+                                        ThrowingRunnable run) {
+        assertEquals(message, assertThrows(AssertionError.class, run).getMessage());
     }
 
     @Test
     public void assertValuePredicateNoMatch() {
         assertThrowsWithMessage("Value 1 (class: Integer) at position 0 did not pass the predicate "
-                + "(latch = 0, values = 1, errors = 0, completions = 1)", AssertionError.class, () -> {
+                + "(latch = 0, values = 1, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1).subscribe(ts);
@@ -1369,7 +1370,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertValuePredicateMatchButMore() {
         assertThrowsWithMessage("The first value passed the predicate but this consumer received more than one value "
-                + "(latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+                + "(latch = 0, values = 2, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1380,7 +1381,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtPredicateEmpty() {
-        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("No values (latch = 0, values = 0, errors = 0, completions = 1)", () -> {
             TestSubscriber<Object> ts = new TestSubscriber<>();
 
             Flowable.empty().subscribe(ts);
@@ -1401,7 +1402,7 @@ public class TestSubscriberTest extends RxJavaTest {
     @Test
     public void assertValueAtPredicateNoMatch() {
         assertThrowsWithMessage("Value 3 (class: Integer) at position 2 did not pass the predicate "
-                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+                + "(latch = 0, values = 3, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2, 3).subscribe(ts);
@@ -1412,7 +1413,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndex() {
-        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1423,7 +1424,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexInvalidIndex() {
-        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index 2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1434,7 +1435,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexInvalidIndexNegative() {
-        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1445,7 +1446,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void assertValueAtInvalidIndexNegative() {
-        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("Index -2 is out of range [0, 2) (latch = 0, values = 2, errors = 0, completions = 1)", () -> {
             TestSubscriber<Integer> ts = new TestSubscriber<>();
 
             Flowable.just(1, 2).subscribe(ts);
@@ -1484,7 +1485,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void timeoutIndicated() throws InterruptedException {
-        Thread.interrupted(); // clear flag
+        IO.println(Thread.interrupted()); // clear flag
 
         TestSubscriber<Object> ts = Flowable.never()
         .test();
@@ -1499,7 +1500,7 @@ public class TestSubscriberTest extends RxJavaTest {
     }
 
     @Test
-    public void timeoutIndicated2() throws InterruptedException {
+    public void timeoutIndicated2() {
         try {
             Flowable.never()
             .test()
@@ -1666,7 +1667,21 @@ public class TestSubscriberTest extends RxJavaTest {
             Thread.currentThread().interrupt();
             ts.awaitCount(1);
         } finally {
-            Thread.interrupted();
+            IO.println(Thread.interrupted()); // clear flag
         }
+    }
+
+    @Test
+    public void assertValueAts() {
+        var ts = new TestSubscriber<Integer>();
+        ts.onSubscribe(new BooleanSubscription());
+        ts.onNext(1);
+        ts.onNext(2);
+
+        ts.assertValueAt(0, 1)
+                .assertValueAt(1, 2)
+                .assertValueAt(0, v -> v == 1)
+                .assertValueAt(1, v -> v == 2)
+                ;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -266,37 +266,6 @@ public enum TestHelper {
     }
 
     /**
-     * Verify that a specific enum type has no enum constants.
-     * @param <E> the enum type
-     * @param e the enum class instance
-     */
-    public static <E extends Enum<E>> void assertEmptyEnum(Class<E> e) {
-        assertEquals(0, e.getEnumConstants().length);
-
-        try {
-            try {
-                Method m0 = e.getDeclaredMethod("values");
-
-                Object[] a = (Object[])m0.invoke(null);
-                assertEquals(0, a.length);
-
-                Method m = e.getDeclaredMethod("valueOf", String.class);
-
-                m.invoke("INSTANCE");
-                fail("Should have thrown!");
-            } catch (InvocationTargetException ex) {
-                fail(ex.toString());
-            } catch (IllegalAccessException ex) {
-                fail(ex.toString());
-            } catch (IllegalArgumentException ex) {
-                // we expected this
-            }
-        } catch (NoSuchMethodException ex) {
-            fail(ex.toString());
-        }
-    }
-
-    /**
      * Assert that by consuming the Publisher with a bad request amount, it is
      * reported to the plugin error handler promptly.
      * @param source the source to consume
@@ -359,7 +328,7 @@ public enum TestHelper {
         try {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            var bad = new FlowableSubscriber<Object>() /* NFI */ {
+            var bad = new FlowableSubscriber<>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -440,7 +409,7 @@ public enum TestHelper {
 
         s.scheduleDirect(() -> {
             if (count.decrementAndGet() != 0) {
-                while (count.get() != 0) { }
+                while (count.get() != 0) { Thread.onSpinWait(); }
             }
 
             try {
@@ -455,7 +424,7 @@ public enum TestHelper {
         });
 
         if (count.decrementAndGet() != 0) {
-            while (count.get() != 0) { }
+            while (count.get() != 0) { Thread.onSpinWait(); }
         }
 
         try {
@@ -483,7 +452,7 @@ public enum TestHelper {
             throw ExceptionHelper.wrapOrThrow(errors[1]);
         }
 
-        if (errors[0] != null && errors[1] != null) {
+        if (errors[0] != null) {
             throw new CompositeException(errors);
         }
     }
@@ -958,7 +927,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1012,7 +981,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1066,7 +1035,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1120,7 +1089,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1174,7 +1143,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1228,7 +1197,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1282,7 +1251,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1335,7 +1304,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1389,7 +1358,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1443,7 +1412,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1497,7 +1466,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null, null, null };
             final CountDownLatch cdl = new CountDownLatch(2);
 
-            ParallelFlowable<T> source = new ParallelFlowable<T>() /* NFI */ {
+            var source = new ParallelFlowable<T>() /* NFI */ {
                 @Override
                 public void subscribe(Subscriber<? super T>[] subscribers) {
                     for (int i = 0; i < subscribers.length; i++) {
@@ -1510,7 +1479,7 @@ public enum TestHelper {
 
                             subscribers[i].onSubscribe(bs2);
 
-                            b[i * 2 + 0] = bs1.isCancelled();
+                            b[i * 2] = bs1.isCancelled();
                             b[i * 2 + 1] = bs2.isCancelled();
                         } finally {
                             cdl.countDown();
@@ -3717,7 +3686,7 @@ public enum TestHelper {
 
         Schedulers.single().scheduleDirect(() -> {
             if (sync.decrementAndGet() != 0) {
-                while (sync.get() != 0) { }
+                while (sync.get() != 0) { Thread.onSpinWait(); }
             }
 
             run.run();
@@ -3726,7 +3695,7 @@ public enum TestHelper {
         });
 
         if (sync.decrementAndGet() != 0) {
-            while (sync.get() != 0) { }
+            while (sync.get() != 0) { Thread.onSpinWait(); }
         }
     }
 


### PR DESCRIPTION
- Use `Thread.onSpinWait()`
- Javadoc insert `<p>` to correct styling.
- Some `signalled` -> `signaled`
- Some `cancelled` -> `canceled`