### PR TITLE
4.x: Java Migration; records, newer API, newer syntax

### DIFF
--- a/src/jmh/java/io/reactivex/rxjava4/core/InputWithIncrementingInteger.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/InputWithIncrementingInteger.java
@@ -44,57 +44,45 @@ public abstract class InputWithIncrementingInteger {
         }
     }
 
-    static final class IncrementingIterable implements Iterable<Integer> {
+    record IncrementingIterable(int size) implements Iterable<Integer> {
 
-        final class IncrementingIterator implements Iterator<Integer> {
-            int i;
+            final class IncrementingIterator implements Iterator<Integer> {
+                int i;
 
-            @Override
-            public boolean hasNext() {
-                return i < size;
+                @Override
+                public boolean hasNext() {
+                    return i < size;
+                }
+
+                @Override
+                public Integer next() {
+                    Blackhole.consumeCPU(10);
+                    return i++;
+                }
+
+                @Override
+                public void remove() {
+
+                }
             }
-
-            @Override
-            public Integer next() {
-                Blackhole.consumeCPU(10);
-                return i++;
-            }
-
-            @Override
-            public void remove() {
-
-            }
-        }
-
-        final int size;
-
-        IncrementingIterable(int size) {
-            this.size = size;
-        }
 
         @Override
-        public Iterator<Integer> iterator() {
-            return new IncrementingIterator();
+            public Iterator<Integer> iterator() {
+                return new IncrementingIterator();
+            }
         }
-    }
 
-    static final class IncrementingPublisher implements Publisher<Integer> {
-
-        final int size;
-
-        IncrementingPublisher(int size) {
-            this.size = size;
-        }
+    record IncrementingPublisher(int size) implements Publisher<Integer> {
 
         @Override
-        public void subscribe(Subscriber<? super Integer> s) {
-            s.onSubscribe(EmptySubscription.INSTANCE);
-            for (int i = 0; i < size; i++) {
-                s.onNext(i);
+            public void subscribe(Subscriber<? super Integer> s) {
+                s.onSubscribe(EmptySubscription.INSTANCE);
+                for (int i = 0; i < size; i++) {
+                    s.onNext(i);
+                }
+                s.onComplete();
             }
-            s.onComplete();
         }
-    }
 
     public Iterable<Integer> iterable;
     public Flowable<Integer> flowable;

--- a/src/jmh/java/io/reactivex/rxjava4/core/StrictPerf.java
+++ b/src/jmh/java/io/reactivex/rxjava4/core/StrictPerf.java
@@ -54,67 +54,51 @@ public class StrictPerf {
         source.subscribe(new ExternalConsumer(bh, cpu));
     }
 
-    static final class InternalConsumer implements FlowableSubscriber<Object> {
-        final Blackhole bh;
-
-        final int cycles;
-
-        InternalConsumer(Blackhole bh, int cycles) {
-            this.bh = bh;
-            this.cycles = cycles;
-        }
+    record InternalConsumer(Blackhole bh, int cycles) implements FlowableSubscriber<Object> {
 
         @Override
-        public void onNext(Object t) {
-            bh.consume(t);
-            Blackhole.consumeCPU(cycles);
+            public void onNext(Object t) {
+                bh.consume(t);
+                Blackhole.consumeCPU(cycles);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                bh.consume(t);
+            }
+
+            @Override
+            public void onComplete() {
+                bh.consume(true);
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
         }
+
+    record ExternalConsumer(Blackhole bh, int cycles) implements Subscriber<Object> {
 
         @Override
-        public void onError(Throwable t) {
-            bh.consume(t);
+            public void onNext(Object t) {
+                bh.consume(t);
+                Blackhole.consumeCPU(cycles);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                bh.consume(t);
+            }
+
+            @Override
+            public void onComplete() {
+                bh.consume(true);
+            }
+
+            @Override
+            public void onSubscribe(Subscription s) {
+                s.request(Long.MAX_VALUE);
+            }
         }
-
-        @Override
-        public void onComplete() {
-            bh.consume(true);
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            s.request(Long.MAX_VALUE);
-        }
-    }
-
-    static final class ExternalConsumer implements Subscriber<Object> {
-        final Blackhole bh;
-
-        final int cycles;
-
-        ExternalConsumer(Blackhole bh, int cycles) {
-            this.bh = bh;
-            this.cycles = cycles;
-        }
-
-        @Override
-        public void onNext(Object t) {
-            bh.consume(t);
-            Blackhole.consumeCPU(cycles);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            bh.consume(t);
-        }
-
-        @Override
-        public void onComplete() {
-            bh.consume(true);
-        }
-
-        @Override
-        public void onSubscribe(Subscription s) {
-            s.request(Long.MAX_VALUE);
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -2467,18 +2467,13 @@ FlowableDocBasic<T>
         Objects.requireNonNull(source, "source is null");
         Objects.requireNonNull(strategy, "strategy is null");
         Flowable<T> f = new FlowableFromObservable<>(source);
-        switch (strategy) {
-            case DROP:
-                return f.onBackpressureDrop();
-            case LATEST:
-                return f.onBackpressureLatest();
-            case MISSING:
-                return f;
-            case ERROR:
-                return RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<>(f));
-            default:
-                return f.onBackpressureBuffer();
-        }
+        return switch (strategy) {
+            case DROP -> f.onBackpressureDrop();
+            case LATEST -> f.onBackpressureLatest();
+            case MISSING -> f;
+            case ERROR -> RxJavaPlugins.onAssembly(new FlowableOnBackpressureError<>(f));
+            default -> f.onBackpressureBuffer();
+        };
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -93,8 +93,10 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
      */
     default Streamer<T> finishVia(@NonNull DisposableContainer canceller) {
         Objects.requireNonNull(canceller, "canceller is null");
-        if (this instanceof StreamerFinishViaDisposableContainerCanceller<T> augment) {
-            if (augment.streamer == this && augment.canceller == canceller) {
+        if (this instanceof StreamerFinishViaDisposableContainerCanceller<T>(
+                Streamer<T> streamer, DisposableContainer canceller1
+        )) {
+            if (streamer == this && canceller1 == canceller) {
                 // DO not rewrap!
                 return this;
             }

--- a/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/CompositeException.java
@@ -64,13 +64,11 @@ public final class CompositeException extends RuntimeException {
         Set<Throwable> deDupedExceptions = new LinkedHashSet<>();
         if (errors != null) {
             for (Throwable ex : errors) {
-                if (ex instanceof CompositeException) {
-                    deDupedExceptions.addAll(((CompositeException) ex).getExceptions());
-                } else
-                if (ex != null) {
-                    deDupedExceptions.add(ex);
+                if (ex instanceof CompositeException ce) {
+                    deDupedExceptions.addAll(ce.getExceptions());
                 } else {
-                    deDupedExceptions.add(new NullPointerException("Throwable was null!"));
+                    deDupedExceptions.add(Objects.requireNonNullElseGet(ex,
+                            () -> new NullPointerException("Throwable was null!")));
                 }
             }
         } else {

--- a/src/main/java/io/reactivex/rxjava4/internal/functions/Functions.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/functions/Functions.java
@@ -143,18 +143,13 @@ public final class Functions {
         return (Supplier<T>)NULL_SUPPLIER;
     }
 
-    static final class FutureAction implements Action {
-        final Future<?> future;
-
-        FutureAction(Future<?> future) {
-            this.future = future;
-        }
+    record FutureAction(Future<?> future) implements Action {
 
         @Override
-        public void run() throws Exception {
-            future.get();
+            public void run() throws Exception {
+                future.get();
+            }
         }
-    }
 
     /**
      * Wraps the blocking get call of the Future into an Action.
@@ -166,28 +161,23 @@ public final class Functions {
         return new FutureAction(future);
     }
 
-    static final class JustValue<T, U> implements Callable<U>, Supplier<U>, Function<T, U> {
-        final U value;
-
-        JustValue(U value) {
-            this.value = value;
-        }
+    record JustValue<T, U>(U value) implements Callable<U>, Supplier<U>, Function<T, U> {
 
         @Override
-        public U call() {
-            return value;
-        }
+            public U call() {
+                return value;
+            }
 
-        @Override
-        public U apply(T t) {
-            return value;
-        }
+            @Override
+            public U apply(T t) {
+                return value;
+            }
 
-        @Override
-        public U get() {
-            return value;
+            @Override
+            public U get() {
+                return value;
+            }
         }
-    }
 
     /**
      * Returns a Callable that returns the given value.
@@ -223,18 +213,13 @@ public final class Functions {
         return new JustValue<>(value);
     }
 
-    static final class CastToClass<T, U> implements Function<T, U> {
-        final Class<U> clazz;
-
-        CastToClass(Class<U> clazz) {
-            this.clazz = clazz;
-        }
+    record CastToClass<T, U>(Class<U> clazz) implements Function<T, U> {
 
         @Override
-        public U apply(T t) {
-            return clazz.cast(t);
+            public U apply(T t) {
+                return clazz.cast(t);
+            }
         }
-    }
 
     /**
      * Returns a function that cast the incoming values via a Class object.
@@ -248,35 +233,25 @@ public final class Functions {
         return new CastToClass<>(target);
     }
 
-    static final class ArrayListCapacityCallable<T> implements Supplier<List<T>> {
-        final int capacity;
-
-        ArrayListCapacityCallable(int capacity) {
-            this.capacity = capacity;
-        }
+    record ArrayListCapacityCallable<T>(int capacity) implements Supplier<List<T>> {
 
         @Override
-        public List<T> get() {
-            return new ArrayList<>(capacity);
+            public List<T> get() {
+                return new ArrayList<>(capacity);
+            }
         }
-    }
 
     public static <T> Supplier<List<T>> createArrayList(int capacity) {
         return new ArrayListCapacityCallable<>(capacity);
     }
 
-    static final class EqualsPredicate<T> implements Predicate<T> {
-        final T value;
-
-        EqualsPredicate(T value) {
-            this.value = value;
-        }
+    record EqualsPredicate<T>(T value) implements Predicate<T> {
 
         @Override
-        public boolean test(T t) {
-            return Objects.equals(t, value);
+            public boolean test(T t) {
+                return Objects.equals(t, value);
+            }
         }
-    }
 
     public static <T> Predicate<T> equalsWith(T value) {
         return new EqualsPredicate<>(value);
@@ -295,44 +270,29 @@ public final class Functions {
         return (Supplier)HashSetSupplier.INSTANCE;
     }
 
-    static final class NotificationOnNext<T> implements Consumer<T> {
-        final Consumer<? super Notification<T>> onNotification;
-
-        NotificationOnNext(Consumer<? super Notification<T>> onNotification) {
-            this.onNotification = onNotification;
-        }
+    record NotificationOnNext<T>(Consumer<? super Notification<T>> onNotification) implements Consumer<T> {
 
         @Override
-        public void accept(T v) throws Throwable {
-            onNotification.accept(Notification.createOnNext(v));
+            public void accept(T v) throws Throwable {
+                onNotification.accept(Notification.createOnNext(v));
+            }
         }
-    }
 
-    static final class NotificationOnError<T> implements Consumer<Throwable> {
-        final Consumer<? super Notification<T>> onNotification;
-
-        NotificationOnError(Consumer<? super Notification<T>> onNotification) {
-            this.onNotification = onNotification;
-        }
+    record NotificationOnError<T>(Consumer<? super Notification<T>> onNotification) implements Consumer<Throwable> {
 
         @Override
-        public void accept(Throwable v) throws Throwable {
-            onNotification.accept(Notification.createOnError(v));
+            public void accept(Throwable v) throws Throwable {
+                onNotification.accept(Notification.createOnError(v));
+            }
         }
-    }
 
-    static final class NotificationOnComplete<T> implements Action {
-        final Consumer<? super Notification<T>> onNotification;
-
-        NotificationOnComplete(Consumer<? super Notification<T>> onNotification) {
-            this.onNotification = onNotification;
-        }
+    record NotificationOnComplete<T>(Consumer<? super Notification<T>> onNotification) implements Action {
 
         @Override
-        public void run() throws Throwable {
-            onNotification.accept(Notification.createOnComplete());
+            public void run() throws Throwable {
+                onNotification.accept(Notification.createOnComplete());
+            }
         }
-    }
 
     public static <T> Consumer<T> notificationOnNext(Consumer<? super Notification<T>> onNotification) {
         return new NotificationOnNext<>(onNotification);
@@ -346,72 +306,49 @@ public final class Functions {
         return new NotificationOnComplete<>(onNotification);
     }
 
-    static final class ActionConsumer<T> implements Consumer<T> {
-        final Action action;
-
-        ActionConsumer(Action action) {
-            this.action = action;
-        }
+    record ActionConsumer<T>(Action action) implements Consumer<T> {
 
         @Override
-        public void accept(T t) throws Throwable {
-            action.run();
+            public void accept(T t) throws Throwable {
+                action.run();
+            }
         }
-    }
 
     public static <T> Consumer<T> actionConsumer(Action action) {
         return new ActionConsumer<>(action);
     }
 
-    static final class ClassFilter<T, U> implements Predicate<T> {
-        final Class<U> clazz;
-
-        ClassFilter(Class<U> clazz) {
-            this.clazz = clazz;
-        }
+    record ClassFilter<T, U>(Class<U> clazz) implements Predicate<T> {
 
         @Override
-        public boolean test(T t) {
-            return clazz.isInstance(t);
+            public boolean test(T t) {
+                return clazz.isInstance(t);
+            }
         }
-    }
 
     public static <T, U> Predicate<T> isInstanceOf(Class<U> clazz) {
         return new ClassFilter<>(clazz);
     }
 
-    static final class BooleanSupplierPredicateReverse<T> implements Predicate<T> {
-        final BooleanSupplier supplier;
-
-        BooleanSupplierPredicateReverse(BooleanSupplier supplier) {
-            this.supplier = supplier;
-        }
+    record BooleanSupplierPredicateReverse<T>(BooleanSupplier supplier) implements Predicate<T> {
 
         @Override
-        public boolean test(T t) throws Throwable {
-            return !supplier.getAsBoolean();
+            public boolean test(T t) throws Throwable {
+                return !supplier.getAsBoolean();
+            }
         }
-    }
 
     public static <T> Predicate<T> predicateReverseFor(BooleanSupplier supplier) {
         return new BooleanSupplierPredicateReverse<>(supplier);
     }
 
-    static final class TimestampFunction<T> implements Function<T, Timed<T>> {
-        final TimeUnit unit;
-
-        final Scheduler scheduler;
-
-        TimestampFunction(TimeUnit unit, Scheduler scheduler) {
-            this.unit = unit;
-            this.scheduler = scheduler;
-        }
+    record TimestampFunction<T>(TimeUnit unit, Scheduler scheduler) implements Function<T, Timed<T>> {
 
         @Override
-        public Timed<T> apply(T t) {
-            return new Timed<>(t, scheduler.now(unit), unit);
+            public Timed<T> apply(T t) {
+                return new Timed<>(t, scheduler.now(unit), unit);
+            }
         }
-    }
 
     public static <T> Function<T, Timed<T>> timestampWith(TimeUnit unit, Scheduler scheduler) {
         return new TimestampFunction<>(unit, scheduler);
@@ -508,19 +445,14 @@ public final class Functions {
         return (Comparator<T>)NaturalComparator.INSTANCE;
     }
 
-    static final class ListSorter<T> implements Function<List<T>, List<T>> {
-        final Comparator<? super T> comparator;
-
-        ListSorter(Comparator<? super T> comparator) {
-            this.comparator = comparator;
-        }
+    record ListSorter<T>(Comparator<? super T> comparator) implements Function<List<T>, List<T>> {
 
         @Override
-        public List<T> apply(List<T> v) {
-            Collections.sort(v, comparator);
-            return v;
+            public List<T> apply(List<T> v) {
+                v.sort(comparator);
+                return v;
+            }
         }
-    }
 
     public static <T> Function<List<T>, List<T>> listSorter(final Comparator<? super T> comparator) {
         return new ListSorter<>(comparator);
@@ -528,56 +460,41 @@ public final class Functions {
 
     public static final Consumer<Subscription> REQUEST_MAX = new MaxRequestSubscription();
 
-    static final class Array2Func<T1, T2, R> implements Function<Object[], R> {
-        final BiFunction<? super T1, ? super T2, ? extends R> f;
-
-        Array2Func(BiFunction<? super T1, ? super T2, ? extends R> f) {
-            this.f = f;
-        }
+    record Array2Func<T1, T2, R>(BiFunction<? super T1, ? super T2, ? extends R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 2) {
-                throw new IllegalArgumentException("Array of size 2 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 2) {
+                    throw new IllegalArgumentException("Array of size 2 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1]);
             }
-            return f.apply((T1)a[0], (T2)a[1]);
         }
-    }
 
-    static final class Array3Func<T1, T2, T3, R> implements Function<Object[], R> {
-        final Function3<T1, T2, T3, R> f;
-
-        Array3Func(Function3<T1, T2, T3, R> f) {
-            this.f = f;
-        }
+    record Array3Func<T1, T2, T3, R>(Function3<T1, T2, T3, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 3) {
-                throw new IllegalArgumentException("Array of size 3 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 3) {
+                    throw new IllegalArgumentException("Array of size 3 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2]);
         }
-    }
 
-    static final class Array4Func<T1, T2, T3, T4, R> implements Function<Object[], R> {
-        final Function4<T1, T2, T3, T4, R> f;
-
-        Array4Func(Function4<T1, T2, T3, T4, R> f) {
-            this.f = f;
-        }
+    record Array4Func<T1, T2, T3, T4, R>(Function4<T1, T2, T3, T4, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 4) {
-                throw new IllegalArgumentException("Array of size 4 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 4) {
+                    throw new IllegalArgumentException("Array of size 4 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2], (T4) a[3]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2], (T4)a[3]);
         }
-    }
 
     static final class Array5Func<T1, T2, T3, T4, T5, R> implements Function<Object[], R> {
         private final Function5<T1, T2, T3, T4, T5, R> f;
@@ -596,73 +513,57 @@ public final class Functions {
         }
     }
 
-    static final class Array6Func<T1, T2, T3, T4, T5, T6, R> implements Function<Object[], R> {
-        final Function6<T1, T2, T3, T4, T5, T6, R> f;
-
-        Array6Func(Function6<T1, T2, T3, T4, T5, T6, R> f) {
-            this.f = f;
-        }
+    record Array6Func<T1, T2, T3, T4, T5, T6, R>(
+            Function6<T1, T2, T3, T4, T5, T6, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 6) {
-                throw new IllegalArgumentException("Array of size 6 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 6) {
+                    throw new IllegalArgumentException("Array of size 6 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2], (T4) a[3], (T5) a[4], (T6) a[5]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2], (T4)a[3], (T5)a[4], (T6)a[5]);
         }
-    }
 
-    static final class Array7Func<T1, T2, T3, T4, T5, T6, T7, R> implements Function<Object[], R> {
-        final Function7<T1, T2, T3, T4, T5, T6, T7, R> f;
-
-        Array7Func(Function7<T1, T2, T3, T4, T5, T6, T7, R> f) {
-            this.f = f;
-        }
+    record Array7Func<T1, T2, T3, T4, T5, T6, T7, R>(
+            Function7<T1, T2, T3, T4, T5, T6, T7, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 7) {
-                throw new IllegalArgumentException("Array of size 7 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 7) {
+                    throw new IllegalArgumentException("Array of size 7 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2], (T4) a[3], (T5) a[4], (T6) a[5], (T7) a[6]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2], (T4)a[3], (T5)a[4], (T6)a[5], (T7)a[6]);
         }
-    }
 
-    static final class Array8Func<T1, T2, T3, T4, T5, T6, T7, T8, R> implements Function<Object[], R> {
-        final Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f;
-
-        Array8Func(Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) {
-            this.f = f;
-        }
+    record Array8Func<T1, T2, T3, T4, T5, T6, T7, T8, R>(
+            Function8<T1, T2, T3, T4, T5, T6, T7, T8, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 8) {
-                throw new IllegalArgumentException("Array of size 8 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 8) {
+                    throw new IllegalArgumentException("Array of size 8 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2], (T4) a[3], (T5) a[4], (T6) a[5], (T7) a[6], (T8) a[7]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2], (T4)a[3], (T5)a[4], (T6)a[5], (T7)a[6], (T8)a[7]);
         }
-    }
 
-    static final class Array9Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> implements Function<Object[], R> {
-        final Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f;
-
-        Array9Func(Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) {
-            this.f = f;
-        }
+    record Array9Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, R>(
+            Function9<T1, T2, T3, T4, T5, T6, T7, T8, T9, R> f) implements Function<Object[], R> {
 
         @SuppressWarnings("unchecked")
-        @Override
-        public R apply(Object[] a) throws Throwable {
-            if (a.length != 9) {
-                throw new IllegalArgumentException("Array of size 9 expected but got " + a.length);
+            @Override
+            public R apply(Object[] a) throws Throwable {
+                if (a.length != 9) {
+                    throw new IllegalArgumentException("Array of size 9 expected but got " + a.length);
+                }
+                return f.apply((T1) a[0], (T2) a[1], (T3) a[2], (T4) a[3], (T5) a[4], (T6) a[5], (T7) a[6], (T8) a[7], (T9) a[8]);
             }
-            return f.apply((T1)a[0], (T2)a[1], (T3)a[2], (T4)a[3], (T5)a[4], (T6)a[5], (T7)a[6], (T8)a[7], (T9)a[8]);
         }
-    }
 
     static final class Identity implements Function<Object, Object> {
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/CompletableFromCompletionStage.java
@@ -45,35 +45,26 @@ public final class CompletableFromCompletionStage<T> extends Completable {
         stage.whenComplete(whenReference);
     }
 
-    static final class CompletionStageHandler<T>
-    implements Disposable, BiConsumer<T, Throwable> {
-
-        final CompletableObserver downstream;
-
-        final BiConsumerAtomicReference<T> whenReference;
-
-        CompletionStageHandler(CompletableObserver downstream, BiConsumerAtomicReference<T> whenReference) {
-            this.downstream = downstream;
-            this.whenReference = whenReference;
-        }
+    record CompletionStageHandler<T>(CompletableObserver downstream, BiConsumerAtomicReference<T> whenReference)
+            implements Disposable, BiConsumer<T, Throwable> {
 
         @Override
-        public void accept(T item, Throwable error) {
-            if (error != null) {
-                downstream.onError(error);
-            } else {
-                downstream.onComplete();
+            public void accept(T item, Throwable error) {
+                if (error != null) {
+                    downstream.onError(error);
+                } else {
+                    downstream.onComplete();
+                }
+            }
+
+            @Override
+            public void dispose() {
+                whenReference.set(null);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return whenReference.get() == null;
             }
         }
-
-        @Override
-        public void dispose() {
-            whenReference.set(null);
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return whenReference.get() == null;
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/MaybeFromCompletionStage.java
@@ -45,38 +45,28 @@ public final class MaybeFromCompletionStage<T> extends Maybe<T> {
         stage.whenComplete(whenReference);
     }
 
-    static final class CompletionStageHandler<T>
-    implements Disposable, BiConsumer<T, Throwable> {
-
-        final MaybeObserver<? super T> downstream;
-
-        final BiConsumerAtomicReference<T> whenReference;
-
-        CompletionStageHandler(MaybeObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
-            this.downstream = downstream;
-            this.whenReference = whenReference;
-        }
+    record CompletionStageHandler<T>(MaybeObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference)
+            implements Disposable, BiConsumer<T, Throwable> {
 
         @Override
-        public void accept(T item, Throwable error) {
-            if (error != null) {
-                downstream.onError(error);
+            public void accept(T item, Throwable error) {
+                if (error != null) {
+                    downstream.onError(error);
+                } else if (item != null) {
+                    downstream.onSuccess(item);
+                } else {
+                    downstream.onComplete();
+                }
             }
-            else if (item != null) {
-                downstream.onSuccess(item);
-            } else {
-                downstream.onComplete();
+
+            @Override
+            public void dispose() {
+                whenReference.set(null);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return whenReference.get() == null;
             }
         }
-
-        @Override
-        public void dispose() {
-            whenReference.set(null);
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return whenReference.get() == null;
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/jdk8/SingleFromCompletionStage.java
@@ -45,38 +45,28 @@ public final class SingleFromCompletionStage<T> extends Single<T> {
         stage.whenComplete(whenReference);
     }
 
-    static final class CompletionStageHandler<T>
-    implements Disposable, BiConsumer<T, Throwable> {
-
-        final SingleObserver<? super T> downstream;
-
-        final BiConsumerAtomicReference<T> whenReference;
-
-        CompletionStageHandler(SingleObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference) {
-            this.downstream = downstream;
-            this.whenReference = whenReference;
-        }
+    record CompletionStageHandler<T>(SingleObserver<? super T> downstream, BiConsumerAtomicReference<T> whenReference)
+            implements Disposable, BiConsumer<T, Throwable> {
 
         @Override
-        public void accept(T item, Throwable error) {
-            if (error != null) {
-                downstream.onError(error);
+            public void accept(T item, Throwable error) {
+                if (error != null) {
+                    downstream.onError(error);
+                } else if (item != null) {
+                    downstream.onSuccess(item);
+                } else {
+                    downstream.onError(new NullPointerException("The CompletionStage terminated with null."));
+                }
             }
-            else if (item != null) {
-                downstream.onSuccess(item);
-            } else {
-                downstream.onError(new NullPointerException("The CompletionStage terminated with null."));
+
+            @Override
+            public void dispose() {
+                whenReference.set(null);
+            }
+
+            @Override
+            public boolean isDisposed() {
+                return whenReference.get() == null;
             }
         }
-
-        @Override
-        public void dispose() {
-            whenReference.set(null);
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return whenReference.get() == null;
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableAndThenCompletable.java
@@ -80,30 +80,22 @@ public final class CompletableAndThenCompletable extends Completable {
         }
     }
 
-    static final class NextObserver implements CompletableObserver {
+    record NextObserver(AtomicReference<Disposable> parent,
+                        CompletableObserver downstream) implements CompletableObserver {
 
-        final AtomicReference<Disposable> parent;
+            @Override
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(parent, d);
+            }
 
-        final CompletableObserver downstream;
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
 
-        NextObserver(AtomicReference<Disposable> parent, CompletableObserver downstream) {
-            this.parent = parent;
-            this.downstream = downstream;
+            @Override
+            public void onError(Throwable e) {
+                downstream.onError(e);
+            }
         }
-
-        @Override
-        public void onSubscribe(Disposable d) {
-            DisposableHelper.replace(parent, d);
-        }
-
-        @Override
-        public void onComplete() {
-            downstream.onComplete();
-        }
-
-        @Override
-        public void onError(Throwable e) {
-            downstream.onError(e);
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromObservable.java
@@ -29,31 +29,26 @@ public final class CompletableFromObservable<T> extends Completable {
         observable.subscribe(new CompletableFromObservableObserver<>(observer));
     }
 
-    static final class CompletableFromObservableObserver<T> implements Observer<T> {
-        final CompletableObserver co;
-
-        CompletableFromObservableObserver(CompletableObserver co) {
-            this.co = co;
-        }
+    record CompletableFromObservableObserver<T>(CompletableObserver co) implements Observer<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            co.onSubscribe(d);
-        }
+            public void onSubscribe(Disposable d) {
+                co.onSubscribe(d);
+            }
 
-        @Override
-        public void onNext(T value) {
-            // Deliberately ignored.
-        }
+            @Override
+            public void onNext(T value) {
+                // Deliberately ignored.
+            }
 
-        @Override
-        public void onError(Throwable e) {
-            co.onError(e);
-        }
+            @Override
+            public void onError(Throwable e) {
+                co.onError(e);
+            }
 
-        @Override
-        public void onComplete() {
-            co.onComplete();
+            @Override
+            public void onComplete() {
+                co.onComplete();
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromSingle.java
@@ -29,26 +29,21 @@ public final class CompletableFromSingle<T> extends Completable {
         single.subscribe(new CompletableFromSingleObserver<>(observer));
     }
 
-    static final class CompletableFromSingleObserver<T> implements SingleObserver<T> {
-        final CompletableObserver co;
-
-        CompletableFromSingleObserver(CompletableObserver co) {
-            this.co = co;
-        }
+    record CompletableFromSingleObserver<T>(CompletableObserver co) implements SingleObserver<T> {
 
         @Override
-        public void onError(Throwable e) {
-            co.onError(e);
-        }
+            public void onError(Throwable e) {
+                co.onError(e);
+            }
 
-        @Override
-        public void onSubscribe(Disposable d) {
-            co.onSubscribe(d);
-        }
+            @Override
+            public void onSubscribe(Disposable d) {
+                co.onSubscribe(d);
+            }
 
-        @Override
-        public void onSuccess(T value) {
-            co.onComplete();
+            @Override
+            public void onSuccess(T value) {
+                co.onComplete();
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeArrayDelayError.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeArrayDelayError.java
@@ -57,11 +57,7 @@ public final class CompletableMergeArrayDelayError extends Completable {
         }
     }
 
-    static final class TryTerminateAndReportDisposable implements Disposable {
-        final AtomicThrowable errors;
-        TryTerminateAndReportDisposable(AtomicThrowable errors) {
-            this.errors = errors;
-        }
+    record TryTerminateAndReportDisposable(AtomicThrowable errors) implements Disposable {
 
         @Override
         public void dispose() {
@@ -74,20 +70,9 @@ public final class CompletableMergeArrayDelayError extends Completable {
         }
     }
 
-    static final class MergeInnerCompletableObserver
-    implements CompletableObserver {
-        final CompletableObserver downstream;
-        final CompositeDisposable set;
-        final AtomicThrowable errors;
-        final AtomicInteger wip;
-
-        MergeInnerCompletableObserver(CompletableObserver observer, CompositeDisposable set, AtomicThrowable error,
-                AtomicInteger wip) {
-            this.downstream = observer;
-            this.set = set;
-            this.errors = error;
-            this.wip = wip;
-        }
+    record MergeInnerCompletableObserver(CompletableObserver downstream, CompositeDisposable set,
+                                         AtomicThrowable errors, AtomicInteger wip)
+            implements CompletableObserver {
 
         @Override
         public void onSubscribe(Disposable d) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMap.java
@@ -47,14 +47,11 @@ public final class FlowableConcatMap<T, R> extends AbstractFlowableWithUpstream<
 
     public static <T, R> Subscriber<T> subscribe(Subscriber<? super R> s, Function<? super T, ? extends Publisher<? extends R>> mapper,
             int prefetch, ErrorMode errorMode) {
-        switch (errorMode) {
-        case BOUNDARY:
-            return new ConcatMapDelayed<>(s, mapper, prefetch, false);
-        case END:
-            return new ConcatMapDelayed<>(s, mapper, prefetch, true);
-        default:
-            return new ConcatMapImmediate<>(s, mapper, prefetch);
-        }
+        return switch (errorMode) {
+            case BOUNDARY -> new ConcatMapDelayed<>(s, mapper, prefetch, false);
+            case END -> new ConcatMapDelayed<>(s, mapper, prefetch, true);
+            default -> new ConcatMapImmediate<>(s, mapper, prefetch);
+        };
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupBy.java
@@ -312,19 +312,13 @@ public final class FlowableGroupBy<T, K, V> extends AbstractFlowableWithUpstream
         }
     }
 
-    static final class EvictionAction<K, V> implements Consumer<GroupedUnicast<K, V>> {
-
-        final Queue<GroupedUnicast<K, V>> evictedGroups;
-
-        EvictionAction(Queue<GroupedUnicast<K, V>> evictedGroups) {
-            this.evictedGroups = evictedGroups;
-        }
+    record EvictionAction<K, V>(Queue<GroupedUnicast<K, V>> evictedGroups) implements Consumer<GroupedUnicast<K, V>> {
 
         @Override
-        public void accept(GroupedUnicast<K, V> value) {
-            evictedGroups.offer(value);
+            public void accept(GroupedUnicast<K, V> value) {
+                evictedGroups.offer(value);
+            }
         }
-    }
 
     static final class GroupedUnicast<K, T> extends GroupedFlowable<K, T> {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableInternalHelper.java
@@ -33,98 +33,69 @@ public final class FlowableInternalHelper {
         throw new IllegalStateException("No instances!");
     }
 
-    static final class SimpleGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
-        final Consumer<Emitter<T>> consumer;
-
-        SimpleGenerator(Consumer<Emitter<T>> consumer) {
-            this.consumer = consumer;
-        }
+    record SimpleGenerator<T, S>(Consumer<Emitter<T>> consumer) implements BiFunction<S, Emitter<T>, S> {
 
         @Override
-        public S apply(S t1, Emitter<T> t2) throws Throwable {
-            consumer.accept(t2);
-            return t1;
+            public S apply(S t1, Emitter<T> t2) throws Throwable {
+                consumer.accept(t2);
+                return t1;
+            }
         }
-    }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
         return new SimpleGenerator<>(consumer);
     }
 
-    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
-        final BiConsumer<S, Emitter<T>> consumer;
-
-        SimpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
-            this.consumer = consumer;
-        }
+    record SimpleBiGenerator<T, S>(BiConsumer<S, Emitter<T>> consumer) implements BiFunction<S, Emitter<T>, S> {
 
         @Override
-        public S apply(S t1, Emitter<T> t2) throws Throwable {
-            consumer.accept(t1, t2);
-            return t1;
+            public S apply(S t1, Emitter<T> t2) throws Throwable {
+                consumer.accept(t1, t2);
+                return t1;
+            }
         }
-    }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
         return new SimpleBiGenerator<>(consumer);
     }
 
-    static final class ItemDelayFunction<T, U> implements Function<T, Publisher<T>> {
-        final Function<? super T, ? extends Publisher<U>> itemDelay;
-
-        ItemDelayFunction(Function<? super T, ? extends Publisher<U>> itemDelay) {
-            this.itemDelay = itemDelay;
-        }
+    record ItemDelayFunction<T, U>(
+            Function<? super T, ? extends Publisher<U>> itemDelay) implements Function<T, Publisher<T>> {
 
         @Override
-        public Publisher<T> apply(final T v) throws Throwable {
-            Publisher<U> p = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null Publisher");
-            return new FlowableTakePublisher<>(p, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            public Publisher<T> apply(final T v) throws Throwable {
+                Publisher<U> p = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null Publisher");
+                return new FlowableTakePublisher<>(p, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            }
         }
-    }
 
     public static <T, U> Function<T, Publisher<T>> itemDelay(final Function<? super T, ? extends Publisher<U>> itemDelay) {
         return new ItemDelayFunction<>(itemDelay);
     }
 
-    static final class SubscriberOnNext<T> implements Consumer<T> {
-        final Subscriber<T> subscriber;
-
-        SubscriberOnNext(Subscriber<T> subscriber) {
-            this.subscriber = subscriber;
-        }
+    record SubscriberOnNext<T>(Subscriber<T> subscriber) implements Consumer<T> {
 
         @Override
-        public void accept(T v) {
-            subscriber.onNext(v);
+            public void accept(T v) {
+                subscriber.onNext(v);
+            }
         }
-    }
 
-    static final class SubscriberOnError<T> implements Consumer<Throwable> {
-        final Subscriber<T> subscriber;
-
-        SubscriberOnError(Subscriber<T> subscriber) {
-            this.subscriber = subscriber;
-        }
+    record SubscriberOnError<T>(Subscriber<T> subscriber) implements Consumer<Throwable> {
 
         @Override
-        public void accept(Throwable v) {
-            subscriber.onError(v);
+            public void accept(Throwable v) {
+                subscriber.onError(v);
+            }
         }
-    }
 
-    static final class SubscriberOnComplete<T> implements Action {
-        final Subscriber<T> subscriber;
-
-        SubscriberOnComplete(Subscriber<T> subscriber) {
-            this.subscriber = subscriber;
-        }
+    record SubscriberOnComplete<T>(Subscriber<T> subscriber) implements Action {
 
         @Override
-        public void run() {
-            subscriber.onComplete();
+            public void run() {
+                subscriber.onComplete();
+            }
         }
-    }
 
     public static <T> Consumer<T> subscriberOnNext(Subscriber<T> subscriber) {
         return new SubscriberOnNext<>(subscriber);
@@ -220,63 +191,31 @@ public final class FlowableInternalHelper {
         }
     }
 
-    static final class ReplaySupplier<T> implements Supplier<ConnectableFlowable<T>> {
-
-        final Flowable<T> parent;
-
-        ReplaySupplier(Flowable<T> parent) {
-            this.parent = parent;
-        }
+    record ReplaySupplier<T>(Flowable<T> parent) implements Supplier<ConnectableFlowable<T>> {
 
         @Override
-        public ConnectableFlowable<T> get() {
-            return parent.replay();
+            public ConnectableFlowable<T> get() {
+                return parent.replay();
+            }
         }
-    }
 
-    static final class BufferedReplaySupplier<T> implements Supplier<ConnectableFlowable<T>> {
-
-        final Flowable<T> parent;
-
-        final int bufferSize;
-
-        final boolean eagerTruncate;
-
-        BufferedReplaySupplier(Flowable<T> parent, int bufferSize, boolean eagerTruncate) {
-            this.parent = parent;
-            this.bufferSize = bufferSize;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record BufferedReplaySupplier<T>(Flowable<T> parent, int bufferSize,
+                                     boolean eagerTruncate) implements Supplier<ConnectableFlowable<T>> {
 
         @Override
-        public ConnectableFlowable<T> get() {
-            return parent.replay(bufferSize, eagerTruncate);
+            public ConnectableFlowable<T> get() {
+                return parent.replay(bufferSize, eagerTruncate);
+            }
         }
-    }
 
-    static final class BufferedTimedReplay<T> implements Supplier<ConnectableFlowable<T>> {
-        final Flowable<T> parent;
-        final int bufferSize;
-        final long time;
-        final TimeUnit unit;
-        final Scheduler scheduler;
-
-        final boolean eagerTruncate;
-
-        BufferedTimedReplay(Flowable<T> parent, int bufferSize, long time, TimeUnit unit, Scheduler scheduler, boolean eagerTruncate) {
-            this.parent = parent;
-            this.bufferSize = bufferSize;
-            this.time = time;
-            this.unit = unit;
-            this.scheduler = scheduler;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record BufferedTimedReplay<T>(Flowable<T> parent, int bufferSize, long time, TimeUnit unit, Scheduler scheduler,
+                                  boolean eagerTruncate) implements Supplier<ConnectableFlowable<T>> {
 
         @Override
-        public ConnectableFlowable<T> get() {
-            return parent.replay(bufferSize, time, unit, scheduler, eagerTruncate);
+            public ConnectableFlowable<T> get() {
+                return parent.replay(bufferSize, time, unit, scheduler, eagerTruncate);
+            }
         }
-    }
 
     static final class TimedReplay<T> implements Supplier<ConnectableFlowable<T>> {
         private final Flowable<T> parent;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplay.java
@@ -1143,22 +1143,13 @@ public final class FlowableReplay<T> extends ConnectableFlowable<T> implements H
         }
     }
 
-    static final class ReplayBufferSupplier<T> implements Supplier<ReplayBuffer<T>> {
-
-        final int bufferSize;
-
-        final boolean eagerTruncate;
-
-        ReplayBufferSupplier(int bufferSize, boolean eagerTruncate) {
-            this.bufferSize = bufferSize;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record ReplayBufferSupplier<T>(int bufferSize, boolean eagerTruncate) implements Supplier<ReplayBuffer<T>> {
 
         @Override
-        public ReplayBuffer<T> get() {
-            return new SizeBoundReplayBuffer<>(bufferSize, eagerTruncate);
+            public ReplayBuffer<T> get() {
+                return new SizeBoundReplayBuffer<>(bufferSize, eagerTruncate);
+            }
         }
-    }
 
     static final class ScheduledReplayBufferSupplier<T> implements Supplier<ReplayBuffer<T>> {
         private final int bufferSize;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSamplePublisher.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSamplePublisher.java
@@ -141,33 +141,28 @@ public final class FlowableSamplePublisher<T> extends Flowable<T> {
         abstract void run();
     }
 
-    static final class SamplerSubscriber<T> implements FlowableSubscriber<Object> {
-        final SamplePublisherSubscriber<T> parent;
-        SamplerSubscriber(SamplePublisherSubscriber<T> parent) {
-            this.parent = parent;
-
-        }
+    record SamplerSubscriber<T>(SamplePublisherSubscriber<T> parent) implements FlowableSubscriber<Object> {
 
         @Override
-        public void onSubscribe(Subscription s) {
-            parent.setOther(s);
-        }
+            public void onSubscribe(Subscription s) {
+                parent.setOther(s);
+            }
 
-        @Override
-        public void onNext(Object t) {
-            parent.run();
-        }
+            @Override
+            public void onNext(Object t) {
+                parent.run();
+            }
 
-        @Override
-        public void onError(Throwable t) {
-            parent.error(t);
-        }
+            @Override
+            public void onError(Throwable t) {
+                parent.error(t);
+            }
 
-        @Override
-        public void onComplete() {
-            parent.complete();
+            @Override
+            public void onComplete() {
+                parent.complete();
+            }
         }
-    }
 
     static final class SampleMainNoLast<T> extends SamplePublisherSubscriber<T> {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOn.java
@@ -144,19 +144,12 @@ public final class FlowableSubscribeOn<T> extends AbstractFlowableWithUpstream<T
             worker.dispose();
         }
 
-        static final class Request implements Runnable {
-            final Subscription upstream;
-            final long n;
-
-            Request(Subscription s, long n) {
-                this.upstream = s;
-                this.n = n;
-            }
+        record Request(Subscription upstream, long n) implements Runnable {
 
             @Override
-            public void run() {
-                upstream.request(n);
-            }
-        }
+                    public void run() {
+                        upstream.request(n);
+                    }
+                }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutTimed.java
@@ -156,22 +156,13 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
     }
 
-    static final class TimeoutTask implements Runnable {
-
-        final TimeoutSupport parent;
-
-        final long idx;
-
-        TimeoutTask(long idx, TimeoutSupport parent) {
-            this.idx = idx;
-            this.parent = parent;
-        }
+    record TimeoutTask(long idx, TimeoutSupport parent) implements Runnable {
 
         @Override
-        public void run() {
-            parent.onTimeout(idx);
+            public void run() {
+                parent.onTimeout(idx);
+            }
         }
-    }
 
     static final class TimeoutFallbackSubscriber<T> extends SubscriptionArbiter
     implements FlowableSubscriber<T>, TimeoutSupport {
@@ -287,37 +278,29 @@ public final class FlowableTimeoutTimed<T> extends AbstractFlowableWithUpstream<
         }
     }
 
-    static final class FallbackSubscriber<T> implements FlowableSubscriber<T> {
-
-        final Subscriber<? super T> downstream;
-
-        final SubscriptionArbiter arbiter;
-
-        FallbackSubscriber(Subscriber<? super T> actual, SubscriptionArbiter arbiter) {
-            this.downstream = actual;
-            this.arbiter = arbiter;
-        }
+    record FallbackSubscriber<T>(Subscriber<? super T> downstream,
+                                 SubscriptionArbiter arbiter) implements FlowableSubscriber<T> {
 
         @Override
-        public void onSubscribe(Subscription s) {
-            arbiter.setSubscription(s);
-        }
+            public void onSubscribe(Subscription s) {
+                arbiter.setSubscription(s);
+            }
 
-        @Override
-        public void onNext(T t) {
-            downstream.onNext(t);
-        }
+            @Override
+            public void onNext(T t) {
+                downstream.onNext(t);
+            }
 
-        @Override
-        public void onError(Throwable t) {
-            downstream.onError(t);
-        }
+            @Override
+            public void onError(Throwable t) {
+                downstream.onError(t);
+            }
 
-        @Override
-        public void onComplete() {
-            downstream.onComplete();
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
         }
-    }
 
     interface TimeoutSupport {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowBoundarySelector.java
@@ -329,13 +329,8 @@ public final class FlowableWindowBoundarySelector<T, B, V> extends AbstractFlowa
             }
         }
 
-        static final class WindowStartItem<B> {
+        record WindowStartItem<B>(B item) {
 
-            final B item;
-
-            WindowStartItem(B item) {
-                this.item = item;
-            }
         }
 
         static final class WindowStartSubscriber<B> extends AtomicReference<Subscription>

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowTimed.java
@@ -526,22 +526,13 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
             return window;
         }
 
-        static final class WindowBoundaryRunnable implements Runnable {
-
-            final WindowExactBoundedSubscriber<?> parent;
-
-            final long index;
-
-            WindowBoundaryRunnable(WindowExactBoundedSubscriber<?> parent, long index) {
-                this.parent = parent;
-                this.index = index;
-            }
+        record WindowBoundaryRunnable(WindowExactBoundedSubscriber<?> parent, long index) implements Runnable {
 
             @Override
-            public void run() {
-                parent.boundary(this);
-            }
-        }
+                    public void run() {
+                        parent.boundary(this);
+                    }
+                }
     }
 
     static final class WindowSkipSubscriber<T>
@@ -703,22 +694,13 @@ public final class FlowableWindowTimed<T> extends AbstractFlowableWithUpstream<T
         static final Object WINDOW_OPEN = new Object();
         static final Object WINDOW_CLOSE = new Object();
 
-        static final class WindowBoundaryRunnable implements Runnable {
-
-            final WindowSkipSubscriber<?> parent;
-
-            final boolean isOpen;
-
-            WindowBoundaryRunnable(WindowSkipSubscriber<?> parent, boolean isOpen) {
-                this.parent = parent;
-                this.isOpen = isOpen;
-            }
+        record WindowBoundaryRunnable(WindowSkipSubscriber<?> parent, boolean isOpen) implements Runnable {
 
             @Override
-            public void run() {
-                parent.boundary(isOpen);
-            }
-        }
+                    public void run() {
+                        parent.boundary(isOpen);
+                    }
+                }
     }
 
     static MissingBackpressureException missingBackpressureMessage(long index) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayWithCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelayWithCompletable.java
@@ -80,35 +80,27 @@ public final class MaybeDelayWithCompletable<T> extends Maybe<T> {
         }
     }
 
-    static final class DelayWithMainObserver<T> implements MaybeObserver<T> {
-
-        final AtomicReference<Disposable> parent;
-
-        final MaybeObserver<? super T> downstream;
-
-        DelayWithMainObserver(AtomicReference<Disposable> parent, MaybeObserver<? super T> downstream) {
-            this.parent = parent;
-            this.downstream = downstream;
-        }
+    record DelayWithMainObserver<T>(AtomicReference<Disposable> parent,
+                                    MaybeObserver<? super T> downstream) implements MaybeObserver<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            DisposableHelper.replace(parent, d);
-        }
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(parent, d);
+            }
 
-        @Override
-        public void onSuccess(T value) {
-            downstream.onSuccess(value);
-        }
+            @Override
+            public void onSuccess(T value) {
+                downstream.onSuccess(value);
+            }
 
-        @Override
-        public void onError(Throwable e) {
-            downstream.onError(e);
-        }
+            @Override
+            public void onError(Throwable e) {
+                downstream.onError(e);
+            }
 
-        @Override
-        public void onComplete() {
-            downstream.onComplete();
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapSingle.java
@@ -107,30 +107,22 @@ public final class MaybeFlatMapSingle<T, R> extends Maybe<R> {
         }
     }
 
-    static final class FlatMapSingleObserver<R> implements SingleObserver<R> {
-
-        final AtomicReference<Disposable> parent;
-
-        final MaybeObserver<? super R> downstream;
-
-        FlatMapSingleObserver(AtomicReference<Disposable> parent, MaybeObserver<? super R> downstream) {
-            this.parent = parent;
-            this.downstream = downstream;
-        }
+    record FlatMapSingleObserver<R>(AtomicReference<Disposable> parent,
+                                    MaybeObserver<? super R> downstream) implements SingleObserver<R> {
 
         @Override
-        public void onSubscribe(final Disposable d) {
-            DisposableHelper.replace(parent, d);
-        }
+            public void onSubscribe(final Disposable d) {
+                DisposableHelper.replace(parent, d);
+            }
 
-        @Override
-        public void onSuccess(final R value) {
-            downstream.onSuccess(value);
-        }
+            @Override
+            public void onSuccess(final R value) {
+                downstream.onSuccess(value);
+            }
 
-        @Override
-        public void onError(final Throwable e) {
-            downstream.onError(e);
+            @Override
+            public void onError(final Throwable e) {
+                downstream.onError(e);
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeOnErrorNext.java
@@ -104,35 +104,28 @@ public final class MaybeOnErrorNext<T> extends AbstractMaybeWithUpstream<T, T> {
             downstream.onComplete();
         }
 
-        static final class NextMaybeObserver<T> implements MaybeObserver<T> {
-            final MaybeObserver<? super T> downstream;
-
-            final AtomicReference<Disposable> upstream;
-
-            NextMaybeObserver(MaybeObserver<? super T> actual, AtomicReference<Disposable> d) {
-                this.downstream = actual;
-                this.upstream = d;
-            }
+        record NextMaybeObserver<T>(MaybeObserver<? super T> downstream,
+                                    AtomicReference<Disposable> upstream) implements MaybeObserver<T> {
 
             @Override
-            public void onSubscribe(Disposable d) {
-                DisposableHelper.setOnce(this.upstream, d);
-            }
+                    public void onSubscribe(Disposable d) {
+                        DisposableHelper.setOnce(this.upstream, d);
+                    }
 
-            @Override
-            public void onSuccess(T value) {
-                downstream.onSuccess(value);
-            }
+                    @Override
+                    public void onSuccess(T value) {
+                        downstream.onSuccess(value);
+                    }
 
-            @Override
-            public void onError(Throwable e) {
-                downstream.onError(e);
-            }
+                    @Override
+                    public void onError(Throwable e) {
+                        downstream.onError(e);
+                    }
 
-            @Override
-            public void onComplete() {
-                downstream.onComplete();
-            }
-        }
+                    @Override
+                    public void onComplete() {
+                        downstream.onComplete();
+                    }
+                }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSubscribeOn.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSubscribeOn.java
@@ -41,20 +41,13 @@ public final class MaybeSubscribeOn<T> extends AbstractMaybeWithUpstream<T, T> {
         parent.task.replace(scheduler.scheduleDirect(new SubscribeTask<>(parent, source)));
     }
 
-    static final class SubscribeTask<T> implements Runnable {
-        final MaybeObserver<? super T> observer;
-        final MaybeSource<T> source;
-
-        SubscribeTask(MaybeObserver<? super T> observer, MaybeSource<T> source) {
-            this.observer = observer;
-            this.source = source;
-        }
+    record SubscribeTask<T>(MaybeObserver<? super T> observer, MaybeSource<T> source) implements Runnable {
 
         @Override
-        public void run() {
-            source.subscribe(observer);
+            public void run() {
+                source.subscribe(observer);
+            }
         }
-    }
 
     static final class SubscribeOnMaybeObserver<T>
     extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmpty.java
@@ -92,36 +92,29 @@ public final class MaybeSwitchIfEmpty<T> extends AbstractMaybeWithUpstream<T, T>
             }
         }
 
-        static final class OtherMaybeObserver<T> implements MaybeObserver<T> {
-
-            final MaybeObserver<? super T> downstream;
-
-            final AtomicReference<Disposable> parent;
-            OtherMaybeObserver(MaybeObserver<? super T> actual, AtomicReference<Disposable> parent) {
-                this.downstream = actual;
-                this.parent = parent;
-            }
+        record OtherMaybeObserver<T>(MaybeObserver<? super T> downstream,
+                                     AtomicReference<Disposable> parent) implements MaybeObserver<T> {
 
             @Override
-            public void onSubscribe(Disposable d) {
-                DisposableHelper.setOnce(parent, d);
-            }
+                    public void onSubscribe(Disposable d) {
+                        DisposableHelper.setOnce(parent, d);
+                    }
 
-            @Override
-            public void onSuccess(T value) {
-                downstream.onSuccess(value);
-            }
+                    @Override
+                    public void onSuccess(T value) {
+                        downstream.onSuccess(value);
+                    }
 
-            @Override
-            public void onError(Throwable e) {
-                downstream.onError(e);
-            }
+                    @Override
+                    public void onError(Throwable e) {
+                        downstream.onError(e);
+                    }
 
-            @Override
-            public void onComplete() {
-                downstream.onComplete();
-            }
-        }
+                    @Override
+                    public void onComplete() {
+                        downstream.onComplete();
+                    }
+                }
 
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSwitchIfEmptySingle.java
@@ -99,31 +99,24 @@ public final class MaybeSwitchIfEmptySingle<T> extends Single<T> implements HasU
             }
         }
 
-        static final class OtherSingleObserver<T> implements SingleObserver<T> {
-
-            final SingleObserver<? super T> downstream;
-
-            final AtomicReference<Disposable> parent;
-            OtherSingleObserver(SingleObserver<? super T> actual, AtomicReference<Disposable> parent) {
-                this.downstream = actual;
-                this.parent = parent;
-            }
+        record OtherSingleObserver<T>(SingleObserver<? super T> downstream,
+                                      AtomicReference<Disposable> parent) implements SingleObserver<T> {
 
             @Override
-            public void onSubscribe(Disposable d) {
-                DisposableHelper.setOnce(parent, d);
-            }
+                    public void onSubscribe(Disposable d) {
+                        DisposableHelper.setOnce(parent, d);
+                    }
 
-            @Override
-            public void onSuccess(T value) {
-                downstream.onSuccess(value);
-            }
+                    @Override
+                    public void onSuccess(T value) {
+                        downstream.onSuccess(value);
+                    }
 
-            @Override
-            public void onError(Throwable e) {
-                downstream.onError(e);
-            }
-        }
+                    @Override
+                    public void onError(Throwable e) {
+                        downstream.onError(e);
+                    }
+                }
 
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInternalHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableInternalHelper.java
@@ -30,98 +30,69 @@ public final class ObservableInternalHelper {
         throw new IllegalStateException("No instances!");
     }
 
-    static final class SimpleGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
-        final Consumer<Emitter<T>> consumer;
-
-        SimpleGenerator(Consumer<Emitter<T>> consumer) {
-            this.consumer = consumer;
-        }
+    record SimpleGenerator<T, S>(Consumer<Emitter<T>> consumer) implements BiFunction<S, Emitter<T>, S> {
 
         @Override
-        public S apply(S t1, Emitter<T> t2) throws Throwable {
-            consumer.accept(t2);
-            return t1;
+            public S apply(S t1, Emitter<T> t2) throws Throwable {
+                consumer.accept(t2);
+                return t1;
+            }
         }
-    }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleGenerator(Consumer<Emitter<T>> consumer) {
         return new SimpleGenerator<>(consumer);
     }
 
-    static final class SimpleBiGenerator<T, S> implements BiFunction<S, Emitter<T>, S> {
-        final BiConsumer<S, Emitter<T>> consumer;
-
-        SimpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
-            this.consumer = consumer;
-        }
+    record SimpleBiGenerator<T, S>(BiConsumer<S, Emitter<T>> consumer) implements BiFunction<S, Emitter<T>, S> {
 
         @Override
-        public S apply(S t1, Emitter<T> t2) throws Throwable {
-            consumer.accept(t1, t2);
-            return t1;
+            public S apply(S t1, Emitter<T> t2) throws Throwable {
+                consumer.accept(t1, t2);
+                return t1;
+            }
         }
-    }
 
     public static <T, S> BiFunction<S, Emitter<T>, S> simpleBiGenerator(BiConsumer<S, Emitter<T>> consumer) {
         return new SimpleBiGenerator<>(consumer);
     }
 
-    static final class ItemDelayFunction<T, U> implements Function<T, ObservableSource<T>> {
-        final Function<? super T, ? extends ObservableSource<U>> itemDelay;
-
-        ItemDelayFunction(Function<? super T, ? extends ObservableSource<U>> itemDelay) {
-            this.itemDelay = itemDelay;
-        }
+    record ItemDelayFunction<T, U>(
+            Function<? super T, ? extends ObservableSource<U>> itemDelay) implements Function<T, ObservableSource<T>> {
 
         @Override
-        public ObservableSource<T> apply(final T v) throws Throwable {
-            ObservableSource<U> o = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null ObservableSource");
-            return new ObservableTake<>(o, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            public ObservableSource<T> apply(final T v) throws Throwable {
+                ObservableSource<U> o = Objects.requireNonNull(itemDelay.apply(v), "The itemDelay returned a null ObservableSource");
+                return new ObservableTake<>(o, 1).map(Functions.justFunction(v)).defaultIfEmpty(v);
+            }
         }
-    }
 
     public static <T, U> Function<T, ObservableSource<T>> itemDelay(final Function<? super T, ? extends ObservableSource<U>> itemDelay) {
         return new ItemDelayFunction<>(itemDelay);
     }
 
-    static final class ObserverOnNext<T> implements Consumer<T> {
-        final Observer<T> observer;
-
-        ObserverOnNext(Observer<T> observer) {
-            this.observer = observer;
-        }
+    record ObserverOnNext<T>(Observer<T> observer) implements Consumer<T> {
 
         @Override
-        public void accept(T v) {
-            observer.onNext(v);
+            public void accept(T v) {
+                observer.onNext(v);
+            }
         }
-    }
 
-    static final class ObserverOnError<T> implements Consumer<Throwable> {
-        final Observer<T> observer;
-
-        ObserverOnError(Observer<T> observer) {
-            this.observer = observer;
-        }
+    record ObserverOnError<T>(Observer<T> observer) implements Consumer<Throwable> {
 
         @Override
-        public void accept(Throwable v) {
-            observer.onError(v);
+            public void accept(Throwable v) {
+                observer.onError(v);
+            }
         }
-    }
 
-    static final class ObserverOnComplete<T> implements Action {
-        final Observer<T> observer;
-
-        ObserverOnComplete(Observer<T> observer) {
-            this.observer = observer;
-        }
+    record ObserverOnComplete<T>(Observer<T> observer) implements Action {
 
         @Override
-        public void run() {
-            observer.onComplete();
+            public void run() {
+                observer.onComplete();
+            }
         }
-    }
 
     public static <T> Consumer<T> observerOnNext(Observer<T> observer) {
         return new ObserverOnNext<>(observer);
@@ -230,67 +201,31 @@ public final class ObservableInternalHelper {
         }
     }
 
-    static final class BufferedReplaySupplier<T> implements Supplier<ConnectableObservable<T>> {
-        final Observable<T> parent;
-        final int bufferSize;
-
-        final boolean eagerTruncate;
-
-        BufferedReplaySupplier(Observable<T> parent, int bufferSize, boolean eagerTruncate) {
-            this.parent = parent;
-            this.bufferSize = bufferSize;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record BufferedReplaySupplier<T>(Observable<T> parent, int bufferSize,
+                                     boolean eagerTruncate) implements Supplier<ConnectableObservable<T>> {
 
         @Override
-        public ConnectableObservable<T> get() {
-            return parent.replay(bufferSize, eagerTruncate);
+            public ConnectableObservable<T> get() {
+                return parent.replay(bufferSize, eagerTruncate);
+            }
         }
-    }
 
-    static final class BufferedTimedReplaySupplier<T> implements Supplier<ConnectableObservable<T>> {
-        final Observable<T> parent;
-        final int bufferSize;
-        final long time;
-        final TimeUnit unit;
-        final Scheduler scheduler;
-
-        final boolean eagerTruncate;
-
-        BufferedTimedReplaySupplier(Observable<T> parent, int bufferSize, long time, TimeUnit unit, Scheduler scheduler, boolean eagerTruncate) {
-            this.parent = parent;
-            this.bufferSize = bufferSize;
-            this.time = time;
-            this.unit = unit;
-            this.scheduler = scheduler;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record BufferedTimedReplaySupplier<T>(Observable<T> parent, int bufferSize, long time, TimeUnit unit,
+                                          Scheduler scheduler,
+                                          boolean eagerTruncate) implements Supplier<ConnectableObservable<T>> {
 
         @Override
-        public ConnectableObservable<T> get() {
-            return parent.replay(bufferSize, time, unit, scheduler, eagerTruncate);
+            public ConnectableObservable<T> get() {
+                return parent.replay(bufferSize, time, unit, scheduler, eagerTruncate);
+            }
         }
-    }
 
-    static final class TimedReplayCallable<T> implements Supplier<ConnectableObservable<T>> {
-        final Observable<T> parent;
-        final long time;
-        final TimeUnit unit;
-        final Scheduler scheduler;
-
-        final boolean eagerTruncate;
-
-        TimedReplayCallable(Observable<T> parent, long time, TimeUnit unit, Scheduler scheduler, boolean eagerTruncate) {
-            this.parent = parent;
-            this.time = time;
-            this.unit = unit;
-            this.scheduler = scheduler;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record TimedReplayCallable<T>(Observable<T> parent, long time, TimeUnit unit, Scheduler scheduler,
+                                  boolean eagerTruncate) implements Supplier<ConnectableObservable<T>> {
 
         @Override
-        public ConnectableObservable<T> get() {
-            return parent.replay(time, unit, scheduler, eagerTruncate);
+            public ConnectableObservable<T> get() {
+                return parent.replay(time, unit, scheduler, eagerTruncate);
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishSelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishSelector.java
@@ -60,37 +60,28 @@ public final class ObservablePublishSelector<T, R> extends AbstractObservableWit
         source.subscribe(new SourceObserver<>(subject, o));
     }
 
-    static final class SourceObserver<T> implements Observer<T> {
-
-        final PublishSubject<T> subject;
-
-        final AtomicReference<Disposable> target;
-
-        SourceObserver(PublishSubject<T> subject, AtomicReference<Disposable> target) {
-            this.subject = subject;
-            this.target = target;
-        }
+    record SourceObserver<T>(PublishSubject<T> subject, AtomicReference<Disposable> target) implements Observer<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            DisposableHelper.setOnce(target, d);
-        }
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.setOnce(target, d);
+            }
 
-        @Override
-        public void onNext(T value) {
-            subject.onNext(value);
-        }
+            @Override
+            public void onNext(T value) {
+                subject.onNext(value);
+            }
 
-        @Override
-        public void onError(Throwable e) {
-            subject.onError(e);
-        }
+            @Override
+            public void onError(Throwable e) {
+                subject.onError(e);
+            }
 
-        @Override
-        public void onComplete() {
-            subject.onComplete();
+            @Override
+            public void onComplete() {
+                subject.onComplete();
+            }
         }
-    }
 
     static final class TargetObserver<R>
     extends AtomicReference<Disposable> implements Observer<R>, Disposable {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplay.java
@@ -956,22 +956,13 @@ public final class ObservableReplay<T> extends ConnectableObservable<T> implemen
         }
     }
 
-    static final class ReplayBufferSupplier<T> implements BufferSupplier<T> {
-
-        final int bufferSize;
-
-        final boolean eagerTruncate;
-
-        ReplayBufferSupplier(int bufferSize, boolean eagerTruncate) {
-            this.bufferSize = bufferSize;
-            this.eagerTruncate = eagerTruncate;
-        }
+    record ReplayBufferSupplier<T>(int bufferSize, boolean eagerTruncate) implements BufferSupplier<T> {
 
         @Override
-        public ReplayBuffer<T> call() {
-            return new SizeBoundReplayBuffer<>(bufferSize, eagerTruncate);
+            public ReplayBuffer<T> call() {
+                return new SizeBoundReplayBuffer<>(bufferSize, eagerTruncate);
+            }
         }
-    }
 
     static final class ScheduledReplaySupplier<T> implements BufferSupplier<T> {
         private final int bufferSize;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleWithObservable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSampleWithObservable.java
@@ -126,33 +126,28 @@ public final class ObservableSampleWithObservable<T> extends AbstractObservableW
         abstract void run();
     }
 
-    static final class SamplerObserver<T> implements Observer<Object> {
-        final SampleMainObserver<T> parent;
-        SamplerObserver(SampleMainObserver<T> parent) {
-            this.parent = parent;
-
-        }
+    record SamplerObserver<T>(SampleMainObserver<T> parent) implements Observer<Object> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            parent.setOther(d);
-        }
+            public void onSubscribe(Disposable d) {
+                parent.setOther(d);
+            }
 
-        @Override
-        public void onNext(Object t) {
-            parent.run();
-        }
+            @Override
+            public void onNext(Object t) {
+                parent.run();
+            }
 
-        @Override
-        public void onError(Throwable t) {
-            parent.error(t);
-        }
+            @Override
+            public void onError(Throwable t) {
+                parent.error(t);
+            }
 
-        @Override
-        public void onComplete() {
-            parent.complete();
+            @Override
+            public void onComplete() {
+                parent.complete();
+            }
         }
-    }
 
     static final class SampleMainNoLast<T> extends SampleMainObserver<T> {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutTimed.java
@@ -151,22 +151,13 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
         }
     }
 
-    static final class TimeoutTask implements Runnable {
-
-        final TimeoutSupport parent;
-
-        final long idx;
-
-        TimeoutTask(long idx, TimeoutSupport parent) {
-            this.idx = idx;
-            this.parent = parent;
-        }
+    record TimeoutTask(long idx, TimeoutSupport parent) implements Runnable {
 
         @Override
-        public void run() {
-            parent.onTimeout(idx);
+            public void run() {
+                parent.onTimeout(idx);
+            }
         }
-    }
 
     static final class TimeoutFallbackObserver<T> extends AtomicReference<Disposable>
     implements Observer<T>, Disposable, TimeoutSupport {
@@ -276,37 +267,29 @@ public final class ObservableTimeoutTimed<T> extends AbstractObservableWithUpstr
         }
     }
 
-    static final class FallbackObserver<T> implements Observer<T> {
-
-        final Observer<? super T> downstream;
-
-        final AtomicReference<Disposable> arbiter;
-
-        FallbackObserver(Observer<? super T> actual, AtomicReference<Disposable> arbiter) {
-            this.downstream = actual;
-            this.arbiter = arbiter;
-        }
+    record FallbackObserver<T>(Observer<? super T> downstream,
+                               AtomicReference<Disposable> arbiter) implements Observer<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            DisposableHelper.replace(arbiter, d);
-        }
+            public void onSubscribe(Disposable d) {
+                DisposableHelper.replace(arbiter, d);
+            }
 
-        @Override
-        public void onNext(T t) {
-            downstream.onNext(t);
-        }
+            @Override
+            public void onNext(T t) {
+                downstream.onNext(t);
+            }
 
-        @Override
-        public void onError(Throwable t) {
-            downstream.onError(t);
-        }
+            @Override
+            public void onError(Throwable t) {
+                downstream.onError(t);
+            }
 
-        @Override
-        public void onComplete() {
-            downstream.onComplete();
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
         }
-    }
 
     interface TimeoutSupport {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowBoundarySelector.java
@@ -314,13 +314,8 @@ public final class ObservableWindowBoundarySelector<T, B, V> extends AbstractObs
             }
         }
 
-        static final class WindowStartItem<B> {
+        record WindowStartItem<B>(B item) {
 
-            final B item;
-
-            WindowStartItem(B item) {
-                this.item = item;
-            }
         }
 
         static final class WindowStartObserver<B> extends AtomicReference<Disposable>

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowTimed.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowTimed.java
@@ -484,22 +484,13 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
             return window;
         }
 
-        static final class WindowBoundaryRunnable implements Runnable {
-
-            final WindowExactBoundedObserver<?> parent;
-
-            final long index;
-
-            WindowBoundaryRunnable(WindowExactBoundedObserver<?> parent, long index) {
-                this.parent = parent;
-                this.index = index;
-            }
+        record WindowBoundaryRunnable(WindowExactBoundedObserver<?> parent, long index) implements Runnable {
 
             @Override
-            public void run() {
-                parent.boundary(this);
-            }
-        }
+                    public void run() {
+                        parent.boundary(this);
+                    }
+                }
     }
 
     static final class WindowSkipObserver<T>
@@ -638,22 +629,13 @@ public final class ObservableWindowTimed<T> extends AbstractObservableWithUpstre
         static final Object WINDOW_OPEN = new Object();
         static final Object WINDOW_CLOSE = new Object();
 
-        static final class WindowBoundaryRunnable implements Runnable {
-
-            final WindowSkipObserver<?> parent;
-
-            final boolean isOpen;
-
-            WindowBoundaryRunnable(WindowSkipObserver<?> parent, boolean isOpen) {
-                this.parent = parent;
-                this.isOpen = isOpen;
-            }
+        record WindowBoundaryRunnable(WindowSkipObserver<?> parent, boolean isOpen) implements Runnable {
 
             @Override
-            public void run() {
-                parent.boundary(isOpen);
-            }
-        }
+                    public void run() {
+                        parent.boundary(isOpen);
+                    }
+                }
     }
 
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
@@ -242,8 +242,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < s.length; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();
@@ -286,9 +285,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimpleQueue<T> q = inner.queue;
                         if (q != null && !q.isEmpty()) {
                             empty = false;
@@ -409,9 +406,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimplePlainQueue<T> q = inner.queue;
                         if (q != null) {
                             T v = q.poll();
@@ -447,9 +442,7 @@ public final class ParallelJoin<T> extends Flowable<T> {
 
                     boolean empty = true;
 
-                    for (int i = 0; i < n; i++) {
-                        JoinInnerSubscriber<T> inner = s[i];
-
+                    for (JoinInnerSubscriber<T> inner : s) {
                         SimpleQueue<T> q = inner.queue;
                         if (q != null && !q.isEmpty()) {
                             empty = false;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleEquals.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleEquals.java
@@ -43,44 +43,33 @@ public final class SingleEquals<T> extends Single<Boolean> {
         second.subscribe(new InnerObserver<T>(1, set, values, observer, count));
     }
 
-    static class InnerObserver<T> implements SingleObserver<T> {
-        final int index;
-        final CompositeDisposable set;
-        final Object[] values;
-        final SingleObserver<? super Boolean> downstream;
-        final AtomicInteger count;
-
-        InnerObserver(int index, CompositeDisposable set, Object[] values, SingleObserver<? super Boolean> observer, AtomicInteger count) {
-            this.index = index;
-            this.set = set;
-            this.values = values;
-            this.downstream = observer;
-            this.count = count;
-        }
+    record InnerObserver<T>(int index, CompositeDisposable set, Object[] values,
+                            SingleObserver<? super Boolean> downstream,
+                            AtomicInteger count) implements SingleObserver<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            set.add(d);
-        }
+            public void onSubscribe(Disposable d) {
+                set.add(d);
+            }
 
-        @Override
-        public void onSuccess(T value) {
-            values[index] = value;
+            @Override
+            public void onSuccess(T value) {
+                values[index] = value;
 
-            if (count.incrementAndGet() == 2) {
-                downstream.onSuccess(Objects.equals(values[0], values[1]));
+                if (count.incrementAndGet() == 2) {
+                    downstream.onSuccess(Objects.equals(values[0], values[1]));
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                int state = count.getAndSet(-1);
+                if (state == 0 || state == 1) {
+                    set.dispose();
+                    downstream.onError(e);
+                } else {
+                    RxJavaPlugins.onError(e);
+                }
             }
         }
-
-        @Override
-        public void onError(Throwable e) {
-            int state = count.getAndSet(-1);
-            if (state == 0 || state == 1) {
-                set.dispose();
-                downstream.onError(e);
-            } else {
-                RxJavaPlugins.onError(e);
-            }
-        }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMap.java
@@ -93,31 +93,23 @@ public final class SingleFlatMap<T, R> extends Single<R> {
             downstream.onError(e);
         }
 
-        static final class FlatMapSingleObserver<R> implements SingleObserver<R> {
-
-            final AtomicReference<Disposable> parent;
-
-            final SingleObserver<? super R> downstream;
-
-            FlatMapSingleObserver(AtomicReference<Disposable> parent, SingleObserver<? super R> downstream) {
-                this.parent = parent;
-                this.downstream = downstream;
-            }
+        record FlatMapSingleObserver<R>(AtomicReference<Disposable> parent,
+                                        SingleObserver<? super R> downstream) implements SingleObserver<R> {
 
             @Override
-            public void onSubscribe(final Disposable d) {
-                DisposableHelper.replace(parent, d);
-            }
+                    public void onSubscribe(final Disposable d) {
+                        DisposableHelper.replace(parent, d);
+                    }
 
-            @Override
-            public void onSuccess(final R value) {
-                downstream.onSuccess(value);
-            }
+                    @Override
+                    public void onSuccess(final R value) {
+                        downstream.onSuccess(value);
+                    }
 
-            @Override
-            public void onError(final Throwable e) {
-                downstream.onError(e);
-            }
-        }
+                    @Override
+                    public void onError(final Throwable e) {
+                        downstream.onError(e);
+                    }
+                }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapMaybe.java
@@ -95,35 +95,27 @@ public final class SingleFlatMapMaybe<T, R> extends Maybe<R> {
         }
     }
 
-    static final class FlatMapMaybeObserver<R> implements MaybeObserver<R> {
-
-        final AtomicReference<Disposable> parent;
-
-        final MaybeObserver<? super R> downstream;
-
-        FlatMapMaybeObserver(AtomicReference<Disposable> parent, MaybeObserver<? super R> downstream) {
-            this.parent = parent;
-            this.downstream = downstream;
-        }
+    record FlatMapMaybeObserver<R>(AtomicReference<Disposable> parent,
+                                   MaybeObserver<? super R> downstream) implements MaybeObserver<R> {
 
         @Override
-        public void onSubscribe(final Disposable d) {
-            DisposableHelper.replace(parent, d);
-        }
+            public void onSubscribe(final Disposable d) {
+                DisposableHelper.replace(parent, d);
+            }
 
-        @Override
-        public void onSuccess(final R value) {
-            downstream.onSuccess(value);
-        }
+            @Override
+            public void onSuccess(final R value) {
+                downstream.onSuccess(value);
+            }
 
-        @Override
-        public void onError(final Throwable e) {
-            downstream.onError(e);
-        }
+            @Override
+            public void onError(final Throwable e) {
+                downstream.onError(e);
+            }
 
-        @Override
-        public void onComplete() {
-            downstream.onComplete();
+            @Override
+            public void onComplete() {
+                downstream.onComplete();
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleMap.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleMap.java
@@ -35,39 +35,31 @@ public final class SingleMap<T, R> extends Single<R> {
         source.subscribe(new MapSingleObserver<T, R>(t, mapper));
     }
 
-    static final class MapSingleObserver<T, R> implements SingleObserver<T> {
-
-        final SingleObserver<? super R> t;
-
-        final Function<? super T, ? extends R> mapper;
-
-        MapSingleObserver(SingleObserver<? super R> t, Function<? super T, ? extends R> mapper) {
-            this.t = t;
-            this.mapper = mapper;
-        }
+    record MapSingleObserver<T, R>(SingleObserver<? super R> t,
+                                   Function<? super T, ? extends R> mapper) implements SingleObserver<T> {
 
         @Override
-        public void onSubscribe(Disposable d) {
-            t.onSubscribe(d);
-        }
-
-        @Override
-        public void onSuccess(T value) {
-            R v;
-            try {
-                v = Objects.requireNonNull(mapper.apply(value), "The mapper function returned a null value.");
-            } catch (Throwable e) {
-                Exceptions.throwIfFatal(e);
-                onError(e);
-                return;
+            public void onSubscribe(Disposable d) {
+                t.onSubscribe(d);
             }
 
-            t.onSuccess(v);
-        }
+            @Override
+            public void onSuccess(T value) {
+                R v;
+                try {
+                    v = Objects.requireNonNull(mapper.apply(value), "The mapper function returned a null value.");
+                } catch (Throwable e) {
+                    Exceptions.throwIfFatal(e);
+                    onError(e);
+                    return;
+                }
 
-        @Override
-        public void onError(Throwable e) {
-            t.onError(e);
+                t.onSuccess(v);
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                t.onError(e);
+            }
         }
-    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/CachedScheduler.java
@@ -57,8 +57,8 @@ public final class CachedScheduler extends Scheduler {
         SHUTDOWN_THREAD_WORKER = new ThreadWorker(new RxThreadFactory("RxCachedThreadSchedulerShutdown"));
         SHUTDOWN_THREAD_WORKER.dispose();
 
-        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
-                Integer.getInteger(KEY_IO_PRIORITY, Thread.NORM_PRIORITY)));
+        int priority = Math.clamp(
+                Integer.getInteger(KEY_IO_PRIORITY, Thread.NORM_PRIORITY), Thread.MIN_PRIORITY, Thread.MAX_PRIORITY);
 
         WORKER_THREAD_FACTORY = new RxThreadFactory(WORKER_THREAD_NAME_PREFIX, priority);
 

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/ComputationScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/ComputationScheduler.java
@@ -53,8 +53,8 @@ public final class ComputationScheduler extends Scheduler implements SchedulerMu
         SHUTDOWN_WORKER = new PoolWorker(new RxThreadFactory("RxComputationShutdown"));
         SHUTDOWN_WORKER.dispose();
 
-        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
-                Integer.getInteger(KEY_COMPUTATION_PRIORITY, Thread.NORM_PRIORITY)));
+        int priority = Math.clamp(
+                Integer.getInteger(KEY_COMPUTATION_PRIORITY, Thread.NORM_PRIORITY), Thread.MIN_PRIORITY, Thread.MAX_PRIORITY);
 
         THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority, true);
 

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/DisposeOnCancel.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/DisposeOnCancel.java
@@ -22,13 +22,7 @@ import io.reactivex.rxjava4.disposables.Disposable;
  * Implements the Future interface and calls dispose() on cancel() but
  * the other methods are not implemented.
  */
-final class DisposeOnCancel implements Future<Object> {
-
-    final Disposable upstream;
-
-    DisposeOnCancel(Disposable d) {
-        this.upstream = d;
-    }
+record DisposeOnCancel(Disposable upstream) implements Future<Object> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/NewThreadScheduler.java
@@ -32,8 +32,8 @@ public final class NewThreadScheduler extends Scheduler {
     private static final String KEY_NEWTHREAD_PRIORITY = "rxjava4.newthread-priority";
 
     static {
-        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
-                Integer.getInteger(KEY_NEWTHREAD_PRIORITY, Thread.NORM_PRIORITY)));
+        int priority = Math.clamp(
+                Integer.getInteger(KEY_NEWTHREAD_PRIORITY, Thread.NORM_PRIORITY), Thread.MIN_PRIORITY, Thread.MAX_PRIORITY);
 
         THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SingleScheduler.java
@@ -43,8 +43,8 @@ public final class SingleScheduler extends Scheduler {
         SHUTDOWN = Executors.newScheduledThreadPool(0);
         SHUTDOWN.shutdown();
 
-        int priority = Math.max(Thread.MIN_PRIORITY, Math.min(Thread.MAX_PRIORITY,
-                Integer.getInteger(KEY_SINGLE_PRIORITY, Thread.NORM_PRIORITY)));
+        int priority = Math.clamp(
+                Integer.getInteger(KEY_SINGLE_PRIORITY, Thread.NORM_PRIORITY), Thread.MIN_PRIORITY, Thread.MAX_PRIORITY);
 
         SINGLE_THREAD_FACTORY = new RxThreadFactory(THREAD_NAME_PREFIX, priority, true);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/util/NotificationLite.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/NotificationLite.java
@@ -29,72 +29,54 @@ public enum NotificationLite {
     ;
 
     /**
-     * Wraps a Throwable.
-     */
-    static final class ErrorNotification implements Serializable {
+         * Wraps a Throwable.
+         */
+        record ErrorNotification(Throwable e) implements Serializable {
 
-        @Serial
-        private static final long serialVersionUID = -8759979445933046293L;
-        final Throwable e;
-        ErrorNotification(Throwable e) {
-            this.e = e;
-        }
+            @Serial
+            private static final long serialVersionUID = -8759979445933046293L;
 
         @Override
         public String toString() {
-            return "NotificationLite.Error[" + e + "]";
-        }
-
-        @Override
-        public int hashCode() {
-            return e.hashCode();
-        }
+                return "NotificationLite.Error[" + e + "]";
+            }
 
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof ErrorNotification n) {
-                return Objects.equals(e, n.e);
+            if (obj instanceof ErrorNotification(Throwable e1)) {
+                return Objects.equals(e, e1);
             }
             return false;
         }
     }
 
     /**
-     * Wraps a Subscription.
-     */
-    static final class SubscriptionNotification implements Serializable {
+         * Wraps a Subscription.
+         */
+        record SubscriptionNotification(Subscription upstream) implements Serializable {
 
-        @Serial
-        private static final long serialVersionUID = -1322257508628817540L;
-        final Subscription upstream;
-        SubscriptionNotification(Subscription s) {
-            this.upstream = s;
-        }
+            @Serial
+            private static final long serialVersionUID = -1322257508628817540L;
 
         @Override
-        public String toString() {
-            return "NotificationLite.Subscription[" + upstream + "]";
+            public String toString() {
+                return "NotificationLite.Subscription[" + upstream + "]";
+            }
         }
-    }
 
     /**
-     * Wraps a Disposable.
-     */
-    static final class DisposableNotification implements Serializable {
+         * Wraps a Disposable.
+         */
+        record DisposableNotification(Disposable upstream) implements Serializable {
 
-        @Serial
-        private static final long serialVersionUID = -7482590109178395495L;
-        final Disposable upstream;
-
-        DisposableNotification(Disposable d) {
-            this.upstream = d;
-        }
+            @Serial
+            private static final long serialVersionUID = -7482590109178395495L;
 
         @Override
-        public String toString() {
-            return "NotificationLite.Disposable[" + upstream + "]";
+            public String toString() {
+                return "NotificationLite.Disposable[" + upstream + "]";
+            }
         }
-    }
 
     /**
      * Converts a value into a notification value.

--- a/src/main/java/io/reactivex/rxjava4/internal/util/SorterFunction.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/SorterFunction.java
@@ -27,7 +27,7 @@ public final class SorterFunction<T> implements Function<List<T>, List<T>> {
 
     @Override
     public List<T> apply(List<T> t) {
-        Collections.sort(t, comparator);
+        t.sort(comparator);
         return t;
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/schedulers/TestScheduler.java
+++ b/src/main/java/io/reactivex/rxjava4/schedulers/TestScheduler.java
@@ -94,33 +94,25 @@ public final class TestScheduler extends Scheduler {
         this.useOnScheduleHook = useOnScheduleHook;
     }
 
-    static final class TimedRunnable implements Comparable<TimedRunnable> {
-
-        final long time;
-        final Runnable run;
-        final TestWorker scheduler;
-        final long count; // for differentiating tasks at same time
-
-        TimedRunnable(TestWorker scheduler, long time, Runnable run, long count) {
-            this.time = time;
-            this.run = run;
-            this.scheduler = scheduler;
-            this.count = count;
-        }
+    /**
+     * @param count for differentiating tasks at same time
+     */
+    record TimedRunnable(TestWorker scheduler, long time, Runnable run,
+                         long count) implements Comparable<TimedRunnable> {
 
         @Override
-        public String toString() {
-            return String.format("TimedRunnable(time = %d, run = %s)", time, run.toString());
-        }
-
-        @Override
-        public int compareTo(TimedRunnable o) {
-            if (time == o.time) {
-                return Long.compare(count, o.count);
+            public String toString() {
+                return String.format("TimedRunnable(time = %d, run = %s)", time, run.toString());
             }
-            return Long.compare(time, o.time);
+
+            @Override
+            public int compareTo(TimedRunnable o) {
+                if (time == o.time) {
+                    return Long.compare(count, o.count);
+                }
+                return Long.compare(time, o.time);
+            }
         }
-    }
 
     @Override
     public long now(@NonNull TimeUnit unit) {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -488,7 +488,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
             System.out.println("testOnBackpressureDrop => Received: " + onNextEvents.size() + "  Emitted: " + c.get() + " Last value: " + lastEvent);
             // it drops, so we should get some number far higher than what would have sequentially incremented
-            assertTrue(num - 1 <= lastEvent.intValue());
+            assertTrue(num - 1 <= lastEvent);
         }
     }
 
@@ -519,7 +519,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             // in reality, num < passCount
             assertTrue(num <= passCount.get());
             // it drops, so we should get some number far higher than what would have sequentially incremented
-            assertTrue(num - 1 <= lastEvent.intValue());
+            assertTrue(num - 1 <= lastEvent);
             assertTrue(0 < dropCount.get());
             assertEquals(emitCount.get(), passCount.get() + dropCount.get());
         }
@@ -543,7 +543,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
 
             System.out.println("testOnBackpressureDrop => Received: " + onNextEvents.size() + "  Emitted: " + c.get() + " Last value: " + lastEvent);
             // it drops, so we should get some number far higher than what would have sequentially incremented
-            assertTrue(num - 1 <= lastEvent.intValue());
+            assertTrue(num - 1 <= lastEvent);
         }
     }
 
@@ -567,7 +567,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
             System.out.println("testOnBackpressureDrop => Received: " + onNextEvents.size() + " Dropped: " + dropCount.get()
                 + "  Emitted: " + c.get() + " Last value: " + lastEvent);
             // it drops, so we should get some number far higher than what would have sequentially incremented
-            assertTrue(num - 1 <= lastEvent.intValue());
+            assertTrue(num - 1 <= lastEvent);
             // no drop in synchronous mode
             assertEquals(0, dropCount.get());
             assertEquals(c.get(), onNextEvents.size());

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableEventStream.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableEventStream.java
@@ -71,22 +71,18 @@ public final class FlowableEventStream {
         }
     }
 
-    public static class Event {
-        public final String type;
-        public final String instanceId;
-        public final Map<String, Object> values;
-
-        /**
-         * Construct an event with the provided parameters.
-         * @param type the event type
-         * @param instanceId the instance identifier
-         * @param values
-         *            This does NOT deep-copy, so do not mutate this Map after passing it in.
-         */
-        public Event(String type, String instanceId, Map<String, Object> values) {
-            this.type = type;
-            this.instanceId = instanceId;
-            this.values = Collections.unmodifiableMap(values);
+    public record Event(String type, String instanceId, Map<String, Object> values) {
+            /**
+             * Construct an event with the provided parameters.
+             *
+             * @param type       the event type
+             * @param instanceId the instance identifier
+             * @param values     This does NOT deep-copy, so do not mutate this Map after passing it in.
+             */
+            public Event(String type, String instanceId, Map<String, Object> values) {
+                this.type = type;
+                this.instanceId = instanceId;
+                this.values = Collections.unmodifiableMap(values);
+            }
         }
-    }
 }

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableGroupByTests.java
@@ -32,7 +32,7 @@ public class FlowableGroupByTests extends RxJavaTest {
             FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(event -> (Object)event.type)
+        .groupBy(event -> (Object) event.type())
         .take(1)
         .blockingForEach(v -> {
             System.out.println(v);
@@ -49,9 +49,9 @@ public class FlowableGroupByTests extends RxJavaTest {
             FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(event -> (Object)event.type)
+        .groupBy(event -> (Object) event.type())
         .flatMap((Function<GroupedFlowable<Object, Event>, Publisher<Object>>)
-                g -> g.map(event -> event.instanceId + " - " + event.values.get("count200")))
+                g -> g.map(event -> event.instanceId() + " - " + event.values().get("count200")))
         .take(20)
         .blockingForEach(System.out::println);
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableZipTests.java
@@ -31,7 +31,7 @@ public class FlowableZipTests extends RxJavaTest {
     @Test
     public void zipObservableOfObservables() {
         FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
-                .groupBy(e -> e.instanceId)
+                .groupBy(Event::instanceId)
                 // now we have streams of cluster+instanceId
                 .flatMap((Function<GroupedFlowable<String, Event>, Publisher<HashMap<String, String>>>) ge -> ge.scan(new HashMap<>(), (accum, _) -> {
                      synchronized (accum) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/BlockingFlowableToIteratorTest.java
@@ -73,12 +73,10 @@ public class BlockingFlowableToIteratorTest extends RxJavaTest {
 
         Flowable<Integer> obs = Flowable.fromIterable(() -> src);
 
-        Iterator<Integer> it = obs.blockingIterable().iterator();
-        while (it.hasNext()) {
+        for (int i : obs.blockingIterable()) {
             // Correct backpressure should cause this interleaved behavior.
             // We first request RxRingBuffer.SIZE. Then in increments of
             // SubscriberIterator.LIMIT.
-            int i = it.next();
             int expected = i - (i % (Flowable.bufferSize() - (Flowable.bufferSize() >> 2))) + Flowable.bufferSize();
             expected = Math.min(expected, Counter.MAX);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableElementAtTest.java
@@ -74,10 +74,9 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void elementAtConstrainsUpstreamRequests() {
         final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
-            .doOnRequest(requests::add)
-            .elementAt(2)
-            .blockingGet()
-                .intValue();
+                .doOnRequest(requests::add)
+                .elementAt(2)
+                .blockingGet();
         assertEquals(List.of(3L), requests);
     }
 
@@ -85,10 +84,9 @@ public class FlowableElementAtTest extends RxJavaTest {
     public void elementAtWithDefaultConstrainsUpstreamRequests() {
         final List<Long> requests = new ArrayList<>();
         Flowable.fromArray(1, 2, 3, 4)
-            .doOnRequest(requests::add)
-            .elementAt(2, 100)
-            .blockingGet()
-                .intValue();
+                .doOnRequest(requests::add)
+                .elementAt(2, 100)
+                .blockingGet();
         assertEquals(List.of(3L), requests);
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -353,7 +353,7 @@ public class FlowableScanTest extends RxJavaTest {
 
         FlowableEventStream.getEventStream("HTTP-ClusterB", 20)
         .scan(new HashMap<>(), (BiFunction<HashMap<String, String>, Event, HashMap<String, String>>) (accum, perInstanceEvent) -> {
-            accum.put("instance", perInstanceEvent.instanceId);
+            accum.put("instance", perInstanceEvent.instanceId());
             return accum;
         })
         .take(10)

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
@@ -64,33 +64,28 @@ public class StrictSubscriberTest extends RxJavaTest {
         assertTrue(list.toString(), list.getFirst() instanceof StrictSubscriber);
     }
 
-    static final class SubscriberWrapper<T> implements Subscriber<T> {
-        final TestSubscriberEx<T> tester;
-
-        SubscriberWrapper(TestSubscriberEx<T> tester) {
-            this.tester = tester;
-        }
+    record SubscriberWrapper<T>(TestSubscriberEx<T> tester) implements Subscriber<T> {
 
         @Override
-        public void onSubscribe(Subscription s) {
-            tester.onSubscribe(s);
-        }
+            public void onSubscribe(Subscription s) {
+                tester.onSubscribe(s);
+            }
 
-        @Override
-        public void onNext(T t) {
-            tester.onNext(t);
-        }
+            @Override
+            public void onNext(T t) {
+                tester.onNext(t);
+            }
 
-        @Override
-        public void onError(Throwable t) {
-            tester.onError(t);
-        }
+            @Override
+            public void onError(Throwable t) {
+                tester.onError(t);
+            }
 
-        @Override
-        public void onComplete() {
-            tester.onComplete();
+            @Override
+            public void onComplete() {
+                tester.onComplete();
+            }
         }
-    }
 
     @Test
     public void normalOnNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/util/OperatorArgumentNaming.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/OperatorArgumentNaming.java
@@ -152,18 +152,11 @@ public final class OperatorArgumentNaming {
         }
     }
 
-    static final class ArgumentNameAndType {
-        final String type;
-        final String name;
-
-        ArgumentNameAndType(String type, String name) {
-            this.type = type;
-            this.name = name;
-        }
+    record ArgumentNameAndType(String type, String name) {
 
         @Override
-        public String toString() {
-            return type + " " + name;
+            public String toString() {
+                return type + " " + name;
+            }
         }
-    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/OperatorMatrixGenerator.java
@@ -127,9 +127,9 @@ public final class OperatorMatrixGenerator {
             out.print("<a name='total'></a>**");
             out.print(sortedOperators.size());
             out.print(" operators** |");
-            for (int m = 0; m < counters.length; m++) {
+            for (int counter : counters) {
                 out.print(" **");
-                out.print(counters[m]);
+                out.print(counter);
                 out.print("** |");
             }
             out.println();

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -2265,7 +2265,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void sequenceEqual() {
-        Maybe.sequenceEqual(Maybe.just(1_000_000), Maybe.just(Integer.valueOf(1_000_000))).test().assertResult(true);
+        Maybe.sequenceEqual(Maybe.just(1_000_000), Maybe.just(1_000_000)).test().assertResult(true);
 
         Maybe.sequenceEqual(Maybe.just(1), Maybe.just(2)).test().assertResult(false);
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableEventStream.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableEventStream.java
@@ -71,22 +71,18 @@ public final class ObservableEventStream {
         }
     }
 
-    public static class Event {
-        public final String type;
-        public final String instanceId;
-        public final Map<String, Object> values;
-
-        /**
-         * Construct an event with the provided parameters.
-         * @param type the event type
-         * @param instanceId the instance identifier
-         * @param values
-         *            This does NOT deep-copy, so do not mutate this Map after passing it in.
-         */
-        public Event(String type, String instanceId, Map<String, Object> values) {
-            this.type = type;
-            this.instanceId = instanceId;
-            this.values = Collections.unmodifiableMap(values);
+    public record Event(String type, String instanceId, Map<String, Object> values) {
+            /**
+             * Construct an event with the provided parameters.
+             *
+             * @param type       the event type
+             * @param instanceId the instance identifier
+             * @param values     This does NOT deep-copy, so do not mutate this Map after passing it in.
+             */
+            public Event(String type, String instanceId, Map<String, Object> values) {
+                this.type = type;
+                this.instanceId = instanceId;
+                this.values = Collections.unmodifiableMap(values);
+            }
         }
-    }
 }

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableGroupByTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableGroupByTests.java
@@ -29,7 +29,7 @@ public class ObservableGroupByTests extends RxJavaTest {
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(event -> event.type)
+        .groupBy(Event::type)
         .take(1)
         .blockingForEach(v -> {
             System.out.println(v);
@@ -48,9 +48,9 @@ public class ObservableGroupByTests extends RxJavaTest {
             ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         )
         // group by type (2 clusters)
-        .groupBy(event -> event.type)
+        .groupBy(Event::type)
         .flatMap((Function<GroupedObservable<String, Event>, Observable<Object>>) g ->
-            g.map((Function<Event, Object>) event -> event.instanceId + " - " + event.values.get("count200")))
+            g.map((Function<Event, Object>) event -> event.instanceId() + " - " + event.values().get("count200")))
         .take(20)
         .blockingForEach(System.out::println);
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableScanTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableScanTests.java
@@ -28,7 +28,7 @@ public class ObservableScanTests extends RxJavaTest {
 
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
         .scan(new HashMap<>(), (BiFunction<HashMap<String, String>, Event, HashMap<String, String>>) (accum, perInstanceEvent) -> {
-            accum.put("instance", perInstanceEvent.instanceId);
+            accum.put("instance", perInstanceEvent.instanceId());
             return accum;
         })
         .take(10)

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
@@ -31,7 +31,7 @@ public class ObservableZipTests extends RxJavaTest {
     @Test
     public void zipObservableOfObservables() throws Exception {
         ObservableEventStream.getEventStream("HTTP-ClusterB", 20)
-                .groupBy(e -> e.instanceId)
+                .groupBy(Event::instanceId)
                 // now we have streams of cluster+instanceId
                 .flatMap((Function<GroupedObservable<String, Event>, Observable<HashMap<String, String>>>) ge ->
                     ge.scan(new HashMap<>(),

--- a/src/test/java/io/reactivex/rxjava4/tck/BaseTck.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/BaseTck.java
@@ -91,46 +91,42 @@ public abstract class BaseTck<T> extends FlowPublisherVerification<T> {
         return a;
     }
 
-    static final class FiniteRange implements Iterable<Long> {
-        final long end;
-        FiniteRange(long end) {
-            this.end = end;
-        }
+    record FiniteRange(long end) implements Iterable<Long> {
 
         @Override
-        public Iterator<Long> iterator() {
-            return new FiniteRangeIterator(end);
-        }
-
-        static final class FiniteRangeIterator implements Iterator<Long> {
-            final long end;
-            long count;
-
-            FiniteRangeIterator(long end) {
-                this.end = end;
+            public Iterator<Long> iterator() {
+                return new FiniteRangeIterator(end);
             }
 
-            @Override
-            public boolean hasNext() {
-                return count != end;
-            }
+            static final class FiniteRangeIterator implements Iterator<Long> {
+                final long end;
+                long count;
 
-            @Override
-            public Long next() {
-                long c = count;
-                if (c != end) {
-                    count = c + 1;
-                    return c;
+                FiniteRangeIterator(long end) {
+                    this.end = end;
                 }
-                throw new NoSuchElementException();
-            }
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
+                @Override
+                public boolean hasNext() {
+                    return count != end;
+                }
+
+                @Override
+                public Long next() {
+                    long c = count;
+                    if (c != end) {
+                        count = c + 1;
+                        return c;
+                    }
+                    throw new NoSuchElementException();
+                }
+
+                @Override
+                public void remove() {
+                    throw new UnsupportedOperationException();
+                }
             }
         }
-    }
 
     static final class InfiniteRange implements Iterable<Long> {
         @Override

--- a/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
@@ -297,11 +297,11 @@ extends BaseTestConsumer<T, U> {
     }
 
     static String fusionModeToString(int mode) {
-        switch (mode) {
-        case QueueFuseable.NONE : return "NONE";
-        case QueueFuseable.SYNC : return "SYNC";
-        case QueueFuseable.ASYNC : return "ASYNC";
-        default: return "Unknown(" + mode + ")";
-        }
+        return switch (mode) {
+            case QueueFuseable.NONE -> "NONE";
+            case QueueFuseable.SYNC -> "SYNC";
+            case QueueFuseable.ASYNC -> "ASYNC";
+            default -> "Unknown(" + mode + ")";
+        };
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverEx.java
@@ -13,6 +13,7 @@
 
 package io.reactivex.rxjava4.testsupport;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.reactivex.rxjava4.annotations.NonNull;
@@ -156,11 +157,8 @@ implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver
 
         try {
             lastThread = Thread.currentThread();
-            if (t == null) {
-                errors.add(new NullPointerException("onError received a null Throwable"));
-            } else {
-                errors.add(t);
-            }
+            errors.add(Objects.requireNonNullElseGet(t,
+                    () -> new NullPointerException("onError received a null Throwable")));
 
             downstream.onError(t);
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationNamingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationNamingTest.java
@@ -439,13 +439,7 @@ public class CheckParamValidationNamingTest extends RxJavaTest {
         }
     }
 
-    static final class ValidatorStrings {
-        final String code;
-        final String javadoc;
-        ValidatorStrings(String code, String javadoc) {
-            this.code = code;
-            this.javadoc = javadoc;
-        }
+    record ValidatorStrings(String code, String javadoc) {
     }
 
     static final List<ValidatorStrings> VALIDATOR_STRINGS = Arrays.asList(

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -1164,49 +1164,34 @@ public class CheckParamValidationTest extends RxJavaTest {
         NON_NEGATIVE
     }
 
-    static final class ParamIgnore {
-        final Class<?> clazz;
-        final String name;
-        final Class<?>[] arguments;
+    record ParamIgnore(Class<?> clazz, String name, Class<?>... arguments) {
 
-        ParamIgnore(Class<?> clazz, String name, Class<?>... arguments) {
-            this.clazz = clazz;
-            this.name = name;
-            this.arguments = arguments;
-        }
-
-        @Override
-        public String toString() {
-            return clazz.getName() + " " + name;
-        }
-    }
-
-    static final class ParamOverride {
-        final Class<?> clazz;
-        final int index;
-        final ParamMode mode;
-        final String name;
-        final Class<?>[] arguments;
-
-        ParamOverride(Class<?> clazz, int index, ParamMode mode, String name, Class<?>... arguments) {
-            this.clazz = clazz;
-            this.index = index;
-            this.mode = mode;
-            this.name = name;
-            this.arguments = arguments;
-
-            try {
-                clazz.getMethod(name, arguments);
-            } catch (Exception ex) {
-                throw new AssertionError(ex);
+            @Override
+            public String toString() {
+                return clazz.getName() + " " + name;
             }
         }
 
-        @Override
-        public String toString() {
-            return clazz.getName() + " " + name;
+    record ParamOverride(Class<?> clazz, int index, ParamMode mode, String name, Class<?>... arguments) {
+            ParamOverride(Class<?> clazz, int index, ParamMode mode, String name, Class<?>... arguments) {
+                this.clazz = clazz;
+                this.index = index;
+                this.mode = mode;
+                this.name = name;
+                this.arguments = arguments;
+
+                try {
+                    clazz.getMethod(name, arguments);
+                } catch (Exception ex) {
+                    throw new AssertionError(ex);
+                }
+            }
+
+            @Override
+            public String toString() {
+                return clazz.getName() + " " + name;
+            }
         }
-    }
 
     static final class NeverPublisher extends Flowable<Object> {
 


### PR DESCRIPTION
- Turn classes into records where possible.
- Use `List.sort` where possible.
- Use `switch` expression where possible.
- Use record extractor pattern where possible.