### PR TITLE
4.x: Cleanup, wording minor things

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -3257,8 +3257,8 @@ public abstract class Completable implements CompletableSource {
     }
 
     /**
-     * Creates a {@link TestObserver} optionally in canceled state, then subscribes it to this {@code Completable}.
-     * @param dispose if {@code true}, the {@code TestObserver} will be canceled before subscribing to this
+     * Creates a {@link TestObserver} optionally in cancelled state, then subscribes it to this {@code Completable}.
+     * @param dispose if {@code true}, the {@code TestObserver} will be cancelled before subscribing to this
      * {@code Completable}.
      * <p>
      * <img width="640" height="499" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.test.b.png" alt="">
@@ -3324,10 +3324,10 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="323" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.c.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
-     * The upstream will be also canceled if the resulting {@code CompletionStage} is converted to and
+     * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
      * completed manually by {@link CompletableFuture#complete(Object)} or {@link CompletableFuture#completeExceptionally(Throwable)}.
      * <p>
      * {@code CompletionStage}s don't have a notion of emptiness and allow {@code null}s, therefore, one can either use

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -172,7 +172,7 @@ FlowableDocBasic<T>
      * <img width="640" height="417" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.amb.png" alt="">
      * <p>
      * When one of the {@code Publisher}s signal an item or terminates first, all subscriptions to the other
-     * {@code Publisher}s are canceled.
+     * {@code Publisher}s are cancelled.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the winning
@@ -210,7 +210,7 @@ FlowableDocBasic<T>
      * <img width="640" height="417" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.ambArray.png" alt="">
      * <p>
      * When one of the {@code Publisher}s signal an item or terminates first, all subscriptions to the other
-     * {@code Publisher}s are canceled.
+     * {@code Publisher}s are cancelled.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the winning
@@ -2151,7 +2151,7 @@ FlowableDocBasic<T>
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@code Action} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link Subscriber#onError(Throwable)},
-     *  except when the downstream has canceled the resulting {@code Flowable} source.
+     *  except when the downstream has cancelled the resulting {@code Flowable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
@@ -2223,7 +2223,7 @@ FlowableDocBasic<T>
      *   <dt><b>Error handling:</b></dt>
      *   <dd> If the {@link Callable} throws an exception, the respective {@link Throwable} is
      *   delivered to the downstream via {@link Subscriber#onError(Throwable)},
-     *   except when the downstream has canceled this {@code Flowable} source.
+     *   except when the downstream has cancelled this {@code Flowable} source.
      *   In this latter case, the {@code Throwable} is delivered to the global error handler via
      *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *   </dd>
@@ -2540,7 +2540,7 @@ FlowableDocBasic<T>
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@code Runnable} throws an exception, the respective {@code Throwable} is
      *  delivered to the downstream via {@link Subscriber#onError(Throwable)},
-     *  except when the downstream has canceled the resulting {@code Flowable} source.
+     *  except when the downstream has cancelled the resulting {@code Flowable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
@@ -2603,7 +2603,7 @@ FlowableDocBasic<T>
      *   <dt><b>Error handling:</b></dt>
      *   <dd> If the {@link Supplier} throws an exception, the respective {@link Throwable} is
      *   delivered to the downstream via {@link Subscriber#onError(Throwable)},
-     *   except when the downstream has canceled this {@code Flowable} source.
+     *   except when the downstream has cancelled this {@code Flowable} source.
      *   In this latter case, the {@code Throwable} is delivered to the global error handler via
      *   {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *   </dd>
@@ -2718,7 +2718,7 @@ FlowableDocBasic<T>
      * {@code onComplete} to signal a value or a terminal event. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@link IllegalStateException}.
      * @param disposeState the {@code Consumer} that is called with the current state when the generator
-     * terminates the sequence or it gets canceled
+     * terminates the sequence or it gets cancelled
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code initialState}, {@code generator} or {@code disposeState} is {@code null}
      */
@@ -2788,7 +2788,7 @@ FlowableDocBasic<T>
      * the next invocation. Signaling multiple {@code onNext}
      * in a call will make the operator signal {@link IllegalStateException}.
      * @param disposeState the {@link Consumer} that is called with the current state when the generator
-     * terminates the sequence or it gets canceled
+     * terminates the sequence or it gets cancelled
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code initialState}, {@code generator} or {@code disposeState} is {@code null}
      */
@@ -3472,13 +3472,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3524,13 +3524,13 @@ FlowableDocBasic<T>
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(int, int, Publisher[])} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3576,13 +3576,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3622,13 +3622,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Iterable, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3673,13 +3673,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3719,13 +3719,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, int)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3769,13 +3769,13 @@ FlowableDocBasic<T>
      *  <dd>{@code mergeArray} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeArrayDelayError(Publisher...)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3815,13 +3815,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3864,13 +3864,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -3916,13 +3916,13 @@ FlowableDocBasic<T>
      *  <dd>{@code merge} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If any of the source {@code Publisher}s signal a {@link Throwable} via {@code onError}, the resulting
-     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are canceled.
+     *  {@code Flowable} terminates with that {@code Throwable} and all other source {@code Publisher}s are cancelled.
      *  If more than one {@code Publisher} signals an error, the resulting {@code Flowable} may terminate with the
      *  first one's error or, depending on the concurrency of the sources, may terminate with a
      *  {@link CompositeException} containing two or more of the various error signals.
      *  {@code Throwable}s that didn't make into the composite will be sent (individually) to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} method as {@link UndeliverableException} errors. Similarly, {@code Throwable}s
