### PR TITLE
4.x: Cleanup - Migration; lambdas expressions

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -238,9 +238,7 @@ public interface Streamable<@NonNull T> {
     default Flowable<T> toFlowable(@NonNull ExecutorService executor) {
         Objects.requireNonNull(executor, "executir is null");
         var me = this;
-        return Flowable.virtualCreate(emitter -> {
-            me.forEach(emitter::emit).await(emitter.canceller());
-        }, executor);
+        return Flowable.virtualCreate(emitter -> me.forEach(emitter::emit).await(emitter.canceller()), executor);
     }
 
     /**
@@ -269,13 +267,11 @@ public interface Streamable<@NonNull T> {
         Objects.requireNonNull(transformer, "transformer is null");
         Objects.requireNonNull(executor, "executor is null");
         var me = this;
-        return create(emitter -> {
-            me.forEach((item, stopper) -> {
-                // System.out.println("item " + item);
-                transformer.transform(item, emitter, stopper);
-            }, emitter.canceller(), executor)
-            .await(emitter.canceller());
-        }, executor);
+        return create(emitter -> me.forEach((item, stopper) -> {
+            // System.out.println("item " + item);
+            transformer.transform(item, emitter, stopper);
+        }, emitter.canceller(), executor)
+        .await(emitter.canceller()), executor);
     }
 
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/parallel/ParallelJoin.java
@@ -216,7 +216,6 @@ public final class ParallelJoin<T> extends Flowable<T> {
             int missed = 1;
 
             JoinInnerSubscriber<T>[] s = this.subscribers;
-            int n = s.length;
             Subscriber<? super T> a = this.downstream;
 
             for (;;) {
@@ -387,7 +386,6 @@ public final class ParallelJoin<T> extends Flowable<T> {
             int missed = 1;
 
             JoinInnerSubscriber<T>[] s = this.subscribers;
-            int n = s.length;
             Subscriber<? super T> a = this.downstream;
 
             for (;;) {

--- a/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
@@ -122,9 +122,7 @@ public interface AwaitCoordinatorStatic {
         var winner = new CompletableFuture<CompletionStage<? extends T>>();
 
         for (var stage : stages) {
-            stage.whenComplete((_, _) -> {
-                winner.complete(stage);
-            });
+            stage.whenComplete((_, _) -> winner.complete(stage));
         }
         return await(winner, canceller).toCompletableFuture().getNow(null);
     }
@@ -144,9 +142,7 @@ public interface AwaitCoordinatorStatic {
         var winner = new CompletableFuture<CompletionStage<? extends T>>();
 
         for (var stage : stages) {
-            stage.whenComplete((_, _) -> {
-                winner.complete(stage);
-            });
+            stage.whenComplete((_, _) -> winner.complete(stage));
         }
         return (CompletionStage<T>)await(winner, canceller).toCompletableFuture().getNow(null);
     }
@@ -167,9 +163,7 @@ public interface AwaitCoordinatorStatic {
         for (int i = 0; i < stages.size(); i++) {
             var stage = stages.get(i);
             var fi = i;
-            stage.whenComplete((_, _) -> {
-                winner.complete(fi);
-            });
+            stage.whenComplete((_, _) -> winner.complete(fi));
         }
         return await(winner, canceller);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/FutureSingleObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/FutureSingleObserverTest.java
@@ -47,9 +47,7 @@ public class FutureSingleObserverTest extends RxJavaTest {
             fail("Should have thrown!");
         } catch (CancellationException ex) {
             // expected
-        } catch (InterruptedException ex) {
-            throw new AssertionError(ex);
-        } catch (ExecutionException ex) {
+        } catch (InterruptedException | ExecutionException ex) {
             throw new AssertionError(ex);
         }
 
@@ -58,11 +56,7 @@ public class FutureSingleObserverTest extends RxJavaTest {
             fail("Should have thrown!");
         } catch (CancellationException ex) {
             // expected
-        } catch (InterruptedException ex) {
-            throw new AssertionError(ex);
-        } catch (ExecutionException ex) {
-            throw new AssertionError(ex);
-        } catch (TimeoutException ex) {
+        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
             throw new AssertionError(ex);
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -1736,11 +1736,11 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void groupSyncFusionRejected() {
         Flowable.just(1)
         .groupBy(_ -> 1)
-        .doOnNext(g -> {
-            g.subscribeWith(new TestSubscriberEx<Integer>().setInitialFusionMode(QueueFuseable.SYNC))
-            .assertFuseable()
-            .assertFusionMode(QueueFuseable.NONE);
-        })
+        .doOnNext(g ->
+                g.subscribeWith(new TestSubscriberEx<Integer>()
+                                .setInitialFusionMode(QueueFuseable.SYNC))
+        .assertFuseable()
+        .assertFusionMode(QueueFuseable.NONE))
         .test()
         .assertComplete();
     }
@@ -1755,11 +1755,7 @@ public class FlowableGroupByTest extends RxJavaTest {
             CountDownLatch cdl = new CountDownLatch(1);
 
             pp.groupBy(_ -> 1)
-            .doOnNext(g -> {
-                TestHelper.raceOther(() -> {
-                    g.subscribe(ts);
-                }, cdl);
-            })
+            .doOnNext(g -> TestHelper.raceOther(() -> g.subscribe(ts), cdl))
             .test();
 
             pp.onNext(1);
@@ -1895,9 +1891,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         Flowable
         .range(1, 500_000)
         .map(i -> i % groups)
-        .doOnCancel(() -> {
-            System.out.println("Cancelling upstream");
-        })
+        .doOnCancel(() -> System.out.println("Cancelling upstream"))
         .groupBy(i -> i, i -> i, false, groupByBufferSize,
                               sizeCap(groups * 2, notifyOnExplicitEviction))
         .flatMap(gf -> gf
@@ -1946,9 +1940,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         Flowable
         .range(1, 500_000)
         .map(i -> i % groups)
-        .doOnRequest(v -> {
-            System.out.println("Source: " + v);
-        })
+        .doOnRequest(v -> System.out.println("Source: " + v))
         .groupBy(i -> i)
         .flatMap(gf -> gf
                      .observeOn(Schedulers.computation())
@@ -1971,9 +1963,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         Flowable
         .range(1, 500_000)
         .map(i -> i % groups)
-        .doOnRequest(v -> {
-            System.out.println("Source: " + v);
-        })
+        .doOnRequest(v -> System.out.println("Source: " + v))
         .groupBy(i -> i)
         .flatMap(gf -> gf
                      .hide()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -551,9 +551,7 @@ public class FlowableGroupJoinTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         pp1.groupJoin(pp2, _ -> Flowable.never(), _ -> Flowable.never(), (a, _) -> a)
-        .doOnNext(_ -> {
-            ts.cancel();
-        })
+        .doOnNext(_ -> ts.cancel())
         .subscribe(ts);
 
         pp2.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -947,9 +947,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         Flowable.range(1, 10000)
         .switchMap((Function<Integer, Flowable<Object>>) _ -> Flowable.just(2).hide()
         .observeOn(Schedulers.single())
-        .map((Function<Integer, Object>) _ -> {
-            return Thread.currentThread().getName();
-        }))
+        .map((Function<Integer, Object>) _ -> Thread.currentThread().getName()))
         .to(TestHelper.<Object>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertNever(thread)
@@ -1110,9 +1108,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
         int n = 10_000;
         for (int i = 0; i < n; i++) {
-            Flowable.<Integer>create(it -> {
-                it.onNext(0);
-            }, BackpressureStrategy.MISSING)
+            Flowable.<Integer>create(it -> it.onNext(0), BackpressureStrategy.MISSING)
             .switchMap(_ -> createFlowable(inner))
             .observeOn(Schedulers.computation())
             .doFinally(outer::incrementAndGet)
@@ -1129,12 +1125,8 @@ public class FlowableSwitchTest extends RxJavaTest {
         return Flowable.<Integer>unsafeCreate(s -> {
             SerializedSubscriber<Integer> it = new SerializedSubscriber<>(s);
             it.onSubscribe(new BooleanSubscription());
-            Schedulers.cached().scheduleDirect(() -> {
-                it.onNext(1);
-            }, 0, TimeUnit.MILLISECONDS);
-            Schedulers.cached().scheduleDirect(() -> {
-                it.onNext(2);
-            }, 0, TimeUnit.MILLISECONDS);
+            Schedulers.cached().scheduleDirect(() -> it.onNext(1), 0, TimeUnit.MILLISECONDS);
+            Schedulers.cached().scheduleDirect(() -> it.onNext(2), 0, TimeUnit.MILLISECONDS);
         })
         .doFinally(inner::incrementAndGet);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToListTest.java
@@ -174,9 +174,7 @@ public class FlowableToListTest extends RxJavaTest {
     static void await(CyclicBarrier cb) {
         try {
             cb.await();
-        } catch (InterruptedException ex) {
-            ex.printStackTrace();
-        } catch (BrokenBarrierException ex) {
+        } catch (InterruptedException | BrokenBarrierException ex) {
             ex.printStackTrace();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToSortedListTest.java
@@ -145,9 +145,7 @@ public class FlowableToSortedListTest extends RxJavaTest {
     static void await(CyclicBarrier cb) {
         try {
             cb.await();
-        } catch (InterruptedException ex) {
-            ex.printStackTrace();
-        } catch (BrokenBarrierException ex) {
+        } catch (InterruptedException | BrokenBarrierException ex) {
             ex.printStackTrace();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
@@ -586,9 +586,7 @@ public class ObservableCreateTest extends RxJavaTest {
             })
             .doOnNext(v -> {
                 if (v == 1) {
-                    TestHelper.raceOther(() -> {
-                        ref.get().onNext(2);
-                    }, cdl);
+                    TestHelper.raceOther(() -> ref.get().onNext(2), cdl);
                     ref.get().onNext(3);
                 }
             })

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGenerateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGenerateTest.java
@@ -30,9 +30,7 @@ public class ObservableGenerateTest extends RxJavaTest {
 
     @Test
     public void statefulBiconsumer() {
-        Observable.generate(() -> 10, (BiConsumer<Object, Emitter<Object>>) (s, e) -> {
-            e.onNext(s);
-        }, _ -> {
+        Observable.generate(() -> 10, (BiConsumer<Object, Emitter<Object>>) (s, e) -> e.onNext(s), _ -> {
 
         })
         .take(5)
@@ -64,9 +62,7 @@ public class ObservableGenerateTest extends RxJavaTest {
     public void disposerThrows() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable.generate(() -> 1, (BiConsumer<Object, Emitter<Object>>) (_, e) -> {
-                e.onComplete();
-            }, _ -> {
+            Observable.generate(() -> 1, (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onComplete(), _ -> {
                 throw new TestException();
             })
             .test()
@@ -80,9 +76,7 @@ public class ObservableGenerateTest extends RxJavaTest {
 
     @Test
     public void dispose() {
-        TestHelper.checkDisposed(Observable.generate(() -> 1, (BiConsumer<Object, Emitter<Object>>) (_, e) -> {
-            e.onComplete();
-        }, Functions.emptyConsumer()));
+        TestHelper.checkDisposed(Observable.generate(() -> 1, (BiConsumer<Object, Emitter<Object>>) (_, e) -> e.onComplete(), Functions.emptyConsumer()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
@@ -1119,9 +1119,7 @@ public class ObservableGroupByTest extends RxJavaTest {
             CountDownLatch cdl = new CountDownLatch(1);
 
             bs.groupBy(_ -> 1)
-            .doOnNext(g -> {
-                TestHelper.raceOther(g::test, cdl);
-            })
+            .doOnNext(g -> TestHelper.raceOther(g::test, cdl))
             .test();
 
             cdl.await();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
@@ -544,9 +544,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
 
         ps1.groupJoin(ps2, _ -> Observable.never(), _ -> Observable.never(), (a, _) -> a)
-        .doOnNext(_ -> {
-            to.dispose();
-        })
+        .doOnNext(_ -> to.dispose())
         .subscribe(to);
 
         ps2.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -1172,9 +1172,7 @@ public class ObservableSwitchTest extends RxJavaTest {
 
         int n = 10_000;
         for (int i = 0; i < n; i++) {
-            Observable.<Integer>create(it -> {
-                it.onNext(0);
-            })
+            Observable.<Integer>create(it -> it.onNext(0))
             .switchMap(_ -> createObservable(inner))
             .observeOn(Schedulers.computation())
             .doFinally(outer::incrementAndGet)
@@ -1191,12 +1189,8 @@ public class ObservableSwitchTest extends RxJavaTest {
         return Observable.<Integer>unsafeCreate(s -> {
             SerializedObserver<Integer> it = new SerializedObserver<>(s);
             it.onSubscribe(Disposable.empty());
-            Schedulers.cached().scheduleDirect(() -> {
-                it.onNext(1);
-            }, 0, TimeUnit.MILLISECONDS);
-            Schedulers.cached().scheduleDirect(() -> {
-                it.onNext(2);
-            }, 0, TimeUnit.MILLISECONDS);
+            Schedulers.cached().scheduleDirect(() -> it.onNext(1), 0, TimeUnit.MILLISECONDS);
+            Schedulers.cached().scheduleDirect(() -> it.onNext(2), 0, TimeUnit.MILLISECONDS);
         })
         .doFinally(inner::incrementAndGet);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToListTest.java
@@ -146,9 +146,7 @@ public class ObservableToListTest extends RxJavaTest {
     static void await(CyclicBarrier cb) {
         try {
             cb.await();
-        } catch (InterruptedException ex) {
-            ex.printStackTrace();
-        } catch (BrokenBarrierException ex) {
+        } catch (InterruptedException | BrokenBarrierException ex) {
             ex.printStackTrace();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToSortedListTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToSortedListTest.java
@@ -63,9 +63,7 @@ public class ObservableToSortedListTest extends RxJavaTest {
     static void await(CyclicBarrier cb) {
         try {
             cb.await();
-        } catch (InterruptedException ex) {
-            ex.printStackTrace();
-        } catch (BrokenBarrierException ex) {
+        } catch (InterruptedException | BrokenBarrierException ex) {
             ex.printStackTrace();
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -37,7 +37,7 @@ public class StreamableTest extends StreamableBaseTest {
             TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
             ts.onSubscribe(EmptySubscription.INSTANCE);
 
-            try (var comp = Streamable.empty().forEach(e -> { ts.onError(new TestException("Element produced? " + e)); }, exec)) {
+            try (var comp = Streamable.empty().forEach(e -> ts.onError(new TestException("Element produced? " + e)), exec)) {
 
                 comp.stage().toCompletableFuture().thenAccept(_ -> ts.onComplete())
                 .exceptionally(e -> { ts.onError(e); return null; });
@@ -113,9 +113,7 @@ public class StreamableTest extends StreamableBaseTest {
                     emitter.emit(i);
                 }
             }, exec)
-            .transform((item, emitter, _) -> {
-                emitter.emit(-item - 1);
-            }, exec)
+            .transform((item, emitter, _) -> emitter.emit(-item - 1), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
@@ -130,9 +128,7 @@ public class StreamableTest extends StreamableBaseTest {
         TestHelper.onVirtual(exec -> {
             Flowable.range(1, 10)
             .toStreamable(exec)
-            .transform((item, emitter, _) -> {
-                emitter.emit(-item - 1);
-            }, exec)
+            .transform((item, emitter, _) -> emitter.emit(-item - 1), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
@@ -155,9 +151,7 @@ public class StreamableTest extends StreamableBaseTest {
             })
             .doOnNext(v -> System.out.println("Flowable::doOnNext " + v))
             .toStreamable(exec)
-            .transform((item, emitter, _) -> {
-                emitter.emit(-item - 1);
-            }, exec)
+            .transform((item, emitter, _) -> emitter.emit(-item - 1), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11);
@@ -228,18 +222,16 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void rangeTransformFilter() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.range(1, 10)
-            .toStreamable(exec)
-            .transform((item, emitter, _) -> {
-                if ((item & 1) == 0) {
-                    emitter.emit(item);
-                }
-            }, exec)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(2, 4, 6, 8, 10);
-        });
+        TestHelper.withVirtual(exec -> Flowable.range(1, 10)
+        .toStreamable(exec)
+        .transform((item, emitter, _) -> {
+            if ((item & 1) == 0) {
+                emitter.emit(item);
+            }
+        }, exec)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(2, 4, 6, 8, 10));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateTest.java
@@ -46,9 +46,7 @@ public class VirtualCreateTest {
     @Test
     public void checkIsInsideVirtualThread() {
         try (var scope = Executors.newVirtualThreadPerTaskExecutor()) {
-            Flowable.virtualCreate(emitter -> {
-                emitter.emit(Thread.currentThread().isVirtual());
-            }, scope)
+            Flowable.virtualCreate(emitter -> emitter.emit(Thread.currentThread().isVirtual()), scope)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(true);
@@ -58,9 +56,7 @@ public class VirtualCreateTest {
     @Test
     public void checkIsInsideVirtualThreadExec() throws Throwable {
         try (var exec = Executors.newSingleThreadExecutor()) {
-            Flowable.virtualCreate(emitter -> {
-                emitter.emit(Thread.currentThread().isVirtual());
-            }, exec)
+            Flowable.virtualCreate(emitter -> emitter.emit(Thread.currentThread().isVirtual()), exec)
             .test()
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(false);
@@ -81,46 +77,38 @@ public class VirtualCreateTest {
 
     @Test
     public void takeUntil() throws Throwable {
-        withVirtual(exec -> {
-            Flowable.<Integer>virtualCreate(e -> {
-                for (int i = 1; i < 6; i++) {
-                    e.emit(i);
-                }
-            }, exec)
-            .take(2)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(1, 2);
-        });
+        withVirtual(exec -> Flowable.<Integer>virtualCreate(e -> {
+            for (int i = 1; i < 6; i++) {
+                e.emit(i);
+            }
+        }, exec)
+        .take(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2));
     }
 
     @Test
     public void backpressure() throws Throwable {
-        withVirtual(exec -> {
-            Flowable.<Integer>virtualCreate(e -> {
-                for (int i = 0; i < 10000; i++) {
-                    e.emit(i);
-                }
-            }, exec)
-            .observeOn(Schedulers.single(), false, 2)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertValueCount(10000)
-            ;
-        });
+        withVirtual(exec -> Flowable.<Integer>virtualCreate(e -> {
+            for (int i = 0; i < 10000; i++) {
+                e.emit(i);
+            }
+        }, exec)
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertValueCount(10000));
     }
 
     @Test
     public void error() throws Throwable {
-        withVirtual(exec -> {
-            Flowable.<Integer>virtualCreate(_ -> {
-                throw new IOException();
-            }, exec)
-            .observeOn(Schedulers.single(), false, 2)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertError(IOException.class)
-            ;
-        });
+        withVirtual(exec -> Flowable.<Integer>virtualCreate(_ -> {
+            throw new IOException();
+        }, exec)
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateVirtualTest.java
@@ -44,9 +44,7 @@ public class VirtualCreateVirtualTest {
 
     @Test
     public void checkIsInsideVirtualThread() {
-        Flowable.virtualCreate(emitter -> {
-            emitter.emit(Thread.currentThread().isVirtual());
-        })
+        Flowable.virtualCreate(emitter -> emitter.emit(Thread.currentThread().isVirtual()))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(true);
@@ -54,9 +52,7 @@ public class VirtualCreateVirtualTest {
 
     @Test
     public void checkIsInsideVirtualThreadExec() throws Throwable {
-        Flowable.virtualCreate(emitter -> {
-            emitter.emit(Thread.currentThread().isVirtual());
-        }, Schedulers.cached())
+        Flowable.virtualCreate(emitter -> emitter.emit(Thread.currentThread().isVirtual()), Schedulers.cached())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(false);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
@@ -45,75 +45,58 @@ public class VirtualTransformTest {
 
     @Test
     public void errorUpstream() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.error(new IOException())
-            .virtualTransform((v, e, _) -> e.emit(v), exec)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertError(IOException.class)
-            ;
-        });
+        TestHelper.withVirtual(exec -> Flowable.error(new IOException())
+        .virtualTransform((v, e, _) -> e.emit(v), exec)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class));
     }
 
     @Test
     public void errorTransform() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.range(1, 5)
-            .virtualTransform((_, _, _) -> { throw new IOException(); }, exec)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertError(IOException.class)
-            ;
-        });
+        TestHelper.withVirtual(exec -> Flowable.range(1, 5)
+        .virtualTransform((_, _, _) -> { throw new IOException(); }, exec)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertError(IOException.class));
     }
 
     @Test
     public void take() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.range(1, 5)
-            .virtualTransform((v, e, _) -> e.emit(v), exec)
-            .take(2)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult(1, 2)
-            ;
-        });
+        TestHelper.withVirtual(exec -> Flowable.range(1, 5)
+        .virtualTransform((v, e, _) -> e.emit(v), exec)
+        .take(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2));
     }
 
     @Test
     public void observeOn() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.range(1, 10000)
-            .virtualTransform((v, e, _) -> e.emit(v), exec)
-            .observeOn(Schedulers.single(), false, 2)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertNoErrors()
-            .assertValueCount(10000);
-        });
+        TestHelper.withVirtual(exec -> Flowable.range(1, 10000)
+        .virtualTransform((v, e, _) -> e.emit(v), exec)
+        .observeOn(Schedulers.single(), false, 2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertNoErrors()
+        .assertValueCount(10000));
     }
 
     @Test
     public void empty() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.empty()
-            .virtualTransform((v, e, _) -> e.emit(v), exec)
-            .test()
-            .awaitDone(5, TimeUnit.SECONDS)
-            .assertResult()
-            ;
-        });
+        TestHelper.withVirtual(exec -> Flowable.empty()
+        .virtualTransform((v, e, _) -> e.emit(v), exec)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult());
     }
 
     @Test
     public void emptyNever() throws Throwable {
-        TestHelper.withVirtual(exec -> {
-            Flowable.just(1).concatWith(Flowable.never())
-            .virtualTransform((v, e, _) -> e.emit(v), exec)
-            .test()
-            .awaitDone(1, TimeUnit.SECONDS)
-            .assertValues(1)
-            ;
-        });
+        TestHelper.withVirtual(exec -> Flowable.just(1).concatWith(Flowable.never())
+        .virtualTransform((v, e, _) -> e.emit(v), exec)
+        .test()
+        .awaitDone(1, TimeUnit.SECONDS)
+        .assertValues(1));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutor2TckTest.java
@@ -56,9 +56,7 @@ public class FlowableVirtualTransformExecutor2TckTest extends BaseTck<Long> {
             Thread.sleep(10);
             return v;
         })
-        .virtualTransform((v, emitter, _) -> {
-            emitter.emit(v);
-        }, service, 2)
+        .virtualTransform((v, emitter, _) -> emitter.emit(v), service, 2)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutorTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformExecutorTckTest.java
@@ -106,9 +106,7 @@ public class FlowableVirtualTransformExecutorTckTest extends BaseTck<Long> {
             }
             return v;
         })
-        .virtualTransform((v, emitter, _) -> {
-            emitter.emit(v);
-        }, service)
+        .virtualTransform((v, emitter, _) -> emitter.emit(v), service)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtual2TckTest.java
@@ -56,9 +56,7 @@ public class FlowableVirtualTransformVirtual2TckTest extends BaseTck<Long> {
             Thread.sleep(10);
             return v;
         })
-        .virtualTransform((v, emitter, _) -> {
-            emitter.emit(v);
-        }, Schedulers.virtual(), 2)
+        .virtualTransform((v, emitter, _) -> emitter.emit(v), Schedulers.virtual(), 2)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/tck/FlowableVirtualTransformVirtualTckTest.java
@@ -106,9 +106,7 @@ public class FlowableVirtualTransformVirtualTckTest extends BaseTck<Long> {
             }
             return v;
         })
-        .virtualTransform((v, emitter, _) -> {
-            emitter.emit(v);
-        }, Schedulers.virtual(), Flowable.bufferSize())
+        .virtualTransform((v, emitter, _) -> emitter.emit(v), Schedulers.virtual(), Flowable.bufferSize())
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -40,6 +40,9 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class TestObserverTest extends RxJavaTest {
 
     static void assertThrowsWithMessage(String message, Class<? extends Throwable> clazz, ThrowingRunnable run) {
+        if (message.startsWith("~")) {
+            message = message.substring(1);
+        }
         assertEquals(message, assertThrows(clazz, run).getMessage());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -752,7 +752,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
+        var to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -958,8 +958,12 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueAtIndexNoMatch() {
-        assertThrowsWithMessage("\nexpected: b (class: String)\ngot: c (class: String); Value at position 2 differ "
-                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("""
+                ~
+                expected: b (class: String)
+                got: c (class: String); Value at position 2 differ \
+                (latch = 0, values = 3, errors = 0, completions = 1)""",
+                AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -981,8 +985,11 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuesCountNoMatch() {
-        assertThrowsWithMessage("\nexpected: 2 [a, b]\ngot: 3 [a, b, c]; "
-                + "Value count differs (latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("""
+                ~
+                expected: 2 [a, b]
+                got: 3 [a, b, c]; \
+                Value count differs (latch = 0, values = 3, errors = 0, completions = 1)""", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -1004,8 +1011,11 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValuesNoMatch() {
-        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ "
-                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("""
+                ~
+                expected: d (class: String)
+                got: c (class: String); Value at position 2 differ \
+                (latch = 0, values = 3, errors = 0, completions = 1)""", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);
@@ -1049,8 +1059,11 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void assertValueSequenceNoMatch() {
-        assertThrowsWithMessage("\nexpected: d (class: String)\ngot: c (class: String); Value at position 2 differ "
-                + "(latch = 0, values = 3, errors = 0, completions = 1)", AssertionError.class, () -> {
+        assertThrowsWithMessage("""
+                ~
+                expected: d (class: String)
+                got: c (class: String); Value at position 2 differ \
+                (latch = 0, values = 3, errors = 0, completions = 1)""", AssertionError.class, () -> {
             TestObserver<String> to = new TestObserver<>();
 
             Observable.just("a", "b", "c").subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -365,9 +365,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -379,9 +377,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         int lastSize = 0;
@@ -417,9 +413,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -431,9 +425,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         for (; !rs.hasThrowable() && !rs.hasComplete();) {
@@ -458,9 +450,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -479,9 +469,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         for (; !rs.hasThrowable() && !rs.hasComplete();) {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -353,9 +353,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -367,9 +365,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         int lastSize = 0;

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ComputationSchedulerTests.java
@@ -178,16 +178,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         // #3 thread's uncaught exception handler
         Scheduler computationScheduler = new ComputationScheduler(r -> {
             Thread t = new Thread(r);
-            t.setUncaughtExceptionHandler((_, _) -> {
-                latch.countDown();
-            });
+            t.setUncaughtExceptionHandler((_, _) -> latch.countDown());
             return t;
         });
 
         // #2 RxJava exception handler
-        RxJavaPlugins.setErrorHandler(_ -> {
-            latch.countDown();
-        });
+        RxJavaPlugins.setErrorHandler(_ -> latch.countDown());
 
         // Exceptions, fatal or not, should be handled by
         // #1 observer's onError(), or
@@ -204,7 +200,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             })
             .subscribeOn(computationScheduler)
             .subscribe(_ -> { },
-                _ -> { latch.countDown(); }
+                _ -> latch.countDown()
             );
 
             assertTrue(latch.await(2, TimeUnit.SECONDS));
@@ -221,16 +217,12 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
         // #3 thread's uncaught exception handler
         Scheduler computationScheduler = new ComputationScheduler(r -> {
             Thread t = new Thread(r);
-            t.setUncaughtExceptionHandler((_, _) -> {
-                latch.countDown();
-            });
+            t.setUncaughtExceptionHandler((_, _) -> latch.countDown());
             return t;
         });
 
         // #2 RxJava exception handler
-        RxJavaPlugins.setErrorHandler(_ -> {
-            latch.countDown();
-        });
+        RxJavaPlugins.setErrorHandler(_ -> latch.countDown());
 
         // Exceptions, fatal or not, should be handled by
         // #1 observer's onError(), or
@@ -243,9 +235,7 @@ public class ComputationSchedulerTests extends AbstractSchedulerConcurrencyTests
             Flowable.interval(500, TimeUnit.MILLISECONDS, computationScheduler)
                     .subscribe(_ -> {
                         throw new OutOfMemoryError();
-                    }, _ -> {
-                        latch.countDown();
-                    });
+                    }, _ -> latch.countDown());
 
             assertTrue(latch.await(2, TimeUnit.SECONDS));
         } finally {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -369,9 +369,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -383,9 +381,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         int lastSize = 0;
@@ -421,9 +417,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -435,9 +429,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         for (; !rs.hasThrowable() && !rs.hasComplete();) {
@@ -462,9 +454,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -483,9 +473,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         for (; !rs.hasThrowable() && !rs.hasComplete();) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -357,9 +357,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         Thread t = new Thread(() -> {
             try {
                 cb.await();
-            } catch (InterruptedException e) {
-                return;
-            } catch (BrokenBarrierException e) {
+            } catch (InterruptedException | BrokenBarrierException e) {
                 return;
             }
             for (int i = 0; i < 1000000; i++) {
@@ -371,9 +369,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         t.start();
         try {
             cb.await();
-        } catch (InterruptedException e) {
-            return;
-        } catch (BrokenBarrierException e) {
+        } catch (InterruptedException | BrokenBarrierException e) {
             return;
         }
         int lastSize = 0;

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -284,9 +284,7 @@ public enum TestHelper {
 
                 m.invoke("INSTANCE");
                 fail("Should have thrown!");
-            } catch (InvocationTargetException ex) {
-                fail(ex.toString());
-            } catch (IllegalAccessException ex) {
+            } catch (InvocationTargetException | IllegalAccessException ex) {
                 fail(ex.toString());
             } catch (IllegalArgumentException ex) {
                 // we expected this
@@ -3537,43 +3535,49 @@ public enum TestHelper {
             })
             .to(transform);
 
-            if (result instanceof MaybeSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+            switch (result) {
+                case MaybeSource<?> maybeSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((MaybeSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof SingleSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    maybeSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case SingleSource<?> singleSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((SingleSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof CompletableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    singleSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case CompletableSource completableSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((CompletableSource)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof ObservableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    completableSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case ObservableSource<?> observableSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((ObservableSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof Publisher) {
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
-                disposable.set(Disposable.fromSubscription(ts));
+                    observableSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case Publisher<?> publisher -> {
+                    TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
+                    disposable.set(Disposable.fromSubscription(ts));
 
-                ((Publisher<?>)result)
-                .subscribe(ts);
-                ts.assertEmpty();
-            } else {
-                fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
+                    publisher
+                            .subscribe(ts);
+                    ts.assertEmpty();
+                }
+                default ->
+                        fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
             }
 
             assertFalse("No undeliverable errors received", errors.isEmpty());
@@ -3602,43 +3606,49 @@ public enum TestHelper {
             })
             .to(transform);
 
-            if (result instanceof MaybeSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+            switch (result) {
+                case MaybeSource<?> maybeSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((MaybeSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof SingleSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    maybeSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case SingleSource<?> singleSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((SingleSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof CompletableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    singleSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case CompletableSource completableSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((CompletableSource)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof ObservableSource) {
-                TestObserverEx<Object> to = new TestObserverEx<>();
-                disposable.set(to.asDisposable());
+                    completableSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case ObservableSource<?> observableSource -> {
+                    TestObserverEx<Object> to = new TestObserverEx<>();
+                    disposable.set(to.asDisposable());
 
-                ((ObservableSource<?>)result)
-                .subscribe(to);
-                to.assertEmpty();
-            } else if (result instanceof Publisher) {
-                TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
-                disposable.set(Disposable.fromSubscription(ts));
+                    observableSource
+                            .subscribe(to);
+                    to.assertEmpty();
+                }
+                case Publisher<?> publisher -> {
+                    TestSubscriberEx<Object> ts = new TestSubscriberEx<>();
+                    disposable.set(Disposable.fromSubscription(ts));
 
-                ((Publisher<?>)result)
-                .subscribe(ts);
-                ts.assertEmpty();
-            } else {
-                fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
+                    publisher
+                            .subscribe(ts);
+                    ts.assertEmpty();
+                }
+                default ->
+                        fail("Unsupported transformation output: " + result + " of class " + (result != null ? result.getClass() : " <null>"));
             }
 
             assertFalse("No undeliverable errors received", errors.isEmpty());
@@ -3901,15 +3911,13 @@ public enum TestHelper {
      * @throws Throwable the exception propagated out
      */
     public static void onVirtual(Consumer<ExecutorService> call) throws Throwable {
-        withVirtual(exec -> {
-            exec.submit(() -> {
-                try {
-                    call.accept(exec);
-                } catch (Throwable ex) {
-                    throw Exceptions.propagate(ex);
-                }
-            }).get();
-        });
+        withVirtual(exec -> exec.submit(() -> {
+            try {
+                call.accept(exec);
+            } catch (Throwable ex) {
+                throw Exceptions.propagate(ex);
+            }
+        }).get());
     }
 
     record ExecutorIntercept(ExecutorService service, boolean printStackTrace) implements ExecutorService {


### PR DESCRIPTION
- Convert one liner block lambdas into expression lambdas.
- Combine `catch` exception variants with the same handler.  