-     *  signaled by source(s) after the returned {@code Flowable} has been canceled or terminated with a
+     *  signaled by source(s) after the returned {@code Flowable} has been cancelled or terminated with a
      *  (composite) error will be sent to the same global error handler.
      *  Use {@link #mergeDelayError(Publisher, Publisher, Publisher, Publisher)} to merge sources and terminate only when all source {@code Publisher}s
      *  have completed or failed with an error.
@@ -4644,7 +4644,7 @@ FlowableDocBasic<T>
      * from the earlier-emitted {@code Publisher} and begins emitting items from the new one.
      * <p>
      * The resulting {@code Flowable} completes if both the outer {@code Publisher} and the last inner {@code Publisher}, if any, complete.
-     * If the outer {@code Publisher} signals an {@code onError}, the inner {@code Publisher} is canceled and the error delivered in-sequence.
+     * If the outer {@code Publisher} signals an {@code onError}, the inner {@code Publisher} is cancelled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -4686,7 +4686,7 @@ FlowableDocBasic<T>
      * from the earlier-emitted {@code Publisher} and begins emitting items from the new one.
      * <p>
      * The resulting {@code Flowable} completes if both the outer {@code Publisher} and the last inner {@code Publisher}, if any, complete.
-     * If the outer {@code Publisher} signals an {@code onError}, the inner {@code Publisher} is canceled and the error delivered in-sequence.
+     * If the outer {@code Publisher} signals an {@code onError}, the inner {@code Publisher} is cancelled and the error delivered in-sequence.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator honors backpressure from downstream. The outer {@code Publisher} is consumed in an
@@ -5959,8 +5959,8 @@ FlowableDocBasic<T>
      * <img width="640" height="376" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Flowable.ambWith.png" alt="">
      * <p>
      * When the current {@code Flowable} signals an item or terminates first, the subscription to the other
-     * {@code Publisher} is canceled. If the other {@code Publisher} signals an item or terminates first,
-     * the subscription to the current {@code Flowable} is canceled.
+     * {@code Publisher} is cancelled. If the other {@code Publisher} signals an item or terminates first,
+     * the subscription to the current {@code Flowable} is cancelled.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
      *  <dd>The operator itself doesn't interfere with backpressure which is determined by the winning
@@ -9334,7 +9334,7 @@ FlowableDocBasic<T>
      * returned {@code Flowable} cancels of the flow and terminates with that type of terminal event:
      * <pre><code>
      * Flowable.just(createOnNext(1), createOnComplete(), createOnNext(2))
-     * .doOnCancel(() -&gt; System.out.println("Canceled!"));
+     * .doOnCancel(() -&gt; System.out.println("Cancelled!"));
      * .dematerialize(notification -&gt; notification)
      * .test()
      * .assertResult(1);
@@ -9628,7 +9628,7 @@ FlowableDocBasic<T>
     }
 
     /**
-     * Calls the specified action after this {@code Flowable} signals {@code onError} or {@code onComplete} or gets canceled by
+     * Calls the specified action after this {@code Flowable} signals {@code onError} or {@code onComplete} or gets cancelled by
      * the downstream.
      * <p>In case of a race between a terminal event and a cancellation, the provided {@code onFinally} action
      * is executed once per subscription.
@@ -9645,7 +9645,7 @@ FlowableDocBasic<T>
      *  synchronous or asynchronous queue-fusion.</dd>
      * </dl>
      * <p>History: 2.0.1 - experimental
-     * @param onFinally the action called when this {@code Flowable} terminates or gets canceled
+     * @param onFinally the action called when this {@code Flowable} terminates or gets cancelled
      * @throws NullPointerException if {@code onFinally} is {@code null}
      * @return the new {@code Flowable} instance
      * @since 2.1
@@ -9736,7 +9736,7 @@ FlowableDocBasic<T>
      * </dl>
      *
      * @param onCancel
-     *            the action that gets called when the current {@code Flowable}'s {@link Subscription} is canceled
+     *            the action that gets called when the current {@code Flowable}'s {@link Subscription} is cancelled
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code onCancel} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
@@ -11844,7 +11844,7 @@ FlowableDocBasic<T>
      *     // Some operators may use their own resources which should be cleaned up if
      *     // the downstream cancels the flow before it completed. Operators without
      *     // resources can simply forward the cancellation to the upstream.
-     *     // In some cases, a canceled flag may be set by this method so that other parts
+     *     // In some cases, a cancelled flag may be set by this method so that other parts
      *     // of this class may detect the cancellation and stop sending events
      *     // to the downstream.
      *     &#64;Override
@@ -15046,7 +15046,7 @@ FlowableDocBasic<T>
     /**
      * Returns a new {@code Flowable} that multicasts (and shares a single subscription to) the current {@code Flowable}. As long as
      * there is at least one {@link Subscriber}, the current {@code Flowable} will be subscribed and emitting data.
-     * When all subscribers have canceled it will cancel the current {@code Flowable}.
+     * When all subscribers have cancelled it will cancel the current {@code Flowable}.
      * <p>
      * This is an alias for {@link #publish()}.{@link ConnectableFlowable#refCount() refCount()}.
      * <p>
@@ -16184,7 +16184,7 @@ FlowableDocBasic<T>
      * of these {@code Publisher}s.
      * <p>
      * The resulting {@code Flowable} completes if both the current {@code Flowable} and the last inner {@code Publisher}, if any, complete.
-     * If the current {@code Flowable} signals an {@code onError}, the inner {@code Publisher} is canceled and the error delivered in-sequence.
+     * If the current {@code Flowable} signals an {@code onError}, the inner {@code Publisher} is cancelled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.v3.png" alt="">
      * <dl>
@@ -16220,7 +16220,7 @@ FlowableDocBasic<T>
      * of these {@code Publisher}s.
      * <p>
      * The resulting {@code Flowable} completes if both the current {@code Flowable} and the last inner {@code Publisher}, if any, complete.
-     * If the current {@code Flowable} signals an {@code onError}, the inner {@code Publisher} is canceled and the error delivered in-sequence.
+     * If the current {@code Flowable} signals an {@code onError}, the inner {@code Publisher} is cancelled and the error delivered in-sequence.
      * <p>
      * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.v3.png" alt="">
      * <dl>
@@ -17551,7 +17551,7 @@ FlowableDocBasic<T>
      *                 upstream item is ignored and the flow terminates.
      * @param onDropped called when an item is replaced by a newer item that doesn't get delivered
      *                 to the downstream, including the very last item if {@code emitLast} is {@code false}
-     *                 and the current undelivered item when the sequence gets canceled.
+     *                 and the current undelivered item when the sequence gets cancelled.
      * @return the new {@code Flowable} instance
      * @throws NullPointerException if {@code unit}, {@code scheduler} or {@code onDropped} is {@code null}
      * @since 3.1.6 - Experimental
@@ -20073,7 +20073,7 @@ FlowableDocBasic<T>
      *  <dd>{@code test} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param initialRequest the initial request amount, positive
-     * @param cancel should the {@code TestSubscriber} be canceled before the subscription?
+     * @param cancel should the {@code TestSubscriber} be cancelled before the subscription?
      * @return the new {@code TestSubscriber} instance
      * @since 2.0
      */
@@ -20281,7 +20281,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -20318,7 +20318,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="229" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -20354,7 +20354,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="315" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -20390,7 +20390,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="343" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstOrErrorStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -20420,7 +20420,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="229" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrErrorStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -20449,7 +20449,7 @@ FlowableDocBasic<T>
      * <p>
      * <img width="640" height="346" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastOrErrorStage.f.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -4388,7 +4388,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * Note that the inner {@code Publisher} returned by the handler function should signal
      * either {@code onNext}, {@code onError} or {@code onComplete} in response to the received
      * {@code Throwable} to indicate the operator should retry or terminate. If the upstream to
-     * the operator is asynchronous, signalling {@code onNext} followed by {@code onComplete} immediately may
+     * the operator is asynchronous, signaling {@code onNext} followed by {@code onComplete} immediately may
      * result in the sequence to be completed immediately. Similarly, if this inner
      * {@code Publisher} signals {@code onError} or {@code onComplete} while the upstream is
      * active, the sequence is terminated with the same signal immediately.
@@ -5571,7 +5571,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="349" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.m.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -5604,7 +5604,7 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="323" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.mv.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and

--- a/src/main/java/io/reactivex/rxjava4/core/MaybeObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/core/MaybeObserver.java
@@ -31,7 +31,7 @@ import io.reactivex.rxjava4.disposables.Disposable;
  * <pre><code>    onSubscribe (onSuccess | onError | onComplete)?</code></pre>
  * <p>
  * Note that unlike with the {@code Observable} protocol, {@link #onComplete()} is not called after the success item has been
- * signalled via {@link #onSuccess(Object)}.
+ * signaled via {@link #onSuccess(Object)}.
  * <p>
  * Subscribing a {@code MaybeObserver} to multiple {@code MaybeSource}s is not recommended. If such reuse
  * happens, it is the duty of the {@code MaybeObserver} implementation to be ready to receive multiple calls to

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -1391,7 +1391,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@code Action} throws an exception, the respective {@link Throwable} is
      *  delivered to the downstream via {@link Observer#onError(Throwable)},
-     *  except when the downstream has canceled the resulting {@code Observable} source.
+     *  except when the downstream has cancelled the resulting {@code Observable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
@@ -1688,7 +1688,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dt><b>Error handling:</b></dt>
      *  <dd> If the {@code Runnable} throws an exception, the respective {@code Throwable} is
      *  delivered to the downstream via {@link Observer#onError(Throwable)},
-     *  except when the downstream has canceled the resulting {@code Observable} source.
+     *  except when the downstream has cancelled the resulting {@code Observable} source.
      *  In this latter case, the {@code Throwable} is delivered to the global error handler via
      *  {@link RxJavaPlugins#onError(Throwable)} as an {@link io.reactivex.rxjava4.exceptions.UndeliverableException UndeliverableException}.
      *  </dd>
@@ -15923,7 +15923,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="313" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -15958,7 +15958,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="227" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -15992,7 +15992,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="313" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -16026,7 +16026,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="341" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/firstOrErrorStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -16053,7 +16053,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="227" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/singleOrErrorStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and
@@ -16079,7 +16079,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="343" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/lastOrErrorStage.o.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and

--- a/src/main/java/io/reactivex/rxjava4/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Single.java
@@ -5206,7 +5206,7 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="321" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/toCompletionStage.s.png" alt="">
      * <p>
-     * The upstream can be canceled by converting the resulting {@code CompletionStage} into
+     * The upstream can be cancelled by converting the resulting {@code CompletionStage} into
      * {@link CompletableFuture} via {@link CompletionStage#toCompletableFuture()} and
      * calling {@link CompletableFuture#cancel(boolean)} on it.
      * The upstream will be also cancelled if the resulting {@code CompletionStage} is converted to and

--- a/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
+++ b/src/main/java/io/reactivex/rxjava4/disposables/Disposable.java
@@ -67,9 +67,9 @@ public interface Disposable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Future} that is
-     * canceled exactly once when the {@code Disposable} is disposed.
+     * cancelled exactly once when the {@code Disposable} is disposed.
      * <p>
-     * The {@code Future} is canceled with {@code mayInterruptIfRunning == true}.
+     * The {@code Future} is cancelled with {@code mayInterruptIfRunning == true}.
      * @param future the {@code Future} to wrap
      * @return the new {@code Disposable} instance
      * @throws NullPointerException if {@code future} is {@code null}
@@ -84,7 +84,7 @@ public interface Disposable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Future} that is
-     * canceled exactly once when the {@code Disposable} is disposed.
+     * cancelled exactly once when the {@code Disposable} is disposed.
      * @param future the {@code Future} to wrap
      * @param allowInterrupt if true, the future cancel happens via {@code Future.cancel(true)}
      * @return the new {@code Disposable} instance
@@ -99,7 +99,7 @@ public interface Disposable {
 
     /**
      * Construct a {@code Disposable} by wrapping a {@link Subscription} that is
-     * canceled exactly once when the {@code Disposable} is disposed.
+     * cancelled exactly once when the {@code Disposable} is disposed.
      * @param subscription the {@code Runnable} to wrap
      * @return the new {@code Disposable} instance
      * @throws NullPointerException if {@code subscription} is {@code null}

--- a/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/OnErrorNotImplementedException.java
@@ -31,7 +31,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
 
     /**
      * Customizes the {@code Throwable} with a custom message and wraps it before it
-     * is signalled to the {@code RxJavaPlugins.onError()} handler as {@code OnErrorNotImplementedException}.
+     * is signaled to the {@code RxJavaPlugins.onError()} handler as {@code OnErrorNotImplementedException}.
      *
      * @param message
      *          the message to assign to the {@code Throwable} to signal
@@ -44,7 +44,7 @@ public final class OnErrorNotImplementedException extends RuntimeException {
 
     /**
      * Wraps the {@code Throwable} before it
-     * is signalled to the {@code RxJavaPlugins.onError()}
+     * is signaled to the {@code RxJavaPlugins.onError()}
      * handler as {@code OnErrorNotImplementedException}.
      *
      * @param e

--- a/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/UndeliverableException.java
@@ -31,7 +31,7 @@ public final class UndeliverableException extends IllegalStateException {
      * @param cause the cause, not null
      */
     public UndeliverableException(Throwable cause) {
-        super("The exception could not be delivered to the consumer because it has already canceled/disposed the flow "
+        super("The exception could not be delivered to the consumer because it has already cancelled/disposed the flow "
                 + "or the exception has nowhere to go to begin with. "
                 + "Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | " + cause, cause);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/DisposableHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/DisposableHelper.java
@@ -68,7 +68,7 @@ public enum DisposableHelper implements Disposable {
      * or returns false if the field is non-null.
      * If the target field contains the common DISPOSED instance, the supplied disposable
      * is disposed. If the field contains other non-null Disposable, an IllegalStateException
-     * is signalled to the RxJavaPlugins.onError hook.
+     * is signaled to the RxJavaPlugins.onError hook.
      * 
      * @param field the target field
      * @param d the disposable to set, not null

--- a/src/main/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseable.java
@@ -17,7 +17,7 @@ import io.reactivex.rxjava4.operators.QueueFuseable;
 
 /**
  * Represents an empty, async-only {@link QueueFuseable} instance that tracks and exposes a
- * canceled/disposed state.
+ * cancelled/disposed state.
  *
  * @param <T> the output value type
  * @since 3.0.0

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
@@ -591,7 +591,7 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         }
 
         void cleanupQueue(long emitted, boolean polled) {
-            // if this group is canceled, all accumulated emissions and
+            // if this group is cancelled, all accumulated emissions and
             // remaining items in the queue should be requested
             // so that other groups can proceed
             while (queue.poll() != null) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -76,7 +76,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
         final AtomicLong requested;
         long emitted;
 
-        volatile boolean upstreamCanceled;
+        volatile boolean upstreamCancelled;
 
         volatile boolean upstreamDone;
         volatile boolean openDone;
@@ -152,7 +152,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                     startSubscriber.cancel();
                     resources.dispose();
                     error.tryTerminateAndReport();
-                    upstreamCanceled = true;
+                    upstreamCancelled = true;
                     drain();
                 } else {
                     startSubscriber.cancel();
@@ -167,7 +167,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                 startSubscriber.cancel();
                 resources.dispose();
                 error.tryTerminateAndReport();
-                upstreamCanceled = true;
+                upstreamCancelled = true;
                 drain();
             }
         }
@@ -217,7 +217,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
             final List<UnicastProcessor<T>> windows = this.windows;
 
             for (;;) {
-                if (upstreamCanceled) {
+                if (upstreamCancelled) {
                     queue.clear();
                     windows.clear();
                 } else {
@@ -228,7 +228,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                     if (isDone) {
                         if (isEmpty || error.get() != null) {
                             terminateDownstream(downstream);
-                            upstreamCanceled = true;
+                            upstreamCancelled = true;
                             continue;
                         }
                     }
@@ -302,7 +302,7 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
                         startSubscriber.cancel();
                         resources.dispose();
                         terminateDownstream(downstream);
-                        upstreamCanceled = true;
+                        upstreamCancelled = true;
                         continue;
                     }
                 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromMany.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromMany.java
@@ -168,7 +168,7 @@ public final class FlowableWithLatestFromMany<T, R> extends AbstractFlowableWith
             for (int i = 0; i < n; i++) {
                 Object o = ara.get(i);
                 if (o == null) {
-                    // somebody hasn't signalled yet, skip this T
+                    // somebody hasn't signaled yet, skip this T
                     return false;
                 }
                 objects[i + 1] = o;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCount.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCount.java
@@ -19,7 +19,7 @@ import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
 import io.reactivex.rxjava4.internal.fuseable.HasUpstreamMaybeSource;
 
 /**
- * Signals 1L if the source signalled an item or 0L if the source is empty.
+ * Signals 1L if the source signaled an item or 0L if the source is empty.
  *
  * @param <T> the source value type
  */

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -76,7 +76,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
         final AtomicLong requested;
         long emitted;
 
-        volatile boolean upstreamCanceled;
+        volatile boolean upstreamCancelled;
 
         volatile boolean upstreamDone;
         volatile boolean openDone;
@@ -143,7 +143,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                     startObserver.dispose();
                     resources.dispose();
                     error.tryTerminateAndReport();
-                    upstreamCanceled = true;
+                    upstreamCancelled = true;
                     drain();
                 } else {
                     startObserver.dispose();
@@ -163,7 +163,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                 startObserver.dispose();
                 resources.dispose();
                 error.tryTerminateAndReport();
-                upstreamCanceled = true;
+                upstreamCancelled = true;
                 drain();
             }
         }
@@ -213,7 +213,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
             final List<UnicastSubject<T>> windows = this.windows;
 
             for (;;) {
-                if (upstreamCanceled) {
+                if (upstreamCancelled) {
                     queue.clear();
                     windows.clear();
                 } else {
@@ -224,7 +224,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                     if (isDone) {
                         if (isEmpty || error.get() != null) {
                             terminateDownstream(downstream);
-                            upstreamCanceled = true;
+                            upstreamCancelled = true;
                             continue;
                         }
                     }
@@ -287,7 +287,7 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
                         startObserver.dispose();
                         resources.dispose();
                         terminateDownstream(downstream);
-                        upstreamCanceled = true;
+                        upstreamCancelled = true;
                         continue;
                     }
                 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleTakeUntil.java
@@ -27,7 +27,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
 /**
  * Signals the events of the source Single or signals a CancellationException if the
- * other Publisher signalled first.
+ * other Publisher signaled first.
  * @param <T> the main value type
  * @param <U> the other value type
  */

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisher.java
@@ -67,7 +67,7 @@ implements Streamable<T>, HasUpstreamPublisher<T> {
             // System.out.println("onNext | " + item);
             this.item.getAndSet(item);
             resumer.resume();
-            // System.out.println("Got " + item + " resume signalled");
+            // System.out.println("Got " + item + " resume signaled");
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriber.java
@@ -24,7 +24,7 @@ import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 
 /**
  * Relays signals from upstream according to downstream requests and allows
- * signalling a final value followed by onComplete in a backpressure-aware manner.
+ * signaling a final value followed by onComplete in a backpressure-aware manner.
  *
  * @param <T> the input value type
  * @param <R> the output value type

--- a/src/main/java/io/reactivex/rxjava4/internal/subscriptions/EmptySubscription.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/subscriptions/EmptySubscription.java
@@ -87,7 +87,7 @@ public enum EmptySubscription implements QueueSubscription<Object> {
 
     @Override
     public int requestFusion(int mode) {
-        return mode & ASYNC; // accept async mode: an onComplete or onError will be signalled after anyway
+        return mode & ASYNC; // accept async mode: an onComplete or onError will be signaled after anyway
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.observers;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.annotations.NonNull;
@@ -131,11 +132,7 @@ implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver
 
         try {
             lastThread = Thread.currentThread();
-            if (t == null) {
-                errors.add(new NullPointerException("onError received a null Throwable"));
-            } else {
-                errors.add(t);
-            }
+            errors.add(Objects.requireNonNullElseGet(t, () -> new NullPointerException("onError received a null Throwable")));
 
             downstream.onError(t);
         } finally {

--- a/src/main/java/io/reactivex/rxjava4/parallel/ParallelFailureHandling.java
+++ b/src/main/java/io/reactivex/rxjava4/parallel/ParallelFailureHandling.java
@@ -26,7 +26,7 @@ public enum ParallelFailureHandling implements BiFunction<Long, Throwable, Paral
      */
     STOP,
     /**
-     * The current rail is stopped and the error is signalled.
+     * The current rail is stopped and the error is signaled.
      */
     ERROR,
     /**

--- a/src/main/java/io/reactivex/rxjava4/parallel/ParallelFlowable.java
+++ b/src/main/java/io/reactivex/rxjava4/parallel/ParallelFlowable.java
@@ -1265,7 +1265,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     }
 
     /**
-     * Generates and concatenates {@link Publisher}s on each 'rail', signalling errors immediately
+     * Generates and concatenates {@link Publisher}s on each 'rail', signaling errors immediately
      * and generating 2 publishers upfront.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>
@@ -1293,7 +1293,7 @@ public abstract class ParallelFlowable<@NonNull T> {
     }
 
     /**
-     * Generates and concatenates {@link Publisher}s on each 'rail', signalling errors immediately
+     * Generates and concatenates {@link Publisher}s on each 'rail', signaling errors immediately
      * and using the given prefetch amount for generating {@code Publisher}s upfront.
      * <dl>
      *  <dt><b>Backpressure:</b></dt>

--- a/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
@@ -51,7 +51,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
  * if the processor is used as a standalone source. However, calling {@code onSubscribe}
  * after the {@code AsyncProcessor} reached its terminal state will result in the
- * given {@link Subscription} being canceled immediately.
+ * given {@link Subscription} being cancelled immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
  * is required to be serialized (called from the same thread or called non-overlappingly from different threads

--- a/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
@@ -104,7 +104,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  *  <dt><b>Backpressure:</b></dt>
  *  <dd>The {@code BehaviorProcessor} does not coordinate requests of its downstream {@code Subscriber}s and
  *  expects each individual {@code Subscriber} is ready to receive {@code onNext} items when {@link #onNext(Object)}
- *  is called. If a {@code Subscriber} is not ready, a {@code MissingBackpressureException} is signalled to it.
+ *  is called. If a {@code Subscriber} is not ready, a {@code MissingBackpressureException} is signaled to it.
  *  To avoid overflowing the current {@code Subscriber}s, the conditional {@link #offer(Object)} method is available
  *  that returns true if any of the {@code Subscriber}s is not ready to receive {@code onNext} events. If
  *  there are no {@code Subscriber}s to the processor, {@code offer()} always succeeds.
@@ -163,8 +163,6 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  */
 public final class BehaviorProcessor<@NonNull T> extends FlowableProcessor<T> {
     final AtomicReference<BehaviorSubscription<T>[]> subscribers;
-
-    static final Object[] EMPTY_ARRAY = new Object[0];
 
     @SuppressWarnings("rawtypes")
     static final BehaviorSubscription[] EMPTY = new BehaviorSubscription[0];

--- a/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
@@ -175,7 +175,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
      * Constructs a fresh instance with the default Flowable.bufferSize() prefetch
      * amount and the optional refCount-behavior.
      * @param <T> the input and output value type
-     * @param refCount if true and if all Subscribers have canceled, the upstream
+     * @param refCount if true and if all Subscribers have cancelled, the upstream
      * is cancelled
      * @return the new MulticastProcessor instance
      */
@@ -203,7 +203,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
      * Constructs a fresh instance with the given prefetch amount and the optional
      * refCount-behavior.
      * @param bufferSize the prefetch amount
-     * @param refCount if true and if all Subscribers have canceled, the upstream
+     * @param refCount if true and if all Subscribers have cancelled, the upstream
      * is cancelled
      * @param <T> the input and output value type
      * @return the new MulticastProcessor instance
@@ -220,7 +220,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
      * Constructs a fresh instance with the given prefetch amount and the optional
      * refCount-behavior.
      * @param bufferSize the prefetch amount
-     * @param refCount if true and if all Subscribers have canceled, the upstream
+     * @param refCount if true and if all Subscribers have cancelled, the upstream
      * is cancelled
      */
     @SuppressWarnings("unchecked")
@@ -237,7 +237,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
      * Initializes this Processor by setting an upstream Subscription that
      * ignores request amounts, uses a fixed buffer
      * and allows using the onXXX and offer methods
-     * afterwards.
+     * afterward.
      */
     public void start() {
         if (SubscriptionHelper.setOnce(upstream, EmptySubscription.INSTANCE)) {
@@ -249,7 +249,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
      * Initializes this Processor by setting an upstream Subscription that
      * ignores request amounts, uses an unbounded buffer
      * and allows using the onXXX and offer methods
-     * afterwards.
+     * afterward.
      */
     public void startUnbounded() {
         if (SubscriptionHelper.setOnce(upstream, EmptySubscription.INSTANCE)) {

--- a/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
@@ -58,7 +58,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
  * if the processor is used as a standalone source. However, calling {@code onSubscribe}
  * after the {@code PublishProcessor} reached its terminal state will result in the
- * given {@link Subscription} being canceled immediately.
+ * given {@link Subscription} being cancelled immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #offer(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
  * is required to be serialized (called from the same thread or called non-overlappingly from different threads

--- a/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
@@ -85,7 +85,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
  * if the processor is used as a standalone source. However, calling {@code onSubscribe}
  * after the {@code ReplayProcessor} reached its terminal state will result in the
- * given {@code Subscription} being canceled immediately.
+ * given {@code Subscription} being cancelled immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
  * is required to be serialized (called from the same thread or called non-overlappingly from different threads
@@ -210,7 +210,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
      * {@code size} {@code onNext} events followed by a termination event.
      * <p>
      * If a {@code Subscriber} subscribes while the {@code ReplayProcessor} is active, it will observe all items in the
-     * buffer at that point in time and each item observed afterwards, even if the buffer evicts items due to
+     * buffer at that point in time and each item observed afterward, even if the buffer evicts items due to
      * the size constraint in the meantime. In other words, once a {@code Subscriber} subscribes, it will receive items
      * without gaps in the sequence.
      *

--- a/src/main/java/io/reactivex/rxjava4/processors/UnicastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/UnicastProcessor.java
@@ -79,7 +79,7 @@ import io.reactivex.rxjava4.plugins.RxJavaPlugins;
  * {@code onSubscribe} is not required (<a href="https://github.com/reactive-streams/reactive-streams-jvm#2.12">Rule 2.12</a>)
  * if the processor is used as a standalone source. However, calling {@code onSubscribe}
  * after the {@code UnicastProcessor} reached its terminal state will result in the
- * given {@code Subscription} being canceled immediately.
+ * given {@code Subscription} being cancelled immediately.
  * <p>
  * Calling {@link #onNext(Object)}, {@link #onError(Throwable)} and {@link #onComplete()}
  * is required to be serialized (called from the same thread or called non-overlappingly from different threads

--- a/src/main/java/io/reactivex/rxjava4/schedulers/BlockingScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/BlockingScheduler.java
@@ -24,17 +24,17 @@ import io.reactivex.rxjava4.internal.schedulers.BlockingCurrentThreadScheduler;
  * @implNote No need to instantiate this record by client applications, it serves as a way to
  *           give access to the {@code Scheduler} interface as well as the blocking-specific
  *           {@link #execute()} methods.
- * @param bcts the scheduler instance
+ * @param backingScheduler the scheduler instance
  * @since 4.0.0
  */
-public record BlockingScheduler(BlockingCurrentThreadScheduler bcts) {
+public record BlockingScheduler(BlockingCurrentThreadScheduler backingScheduler) {
 
     /**
      * Returns the Scheduler view to submit tasks to or use it as a parameter.
      * @return the Scheduler view of the underlying blocking current thread scheduler.
      */
     public Scheduler scheduler( ) {
-        return bcts;
+        return backingScheduler;
     }
 
     /**
@@ -55,13 +55,13 @@ public record BlockingScheduler(BlockingCurrentThreadScheduler bcts) {
      * @param action the action to execute
      */
     public void execute(Action action) {
-        bcts.execute(action);
+        backingScheduler.execute(action);
     }
 
     /**
      * Shuts down the underlying blocking current thread scheduler
      */
     public void shutdown() {
-        bcts.shutdown();
+        backingScheduler.shutdown();
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Schedulers.java
@@ -406,7 +406,7 @@ public final class Schedulers {
      * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
      * the {@code RejectedExecutionException} is routed to the global error handler via
      * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-related problems, it is recommended
-     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * all flows using the returned {@code Scheduler} to be cancelled/disposed before the underlying
      * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
      * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
      * <p>
@@ -484,7 +484,7 @@ public final class Schedulers {
      * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
      * the {@code RejectedExecutionException} is routed to the global error handler via
      * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-related problems, it is recommended
-     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * all flows using the returned {@code Scheduler} to be cancelled/disposed before the underlying
      * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
      * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
      * <p>
@@ -568,7 +568,7 @@ public final class Schedulers {
      * If the {@link Executor#execute(Runnable)} or {@link ExecutorService#submit(Callable)} throws,
      * the {@code RejectedExecutionException} is routed to the global error handler via
      * {@link RxJavaPlugins#onError(Throwable)}. To avoid shutdown-related problems, it is recommended
-     * all flows using the returned {@code Scheduler} to be canceled/disposed before the underlying
+     * all flows using the returned {@code Scheduler} to be cancelled/disposed before the underlying
      * {@code Executor} is shut down. To avoid problems due to the {@code Executor} having a bounded-queue,
      * it is recommended to rephrase the flow to utilize backpressure as the means to limit outstanding work.
      * <p>

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
@@ -23,16 +23,13 @@ import io.reactivex.rxjava4.annotations.NonNull;
  *
  * @param <T> the value type
  */
-public final class Timed<T> {
-    final T value;
-    final long time;
-    final TimeUnit unit;
-
+public record Timed<T>(T value, long time, TimeUnit unit) {
     /**
      * Constructs a {@code Timed} instance with the given value and time information.
+     *
      * @param value the value to hold
-     * @param time the time to hold
-     * @param unit the time unit, not null
+     * @param time  the time to hold
+     * @param unit  the time unit, not null
      * @throws NullPointerException if {@code value} or {@code unit} is {@code null}
      */
     public Timed(@NonNull T value, long time, @NonNull TimeUnit unit) {
@@ -42,33 +39,8 @@ public final class Timed<T> {
     }
 
     /**
-     * Returns the contained value.
-     * @return the contained value
-     */
-    @NonNull
-    public T value() {
-        return value;
-    }
-
-    /**
-     * Returns the time unit of the contained time.
-     * @return the time unit of the contained time
-     */
-    @NonNull
-    public TimeUnit unit() {
-        return unit;
-    }
-
-    /**
-     * Returns the time value.
-     * @return the time value
-     */
-    public long time() {
-        return time;
-    }
-
-    /**
      * Returns the contained time value in the time unit specified.
+     *
      * @param unit the time unit
      * @return the converted time
      */
@@ -78,10 +50,10 @@ public final class Timed<T> {
 
     @Override
     public boolean equals(Object other) {
-        if (other instanceof Timed<?> o) {
-            return Objects.equals(value, o.value)
-                    && time == o.time
-                    && Objects.equals(unit, o.unit);
+        if (other instanceof Timed<?>(Object value1, long time1, TimeUnit unit1)) {
+            return Objects.equals(value, value1)
+                    && time == time1
+                    && Objects.equals(unit, unit1);
         }
         return false;
     }
@@ -89,7 +61,7 @@ public final class Timed<T> {
     @Override
     public int hashCode() {
         int h = value.hashCode();
-        h = h * 31 + (int)((time >>> 31) ^ time);
+        h = h * 31 + (int) ((time >>> 31) ^ time);
         h = h * 31 + unit.hashCode();
         return h;
     }

--- a/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/Timed.java
@@ -22,6 +22,10 @@ import io.reactivex.rxjava4.annotations.NonNull;
  * Holds onto a value along with time information.
  *
  * @param <T> the value type
+ * @param value the item to store
+ * @param time the time value
+ * @param unit the unit of time
+ * @since 4.0.0
  */
 public record Timed<T>(T value, long time, TimeUnit unit) {
     /**
@@ -32,10 +36,9 @@ public record Timed<T>(T value, long time, TimeUnit unit) {
      * @param unit  the time unit, not null
      * @throws NullPointerException if {@code value} or {@code unit} is {@code null}
      */
-    public Timed(@NonNull T value, long time, @NonNull TimeUnit unit) {
-        this.value = Objects.requireNonNull(value, "value is null");
-        this.time = time;
-        this.unit = Objects.requireNonNull(unit, "unit is null");
+    public Timed {
+        Objects.requireNonNull(value, "value is null");
+        Objects.requireNonNull(unit, "unit is null");
     }
 
     /**
@@ -46,24 +49,6 @@ public record Timed<T>(T value, long time, TimeUnit unit) {
      */
     public long time(@NonNull TimeUnit unit) {
         return unit.convert(time, this.unit);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other instanceof Timed<?>(Object value1, long time1, TimeUnit unit1)) {
-            return Objects.equals(value, value1)
-                    && time == time1
-                    && Objects.equals(unit, unit1);
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        int h = value.hashCode();
-        h = h * 31 + (int) ((time >>> 31) ^ time);
-        h = h * 31 + unit.hashCode();
-        return h;
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
@@ -197,7 +197,7 @@ public final class ReplaySubject<T> extends Subject<T> {
      * {@code size} {@code onNext} events followed by a termination event.
      * <p>
      * If an observer subscribes while the {@code ReplaySubject} is active, it will observe all items in the
-     * buffer at that point in time and each item observed afterwards, even if the buffer evicts items due to
+     * buffer at that point in time and each item observed afterward, even if the buffer evicts items due to
      * the size constraint in the meantime. In other words, once an Observer subscribes, it will receive items
      * without gaps in the sequence.
      *

--- a/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.subscribers;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.*;
 
 import static java.util.concurrent.Flow.*;
@@ -187,11 +188,7 @@ implements FlowableSubscriber<T>, Subscription {
         try {
             lastThread = Thread.currentThread();
 
-            if (t == null) {
-                errors.add(new NullPointerException("onError received a null Throwable"));
-            } else {
-                errors.add(t);
-            }
+            errors.add(Objects.requireNonNullElseGet(t, () -> new NullPointerException("onError received a null Throwable")));
 
             downstream.onError(t);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletableTest.java
@@ -90,7 +90,7 @@ public class CompletableAndThenCompletableTest extends RxJavaTest {
     }
 
     @Test
-    public void andThenCanceled() {
+    public void andThenCancelled() {
         final AtomicInteger completableRunCount = new AtomicInteger();
         Completable.fromRunnable(completableRunCount::incrementAndGet)
                 .andThen(Completable.complete())

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -1365,13 +1365,13 @@ public class FlowableGroupByTest extends RxJavaTest {
 
         final List<String> list = new CopyOnWriteArrayList<>();
         Flowable<Integer> stream = source //
-                .doOnCancel(() -> list.add("Source canceled"))
+                .doOnCancel(() -> list.add("Source cancelled"))
                 .<Integer, Integer>groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), false,
                         Flowable.bufferSize(), mapFactory) //
                 .flatMap(group -> group //
-                        .doOnComplete(() -> list.add("Group completed")).doOnCancel(() -> list.add("Group canceled")));
+                        .doOnComplete(() -> list.add("Group completed")).doOnCancel(() -> list.add("Group cancelled")));
         TestSubscriber<Integer> ts = stream //
-                .doOnCancel(() -> list.add("Outer group by canceled")).test();
+                .doOnCancel(() -> list.add("Outer group by cancelled")).test();
 
         // Send 3 in the same group and wait for them to be seen
         source.onNext(1);
@@ -1391,16 +1391,16 @@ public class FlowableGroupByTest extends RxJavaTest {
         ts.cancel();
 
         // Observe the result.  Note that right now the result differs depending on whether eviction occurred or
-        // not.  The observed sequence in that case is:  Group completed, Outer group by canceled., Group canceled.
+        // not.  The observed sequence in that case is:  Group completed, Outer group by cancelled., Group cancelled.
         // The addition of the "Group completed" is actually fine, but the fact that the cancel doesn't reach the
         // source seems like a bug.  Commenting out the setting of "tick" above will produce the "expected" sequence.
         System.out.println(list);
-        assertTrue(list.contains("Source canceled"));
+        assertTrue(list.contains("Source cancelled"));
         assertEquals(Arrays.asList(
                 "Group completed", // this is here when eviction occurs
-                "Outer group by canceled",
-                "Group canceled",
-                "Source canceled"  // This is *not* here when eviction occurs
+                "Outer group by cancelled",
+                "Group cancelled",
+                "Source cancelled"  // This is *not* here when eviction occurs
         ), list);
     }
 

--- a/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/UnicastProcessorTest.java
@@ -147,7 +147,7 @@ public class UnicastProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     @Test
-    public void onTerminateCalledWhenCanceled() {
+    public void onTerminateCalledWhenCancelled() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
         UnicastProcessor<Integer> up = UnicastProcessor.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));

--- a/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/UnicastSubjectTest.java
@@ -185,7 +185,7 @@ public class UnicastSubjectTest extends SubjectTest<Integer> {
     }
 
     @Test
-    public void onTerminateCalledWhenCanceled() {
+    public void onTerminateCalledWhenCancelled() {
         final AtomicBoolean didRunOnTerminate = new AtomicBoolean();
 
         UnicastSubject<Integer> us = UnicastSubject.create(Observable.bufferSize(), () -> didRunOnTerminate.set(true));

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -1644,6 +1644,18 @@ public class TestSubscriberTest extends RxJavaTest {
         ts.assertFailure(NullPointerException.class);
     }
 
+    @Test
+    public void asDisposable() {
+        var ts = new TestSubscriber<>();
+        var d = ts.asDisposable();
+
+        assertFalse("d is disposed", d.isDisposed());
+
+        d.dispose();
+
+        assertTrue("d is disposed", d.isDisposed());
+    }
+
     static final class TestSubscriberImpl<T> extends TestSubscriber<T> {
         public boolean isTimeout() {
             return timeout;

--- a/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
@@ -170,7 +170,7 @@ extends BaseTestConsumer<T, U> {
     }
 
     /**
-     * Assert that the upstream signalled the specified values in order and then failed
+     * Assert that the upstream signaled the specified values in order and then failed
      * with a Throwable for which the provided predicate returns true.
      * @param errorPredicate
      *            the predicate that receives the error Throwable
@@ -187,7 +187,7 @@ extends BaseTestConsumer<T, U> {
     }
 
     /**
-     * Assert that the upstream signalled the specified values in order,
+     * Assert that the upstream signaled the specified values in order,
      * then failed with a specific class or subclass of Throwable
      * and with the given exact error message.
      * @param error the expected exception (parent) class


### PR DESCRIPTION
- Decided to use `Cancelled` with two Ls because API already usees that spelling.
- `signalled` -> `signaled`
- `Timed` is now a record class.