### PR TITLE
4.x: Cleanup, fix inferable types via var or diamond

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -115,7 +115,7 @@ public interface Streamable<@NonNull T> {
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
         Objects.requireNonNull(source, "source is null");
-        return new StreamableFromPublisher<T>(source, executor);
+        return new StreamableFromPublisher<>(source, executor);
     }
 
     /**
@@ -357,7 +357,7 @@ public interface Streamable<@NonNull T> {
             return null;
         });
         canceller.add(Disposable.fromFuture(future));
-        return new CompletionStageDisposable<Void>(StreamableHelper.toCompletionStage((Future<Void>)(Future<?>)future), canceller);
+        return new CompletionStageDisposable<>(StreamableHelper.toCompletionStage((Future<Void>) (Future<?>) future), canceller);
     }
 
     /**
@@ -407,8 +407,8 @@ public interface Streamable<@NonNull T> {
             return null;
         });
         canceller.add(Disposable.fromFuture(future));
-        return new CompletionStageDisposable<Void>(
-                StreamableHelper.toCompletionStage((Future<Void>)(Future<?>)future), canceller);
+        return new CompletionStageDisposable<>(
+                StreamableHelper.toCompletionStage((Future<Void>) (Future<?>) future), canceller);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
@@ -103,7 +103,7 @@ implements FlowableSubscriber<T> {
         Node<T> n = new Node<>(capacityHint);
         this.head = n;
         this.tail = n;
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<CacheSubscription<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublish.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublish.java
@@ -179,7 +179,7 @@ implements HasUpstreamPublisher<T> {
             this.upstream = new AtomicReference<>();
             this.connect = new AtomicBoolean();
             this.bufferSize = bufferSize;
-            this.subscribers = new AtomicReference<>(EMPTY);
+            this.subscribers = new AtomicReference<InnerSubscription<T>[]>(EMPTY);
         }
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishMulticast.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishMulticast.java
@@ -158,7 +158,7 @@ public final class FlowablePublishMulticast<T, R> extends AbstractFlowableWithUp
             this.delayError = delayError;
             this.wip = new AtomicInteger();
             this.upstream = new AtomicReference<>();
-            this.subscribers = new AtomicReference<>(EMPTY);
+            this.subscribers = new AtomicReference<MulticastSubscription<T>[]>(EMPTY);
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCache.java
@@ -43,7 +43,7 @@ public final class MaybeCache<T> extends Maybe<T> implements MaybeObserver<T> {
     @SuppressWarnings("unchecked")
     public MaybeCache(MaybeSource<T> source) {
         this.source = new AtomicReference<>(source);
-        this.observers = new AtomicReference<>(EMPTY);
+        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleCache.java
@@ -40,7 +40,7 @@ public final class SingleCache<T> extends Single<T> implements SingleObserver<T>
     public SingleCache(SingleSource<? extends T> source) {
         this.source = source;
         this.wip = new AtomicInteger();
-        this.observers = new AtomicReference<>(EMPTY);
+        this.observers = new AtomicReference<CacheDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorComplete.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorComplete.java
@@ -38,6 +38,6 @@ public final class SingleOnErrorComplete<T> extends Maybe<T> {
 
     @Override
     protected void subscribeActual(MaybeObserver<? super T> observer) {
-        source.subscribe(new MaybeOnErrorComplete.OnErrorCompleteMultiObserver<T>(observer, predicate));
+        source.subscribe(new MaybeOnErrorComplete.OnErrorCompleteMultiObserver<>(observer, predicate));
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
@@ -24,7 +24,7 @@ public final class StreamableEmpty<T> implements Streamable<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new EmptyStreamer<T>();
+        return new EmptyStreamer<>();
     }
 
     static final class EmptyStreamer<T> implements Streamer<T> {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -28,7 +28,7 @@ public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new JustStreamer<T>(item, cancellation);
+        return new JustStreamer<>(item, cancellation);
     }
 
     static final class JustStreamer<T> implements Streamer<T>, Disposable {

--- a/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/AsyncProcessor.java
@@ -148,7 +148,7 @@ public final class AsyncProcessor<@NonNull T> extends FlowableProcessor<T> {
      */
     @SuppressWarnings("unchecked")
     AsyncProcessor() {
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<AsyncSubscription<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/BehaviorProcessor.java
@@ -222,7 +222,7 @@ public final class BehaviorProcessor<@NonNull T> extends FlowableProcessor<T> {
         this.lock = new ReentrantReadWriteLock();
         this.readLock = lock.readLock();
         this.writeLock = lock.writeLock();
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<BehaviorSubscription<T>[]>(EMPTY);
         this.terminalEvent = new AtomicReference<>();
     }
 

--- a/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/MulticastProcessor.java
@@ -228,7 +228,7 @@ public final class MulticastProcessor<@NonNull T> extends FlowableProcessor<T> {
         this.bufferSize = bufferSize;
         this.limit = bufferSize - (bufferSize >> 2);
         this.wip = new AtomicInteger();
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<MulticastSubscription<T>[]>(EMPTY);
         this.upstream = new AtomicReference<>();
         this.refcount = refCount;
     }

--- a/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/PublishProcessor.java
@@ -139,7 +139,7 @@ public final class PublishProcessor<@NonNull T> extends FlowableProcessor<T> {
      */
     @SuppressWarnings("unchecked")
     PublishProcessor() {
-        subscribers = new AtomicReference<>(EMPTY);
+        subscribers = new AtomicReference<PublishSubscription<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/ReplayProcessor.java
@@ -342,7 +342,7 @@ public final class ReplayProcessor<@NonNull T> extends FlowableProcessor<T> {
     @SuppressWarnings("unchecked")
     ReplayProcessor(ReplayBuffer<T> buffer) {
         this.buffer = buffer;
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<ReplaySubscription<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/AsyncSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/AsyncSubject.java
@@ -139,7 +139,7 @@ public final class AsyncSubject<T> extends Subject<T> {
      */
     @SuppressWarnings("unchecked")
     AsyncSubject() {
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<AsyncDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/BehaviorSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/BehaviorSubject.java
@@ -208,7 +208,7 @@ public final class BehaviorSubject<T> extends Subject<T> {
         this.lock = new ReentrantReadWriteLock();
         this.readLock = lock.readLock();
         this.writeLock = lock.writeLock();
-        this.observers = new AtomicReference<>(EMPTY);
+        this.observers = new AtomicReference<BehaviorDisposable<T>[]>(EMPTY);
         this.value = new AtomicReference<>(defaultValue);
         this.terminalEvent = new AtomicReference<>();
     }

--- a/src/main/java/io/reactivex/rxjava4/subjects/MaybeSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/MaybeSubject.java
@@ -138,7 +138,7 @@ public final class MaybeSubject<T> extends Maybe<T> implements MaybeObserver<T> 
     @SuppressWarnings("unchecked")
     MaybeSubject() {
         once = new AtomicBoolean();
-        observers = new AtomicReference<>(EMPTY);
+        observers = new AtomicReference<MaybeDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/PublishSubject.java
@@ -125,7 +125,7 @@ public final class PublishSubject<T> extends Subject<T> {
      */
     @SuppressWarnings("unchecked")
     PublishSubject() {
-        subscribers = new AtomicReference<>(EMPTY);
+        subscribers = new AtomicReference<PublishDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/ReplaySubject.java
@@ -328,7 +328,7 @@ public final class ReplaySubject<T> extends Subject<T> {
     @SuppressWarnings("unchecked")
     ReplaySubject(ReplayBuffer<T> buffer) {
         this.buffer = buffer;
-        this.observers = new AtomicReference<>(EMPTY);
+        this.observers = new AtomicReference<ReplayDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/subjects/SingleSubject.java
+++ b/src/main/java/io/reactivex/rxjava4/subjects/SingleSubject.java
@@ -122,7 +122,7 @@ public final class SingleSubject<T> extends Single<T> implements SingleObserver<
     @SuppressWarnings("unchecked")
     SingleSubject() {
         once = new AtomicBoolean();
-        observers = new AtomicReference<>(EMPTY);
+        observers = new AtomicReference<SingleDisposable<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/completable/CompletableTest.java
@@ -56,7 +56,7 @@ public class CompletableTest extends RxJavaTest {
     static final class IterableIteratorNextThrows implements Iterable<Completable> {
         @Override
         public Iterator<Completable> iterator() {
-            return new Iterator<Completable>() /* NFI */ {
+            return new Iterator<>() /* NFI */ {
                 @Override
                 public boolean hasNext() {
                     return true;
@@ -80,7 +80,7 @@ public class CompletableTest extends RxJavaTest {
     static final class IterableIteratorHasNextThrows implements Iterable<Completable> {
         @Override
         public Iterator<Completable> iterator() {
-            return new Iterator<Completable>() /* NFI */ {
+            return new Iterator<>() /* NFI */ {
                 @Override
                 public boolean hasNext() {
                     throw new TestException();
@@ -3097,7 +3097,7 @@ public class CompletableTest extends RxJavaTest {
 
     @Test
     public void onStartCalledSafe() {
-        TestSubscriber<Object> ts = new TestSubscriber<Object>() /* NFI */ {
+        var ts = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onStart() {
                 onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/ConverterTest.java
@@ -87,7 +87,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void observableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Observable.just(a).to((ObservableConverter)ConverterTest.testObservableConverterCreator());
     }
@@ -95,7 +95,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void singleGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Single.just(a).to((SingleConverter)ConverterTest.<String>testSingleConverterCreator());
     }
@@ -103,7 +103,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void maybeGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Maybe.just(a).to((MaybeConverter)ConverterTest.<String>testMaybeConverterCreator());
     }
@@ -111,7 +111,7 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void flowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).to((FlowableConverter)ConverterTest.<String>testFlowableConverterCreator());
     }
@@ -119,14 +119,14 @@ public final class ConverterTest extends RxJavaTest {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
     public void parallelFlowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).parallel().to((ParallelFlowableConverter)ConverterTest.<String>testParallelFlowableConverterCreator());
     }
 
     @Test
     public void compositeTest() {
-        CompositeConverter converter = new CompositeConverter();
+        var converter = new CompositeConverter();
 
         Flowable.just(1)
                 .to(converter)
@@ -174,27 +174,27 @@ public final class ConverterTest extends RxJavaTest {
     interface B<T> { }
 
     private static <T> ObservableConverter<A<T, ?>, B<T>> testObservableConverterCreator() {
-        return _ -> new B<T>() /* NFI */ {
+        return _ -> new B<>() /* NFI */ {
         };
     }
 
     private static <T> SingleConverter<A<T, ?>, B<T>> testSingleConverterCreator() {
-        return _ -> new B<T>() /* NFI */ {
+        return _ -> new B<>() /* NFI */ {
         };
     }
 
     private static <T> MaybeConverter<A<T, ?>, B<T>> testMaybeConverterCreator() {
-        return _ -> new B<T>() /* NFI */ {
+        return _ -> new B<>() /* NFI */ {
         };
     }
 
     private static <T> FlowableConverter<A<T, ?>, B<T>> testFlowableConverterCreator() {
-        return _ -> new B<T>() /* NFI */ {
+        return _ -> new B<>() /* NFI */ {
         };
     }
 
     private static <T> ParallelFlowableConverter<A<T, ?>, B<T>> testParallelFlowableConverterCreator() {
-        return _ -> new B<T>() /* NFI */ {
+        return _ -> new B<>() /* NFI */ {
         };
     }
 

--- a/src/test/java/io/reactivex/rxjava4/core/TransformerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/TransformerTest.java
@@ -86,28 +86,28 @@ public class TransformerTest extends RxJavaTest {
 
     @Test
     public void observableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Observable.just(a).compose(TransformerTest.<String>testObservableTransformerCreator());
     }
 
     @Test
     public void singleGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Single.just(a).compose(TransformerTest.<String>testSingleTransformerCreator());
     }
 
     @Test
     public void maybeGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Maybe.just(a).compose(TransformerTest.<String>testMaybeTransformerCreator());
     }
 
     @Test
     public void flowableGenericsSignatureTest() {
-        A<String, Integer> a = new A<String, Integer>() /* NFI */ { };
+        var a = new A<String, Integer>() /* NFI */ { };
 
         Flowable.just(a).compose(TransformerTest.<String>testFlowableTransformerCreator());
     }

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
@@ -55,7 +55,7 @@ public class ExceptionsTest extends RxJavaTest {
         final int MAX_STACK_DEPTH = 800;
         final AtomicInteger depth = new AtomicInteger();
 
-        a.subscribe(new Observer<Integer>() /* NFI */ {
+        a.subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -77,7 +77,7 @@ public class ExceptionsTest extends RxJavaTest {
                 b.onNext(n + 1);
             }
         });
-        b.subscribe(new Observer<Integer>() /* NFI */ {
+        b.subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -109,7 +109,7 @@ public class ExceptionsTest extends RxJavaTest {
 
     @Test(expected = StackOverflowError.class)
     public void stackOverflowErrorIsThrown() {
-        Observable.just(1).subscribe(new Observer<Integer>() /* NFI */ {
+        Observable.just(1).subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableBackpressureTests.java
@@ -336,7 +336,7 @@ public class FlowableBackpressureTests extends RxJavaTest {
         final AtomicInteger totalReceived = new AtomicInteger();
         final AtomicInteger batches = new AtomicInteger();
         final AtomicInteger received = new AtomicInteger();
-        incrementingIntegers(c).subscribe(new ResourceSubscriber<Integer>() /* NFI */ {
+        incrementingIntegers(c).subscribe(new ResourceSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -383,45 +383,45 @@ public class FlowableBackpressureTests extends RxJavaTest {
         final AtomicInteger batches = new AtomicInteger();
         final CountDownLatch latch = new CountDownLatch(1);
         incrementingIntegers(c).subscribeOn(Schedulers.newThread()).subscribe(
-                new ResourceSubscriber<Integer>() /* NFI */ {
+                new ResourceSubscriber<>() /* NFI */ {
 
-            @Override
-            public void onStart() {
-                request(100);
-            }
-
-            @Override
-            public void onComplete() {
-                latch.countDown();
-            }
-
-            @Override
-            public void onError(Throwable e) {
-                latch.countDown();
-            }
-
-            @Override
-            public void onNext(Integer t) {
-                int total = totalReceived.incrementAndGet();
-                received.incrementAndGet();
-                boolean done = false;
-                if (total >= 2000) {
-                    done = true;
-                    dispose();
-                }
-                if (received.get() == 100) {
-                    batches.incrementAndGet();
-                    received.set(0);
-                    if (!done) {
+                    @Override
+                    public void onStart() {
                         request(100);
                     }
-                }
-                if (done) {
-                    latch.countDown();
-                }
-            }
 
-        });
+                    @Override
+                    public void onComplete() {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onError(Throwable e) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void onNext(Integer t) {
+                        int total = totalReceived.incrementAndGet();
+                        received.incrementAndGet();
+                        boolean done = false;
+                        if (total >= 2000) {
+                            done = true;
+                            dispose();
+                        }
+                        if (received.get() == 100) {
+                            batches.incrementAndGet();
+                            received.set(0);
+                            if (!done) {
+                                request(100);
+                            }
+                        }
+                        if (done) {
+                            latch.countDown();
+                        }
+                    }
+
+                });
 
         latch.await();
         System.out.println("testUserSubscriberUsingRequestAsync => Received: " + totalReceived.get() + "  Emitted: " + c.get() + " Request Batches: " + batches.get());
@@ -652,8 +652,9 @@ public class FlowableBackpressureTests extends RxJavaTest {
         });
     }
 
-    static final Function<Integer, Integer> SLOW_PASS_THRU = new Function<Integer, Integer>() /* NFI */ {
+    static final Function<Integer, Integer> SLOW_PASS_THRU = new Function<>() /* NFI */ {
         volatile int sink;
+
         @Override
         public Integer apply(Integer t1) {
             // be slow ... but faster than Thread.sleep(1)

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableCollectTest.java
@@ -117,7 +117,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissionsFlowable() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
+        var throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 
@@ -232,7 +232,7 @@ public final class FlowableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissions() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
+        var throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableConversionTest.java
@@ -144,7 +144,7 @@ public class FlowableConversionTest extends RxJavaTest {
 
     @Test
     public void conversionBetweenObservableClasses() {
-        final TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
+        var to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -196,7 +196,7 @@ public class FlowableConversionTest extends RxJavaTest {
                         }))
                     .to(onSubscribe -> {
                         final ConcurrentLinkedQueue<Integer> q = new ConcurrentLinkedQueue<>();
-                        onSubscribe.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                        onSubscribe.subscribe(new DefaultSubscriber<>() /* NFI */ {
                             @Override
                             public void onComplete() {
                                 isFinished.set(true);
@@ -210,7 +210,8 @@ public class FlowableConversionTest extends RxJavaTest {
                             @Override
                             public void onNext(Integer t) {
                                 q.add(t);
-                            }});
+                            }
+                        });
                         return q;
                     });
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableErrorHandlingTests.java
@@ -19,7 +19,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.schedulers.Schedulers;
@@ -37,7 +36,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() /* NFI */ {
+        var subscriber = new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -74,7 +73,7 @@ public class FlowableErrorHandlingTests extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
         Flowable<Long> f = Flowable.interval(50, TimeUnit.MILLISECONDS);
-        Subscriber<Long> subscriber = new DefaultSubscriber<Long>() /* NFI */ {
+        var subscriber = new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableSubscriberTest.java
@@ -84,7 +84,7 @@ public class FlowableSubscriberTest {
     @Test
     public void requestFromChainedOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<>(10L);
-        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<String>() /* NFI */ {
+        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription a) {
@@ -131,7 +131,7 @@ public class FlowableSubscriberTest {
     @Test
     public void requestFromDecoupledOperator() throws Throwable {
         TestSubscriber<String> s = new TestSubscriber<>(0L);
-        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<String>() /* NFI */ {
+        FlowableOperator<String, String> o = s1 -> new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription a) {
@@ -196,7 +196,7 @@ public class FlowableSubscriberTest {
 
             });
 
-            ResourceSubscriber<String> as = new ResourceSubscriber<String>() /* NFI */ {
+            var as = new ResourceSubscriber<String>() /* NFI */ {
 
                 @Override
                 protected void onStart() {
@@ -329,7 +329,7 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -360,7 +360,7 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.just(1, 2, 3, 4).take(2).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -391,7 +391,7 @@ public class FlowableSubscriberTest {
     @Test
     public void onStartCalledOnceViaLift() {
         final AtomicInteger c = new AtomicInteger();
-        Flowable.just(1, 2, 3, 4).lift(child -> new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.just(1, 2, 3, 4).lift(child -> new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -424,7 +424,7 @@ public class FlowableSubscriberTest {
     public void onStartRequestsAreAdditive() {
         final List<Integer> list = new ArrayList<>();
         Flowable.just(1, 2, 3, 4, 5)
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onStart() {
                 request(3);
@@ -444,14 +444,15 @@ public class FlowableSubscriberTest {
             @Override
             public void onNext(Integer t) {
                 list.add(t);
-            }});
+            }
+        });
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
 
     @Test
     public void onStartRequestsAreAdditiveAndOverflowBecomesMaxValue() {
         final List<Integer> list = new ArrayList<>();
-        Flowable.just(1, 2, 3, 4, 5).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.just(1, 2, 3, 4, 5).subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onStart() {
                 request(2);
@@ -471,7 +472,8 @@ public class FlowableSubscriberTest {
             @Override
             public void onNext(Integer t) {
                 list.add(t);
-            }});
+            }
+        });
         assertEquals(Arrays.asList(1, 2, 3, 4, 5), list);
     }
 

--- a/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
+++ b/src/test/java/io/reactivex/rxjava4/flowable/FlowableTests.java
@@ -319,7 +319,7 @@ public class FlowableTests extends RxJavaTest {
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
         .subscribeOn(Schedulers.newThread())
-        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
+        .safeSubscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onComplete() {
                 System.out.println("completed");
@@ -366,7 +366,7 @@ public class FlowableTests extends RxJavaTest {
 
         // FIXME custom built???
         Flowable.just("1", "2", "three", "4")
-        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
+        .safeSubscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -407,7 +407,7 @@ public class FlowableTests extends RxJavaTest {
         final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
         Flowable.just("1", "2").concatWith(Flowable.<String>error(NumberFormatException::new))
-        .subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -575,7 +575,7 @@ public class FlowableTests extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         Flowable.just("1", "2", "three", "4").take(3)
-        .safeSubscribe(new DefaultSubscriber<String>() /* NFI */ {
+        .safeSubscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/fuseable/CancellableQueueFuseableTest.java
@@ -67,7 +67,7 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void cancel2() {
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
+        var qs = new AbstractEmptyQueueFuseable<>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());
 
@@ -76,7 +76,7 @@ public class CancellableQueueFuseableTest {
 
     @Test
     public void dispose2() {
-        AbstractEmptyQueueFuseable<Object> qs = new AbstractEmptyQueueFuseable<Object>() /* NFI */ { };
+        var qs = new AbstractEmptyQueueFuseable<>() /* NFI */ { };
 
         assertFalse(qs.isDisposed());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
@@ -164,7 +164,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
+            var source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());
@@ -360,7 +360,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignalsToFlowable() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
+            var source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
@@ -370,7 +370,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
@@ -149,10 +149,10 @@ public class FlowableFromStreamTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Flowable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
-                queue.set((SimpleQueue<?>)s);
+                queue.set((SimpleQueue<?>) s);
             }
 
             @Override
@@ -192,11 +192,11 @@ public class FlowableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Flowable.fromStream(Stream.of(1).onClose(calls::getAndIncrement))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
-                queue.set((SimpleQueue<?>)s);
-                ((QueueSubscription<?>)s).requestFusion(QueueFuseable.ANY);
+                queue.set((SimpleQueue<?>) s);
+                ((QueueSubscription<?>) s).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -340,9 +340,10 @@ public class FlowableFromStreamTest extends RxJavaTest {
             source = source.filter(_ -> true);
         }
 
-        source.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        source.subscribe(new FlowableSubscriber<>() /* NFI */ {
 
-            @NonNull Subscription upstream;
+            @NonNull
+            Subscription upstream;
 
             @Override
             public void onSubscribe(@NonNull Subscription s) {
@@ -397,9 +398,10 @@ public class FlowableFromStreamTest extends RxJavaTest {
                 CountDownLatch cdl = new CountDownLatch(1);
 
                 source
-                .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+                .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
-                    @NonNull Subscription upstream;
+                    @NonNull
+                    Subscription upstream;
 
                     @Override
                     public void onSubscribe(@NonNull Subscription s) {
@@ -416,13 +418,15 @@ public class FlowableFromStreamTest extends RxJavaTest {
                         AtomicInteger sync = new AtomicInteger(2);
                         exec.submit(() -> {
                             if (sync.decrementAndGet() != 0) {
-                                while (sync.get() != 0) { }
+                                while (sync.get() != 0) {
+                                }
                             }
                             upstream.request(1);
                         });
 
                         if (sync.decrementAndGet() != 0) {
-                            while (sync.get() != 0) { }
+                            while (sync.get() != 0) {
+                            }
                         }
                     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableMapOptionalTest.java
@@ -83,7 +83,7 @@ public class FlowableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNexts() {
-        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
+        var source = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -297,7 +297,7 @@ public class FlowableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNextsConditional() {
-        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
+        var source = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
@@ -233,7 +233,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsFlowable(Stream::of)
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -250,7 +250,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(@NonNull Subscription s) {
-                qsr.set((QueueSubscription<Integer>)s);
+                qsr.set((QueueSubscription<Integer>) s);
             }
         });
 
@@ -281,7 +281,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         Maybe.just(1)
         .flattenStreamAsFlowable(_ -> Stream.of(1, 2, 3, 4, 5))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             Subscription upstream;
 
@@ -328,7 +328,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -356,7 +356,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -382,7 +382,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -413,7 +413,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
@@ -197,7 +197,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsObservable(Stream::of)
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -214,7 +214,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(Disposable d) {
-                qdr.set((QueueDisposable<Integer>)d);
+                qdr.set((QueueDisposable<Integer>) d);
             }
         });
 
@@ -247,7 +247,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         ms
         .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -264,7 +264,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(Disposable d) {
-                qdr.set((QueueDisposable<Integer>)d);
+                qdr.set((QueueDisposable<Integer>) d);
             }
         });
 
@@ -308,7 +308,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -336,7 +336,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -362,7 +362,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -393,7 +393,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
@@ -167,7 +167,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+            var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -363,7 +363,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
     @Test
     public void collectorAccumulatorDropSignalsToObservable() throws Throwable {
         TestHelper.withErrorTracking(errors -> {
-            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+            var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
@@ -304,7 +304,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -332,7 +332,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
@@ -122,11 +122,11 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Observable.fromStream(IntStream.rangeClosed(1, 10).boxed())
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
-                queue.set((SimpleQueue<?>)d);
-                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
+                queue.set((SimpleQueue<?>) d);
+                ((QueueDisposable<?>) d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -166,11 +166,11 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Observable.fromStream(Stream.of(1).onClose(calls::getAndIncrement))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
-                queue.set((SimpleQueue<?>)d);
-                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
+                queue.set((SimpleQueue<?>) d);
+                ((QueueDisposable<?>) d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -203,11 +203,11 @@ public class ObservableFromStreamTest extends RxJavaTest {
         AtomicInteger calls = new AtomicInteger();
 
         Observable.fromStream(Stream.of(1, 2).onClose(calls::getAndIncrement))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Disposable d) {
-                queue.set((SimpleQueue<?>)d);
-                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
+                queue.set((SimpleQueue<?>) d);
+                ((QueueDisposable<?>) d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -438,7 +438,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -464,7 +464,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int calls;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableMapOptionalTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableMapOptionalTest.java
@@ -81,7 +81,7 @@ public class ObservableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNexts() {
-        Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+        var source = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -259,7 +259,7 @@ public class ObservableMapOptionalTest extends RxJavaTest {
 
     @Test
     public void crashDropsOnNextsConditional() {
-        Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+        var source = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
@@ -220,7 +220,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsFlowable(Stream::of)
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -237,7 +237,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(@NonNull Subscription s) {
-                qsr.set((QueueSubscription<Integer>)s);
+                qsr.set((QueueSubscription<Integer>) s);
             }
         });
 
@@ -268,7 +268,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         Single.just(1)
         .flattenStreamAsFlowable(_ -> Stream.of(1, 2, 3, 4, 5))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             Subscription upstream;
 
@@ -315,7 +315,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -343,7 +343,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -369,7 +369,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -400,7 +400,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
@@ -184,7 +184,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsObservable(Stream::of)
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -201,7 +201,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(Disposable d) {
-                qdr.set((QueueDisposable<Integer>)d);
+                qdr.set((QueueDisposable<Integer>) d);
             }
         });
 
@@ -234,7 +234,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         ss
         .flattenStreamAsObservable(v -> Stream.of(v, v + 1))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -251,7 +251,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
             @Override
             @SuppressWarnings("unchecked")
             public void onSubscribe(Disposable d) {
-                qdr.set((QueueDisposable<Integer>)d);
+                qdr.set((QueueDisposable<Integer>) d);
             }
         });
 
@@ -295,7 +295,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
     public void hasNextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -323,7 +323,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
     public void nextThrowsInDrain() {
         @SuppressWarnings("unchecked")
         Stream<Integer> stream = mock(Stream.class);
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {
@@ -349,7 +349,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             int count;
 
@@ -380,7 +380,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
         TestObserver<Integer> to = new TestObserver<>();
 
-        when(stream.iterator()).thenReturn(new Iterator<Integer>() /* NFI */ {
+        when(stream.iterator()).thenReturn(new Iterator<>() /* NFI */ {
 
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BasicFuseableObserverTest.java
@@ -57,7 +57,7 @@ public class BasicFuseableObserverTest extends RxJavaTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void offer2() {
-        BasicFuseableObserver<Integer, Integer> o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<>()) {
+        var o = new BasicFuseableObserver<Integer, Integer>(new TestObserver<>()) {
             @Nullable
             @Override
             public Integer poll() throws Exception {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/BasicQueueDisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/BasicQueueDisposableTest.java
@@ -20,7 +20,7 @@ import io.reactivex.rxjava4.core.RxJavaTest;
 
 public class BasicQueueDisposableTest extends RxJavaTest {
 
-    BasicQueueDisposable<Integer> q = new BasicQueueDisposable<Integer>() /* NFI */ {
+    BasicQueueDisposable<Integer> q = new BasicQueueDisposable<>() /* NFI */ {
 
         @Override
         public boolean isDisposed() {

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/DeferredScalarObserverTest.java
@@ -315,7 +315,7 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void disposedAfterOnNext() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
+        TakeLast source = new TakeLast(new Observer<>() /* NFI */ {
             Disposable upstream;
 
             @Override
@@ -382,13 +382,13 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusion() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
+        TakeLast source = new TakeLast(new Observer<>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Disposable d) {
-                this.d = (QueueDisposable<Integer>)d;
+                this.d = (QueueDisposable<Integer>) d;
                 to.onSubscribe(d);
                 this.d.requestFusion(QueueFuseable.ANY);
             }
@@ -432,13 +432,13 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusionClear() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        TakeLast source = new TakeLast(new Observer<Integer>() /* NFI */ {
+        TakeLast source = new TakeLast(new Observer<>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Disposable d) {
-                this.d = (QueueDisposable<Integer>)d;
+                this.d = (QueueDisposable<Integer>) d;
                 to.onSubscribe(d);
                 this.d.requestFusion(QueueFuseable.ANY);
             }
@@ -480,13 +480,13 @@ public class DeferredScalarObserverTest extends RxJavaTest {
     public void customFusionDontConsume() {
         final TestObserver<Integer> to = new TestObserver<>();
 
-        TakeFirst source = new TakeFirst(new Observer<Integer>() /* NFI */ {
+        TakeFirst source = new TakeFirst(new Observer<>() /* NFI */ {
             QueueDisposable<Integer> d;
 
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Disposable d) {
-                this.d = (QueueDisposable<Integer>)d;
+                this.d = (QueueDisposable<Integer>) d;
                 to.onSubscribe(d);
                 this.d.requestFusion(QueueFuseable.ANY);
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/LambdaObserverTest.java
@@ -133,7 +133,7 @@ public class LambdaObserverTest extends RxJavaTest {
     public void badSourceOnSubscribe() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+            var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 public void subscribeActual(Observer<? super Integer> observer) {
                     Disposable d1 = Disposable.empty();
@@ -171,7 +171,7 @@ public class LambdaObserverTest extends RxJavaTest {
     public void badSourceEmitAfterDone() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Observable<Integer> source = new Observable<Integer>() /* NFI */ {
+            var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 public void subscribeActual(Observer<? super Integer> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/observers/QueueDrainObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/observers/QueueDrainObserverTest.java
@@ -24,7 +24,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class QueueDrainObserverTest extends RxJavaTest {
 
     static QueueDrainObserver<Integer, Integer, Integer> createUnordered(TestObserver<Integer> to, final Disposable d) {
-        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<>(4)) {
+        return new QueueDrainObserver<>(to, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmit(t, false, d);
@@ -51,7 +51,7 @@ public class QueueDrainObserverTest extends RxJavaTest {
     }
 
     static QueueDrainObserver<Integer, Integer, Integer> createOrdered(TestObserver<Integer> to, final Disposable d) {
-        return new QueueDrainObserver<Integer, Integer, Integer>(to, new SpscArrayQueue<>(4)) {
+        return new QueueDrainObserver<>(to, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmit(t, false, d);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableCacheTest.java
@@ -86,9 +86,9 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void crossDispose() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> to1 = new TestObserver<>();
+        var to1 = new TestObserver<>();
 
-        final TestObserver<Void> to2 = new TestObserver<Void>() /* NFI */ {
+        var to2 = new TestObserver<Void>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -111,9 +111,9 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
     public void crossDisposeOnError() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserver<Void> to1 = new TestObserver<>();
+        var to1 = new TestObserver<>();
 
-        final TestObserver<Void> to2 = new TestObserver<Void>() /* NFI */ {
+        var to2 = new TestObserver<Void>() /* NFI */ {
             @Override
             public void onError(Throwable ex) {
                 super.onError(ex);
@@ -140,7 +140,7 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
 
         assertFalse(ps.hasObservers());
 
-        TestObserver<Void> to1 = c.test();
+        var to1 = c.test();
 
         assertTrue(ps.hasObservers());
 
@@ -148,12 +148,12 @@ public class CompletableCacheTest extends RxJavaTest implements Consumer<Object>
 
         assertTrue(ps.hasObservers());
 
-        TestObserver<Void> to2 = c.test();
+        var to2 = c.test();
 
-        TestObserver<Void> to3 = c.test();
+        var to3 = c.test();
         to3.dispose();
 
-        TestObserver<Void> to4 = c.test(true);
+        var to4 = c.test(true);
         to3.dispose();
 
         ps.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeIterableTest.java
@@ -62,7 +62,7 @@ public class CompletableMergeIterableTest extends RxJavaTest {
     public void cancelAfterHasNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 to.dispose();
@@ -87,7 +87,7 @@ public class CompletableMergeIterableTest extends RxJavaTest {
     public void cancelAfterNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
+        Completable.merge((Iterable<Completable>) () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableMergeTest.java
@@ -458,23 +458,23 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterHasNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
-            @Override
-            public boolean hasNext() {
-                to.dispose();
-                return true;
-            }
+        Completable.merge((Iterable<Completable>) () -> new Iterator<>() /* NFI */ {
+                    @Override
+                    public boolean hasNext() {
+                        to.dispose();
+                        return true;
+                    }
 
-            @Override
-            public Completable next() {
-                return Completable.complete();
-            }
+                    @Override
+                    public Completable next() {
+                        return Completable.complete();
+                    }
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        }, CompletableMergeConfig.DELAY_ERRORS)
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                }, CompletableMergeConfig.DELAY_ERRORS)
         .subscribe(to);
 
         to.assertEmpty();
@@ -484,23 +484,23 @@ public class CompletableMergeTest extends RxJavaTest {
     public void delayErrorIterableCancelAfterNext() {
         final TestObserver<Void> to = new TestObserver<>();
 
-        Completable.merge((Iterable<Completable>) () -> new Iterator<Completable>() /* NFI */ {
-            @Override
-            public boolean hasNext() {
-                return true;
-            }
+        Completable.merge((Iterable<Completable>) () -> new Iterator<>() /* NFI */ {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
 
-            @Override
-            public Completable next() {
-                to.dispose();
-                return Completable.complete();
-            }
+                    @Override
+                    public Completable next() {
+                        to.dispose();
+                        return Completable.complete();
+                    }
 
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException();
-            }
-        }, CompletableMergeConfig.DELAY_ERRORS)
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                }, CompletableMergeConfig.DELAY_ERRORS)
         .subscribe(to);
 
         to.assertEmpty();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableAmbTest.java
@@ -578,7 +578,7 @@ public class FlowableAmbTest extends RxJavaTest {
     @Test
     public void requestAfterCancel() {
         Flowable.amb(Arrays.asList(Flowable.never(), Flowable.never()))
-        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Object t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableBufferTest.java
@@ -819,7 +819,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
             }
 
-        })).buffer(3, 2).subscribe(new DefaultSubscriber<List<Integer>>() /* NFI */ {
+        })).buffer(3, 2).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -849,7 +849,7 @@ public class FlowableBufferTest extends RxJavaTest {
         final Subscriber<Object> subscriber = TestHelper.mockSubscriber();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        ResourceSubscriber<Object> s = new ResourceSubscriber<Object>() /* NFI */ {
+        var s = new ResourceSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 subscriber.onNext(t);
@@ -1686,7 +1686,7 @@ public class FlowableBufferTest extends RxJavaTest {
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Flowable<Object>() /* NFI */ {
+            new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
                     BooleanSubscription bs1 = new BooleanSubscription();
@@ -1843,11 +1843,11 @@ public class FlowableBufferTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.never()
-            .buffer(new Flowable<Object>() /* NFI */ {
+            .buffer(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> s) {
 
-                    assertFalse(((Disposable)s).isDisposed());
+                    assertFalse(((Disposable) s).isDisposed());
 
                     BooleanSubscription bs1 = new BooleanSubscription();
                     BooleanSubscription bs2 = new BooleanSubscription();
@@ -1864,7 +1864,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
                     s.onError(new IOException());
 
-                    assertTrue(((Disposable)s).isDisposed());
+                    assertTrue(((Disposable) s).isDisposed());
 
                     s.onComplete();
                     s.onNext(1);
@@ -1956,7 +1956,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryBadSource() {
-        Flowable<Integer> pp = new Flowable<Integer>() /* NFI */ {
+        var pp = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -1967,7 +1967,7 @@ public class FlowableBufferTest extends RxJavaTest {
         };
 
         final AtomicReference<Subscriber<? super Integer>> ref = new AtomicReference<>();
-        Flowable<Integer> b = new Flowable<Integer>() /* NFI */ {
+        var b = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -1996,7 +1996,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryDisposed() {
-        Flowable<Integer> pp = new Flowable<Integer>() /* NFI */ {
+        var pp = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Integer> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -2040,7 +2040,7 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         BufferExactUnboundedSubscriber<Integer, List<Integer>> sub = new BufferExactUnboundedSubscriber<>(
-                ts, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                ts, Functions.justSupplier(new ArrayList<>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2078,7 +2078,7 @@ public class FlowableBufferTest extends RxJavaTest {
         TestSubscriber<List<Integer>> ts = new TestSubscriber<>();
 
         BufferSkipBoundedSubscriber<Integer, List<Integer>> sub = new BufferSkipBoundedSubscriber<>(
-                ts, Functions.justSupplier(new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                ts, Functions.justSupplier(new ArrayList<>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(new BooleanSubscription());
 
@@ -2124,7 +2124,7 @@ public class FlowableBufferTest extends RxJavaTest {
 
         BufferExactBoundedSubscriber<Integer, List<Integer>> sub =
                 new BufferExactBoundedSubscriber<>(
-                        ts, Functions.justSupplier(new ArrayList<Integer>()),
+                        ts, Functions.justSupplier(new ArrayList<>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -450,7 +450,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Subscriber<List<Object>> s = new DefaultSubscriber<List<Object>>() /* NFI */ {
+            var s = new DefaultSubscriber<List<Object>>() /* NFI */ {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -721,7 +721,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         Flowable<Integer> f = Flowable.combineLatest(sources, args -> (Integer) args[0]);
         //should get at least 4
         final CountDownLatch latch = new CountDownLatch(4);
-        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -742,7 +742,8 @@ public class FlowableCombineLatestTest extends RxJavaTest {
             public void onNext(Integer t) {
                 latch.countDown();
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
@@ -1197,7 +1198,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1257,7 +1258,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void FlowableSourcesInIterable() {
-        Flowable<Integer> source = new Flowable<Integer>() /* NFI */ {
+        var source = new Flowable<Integer>() /* NFI */ {
             @Override
             public void subscribeActual(Subscriber<? super Integer> s) {
                 Flowable.just(1).subscribe(s);
@@ -1292,7 +1293,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
                 TestSubscriberEx<Object[]> ts = new TestSubscriberEx<>();
                 AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
-                Flowable<Object> f = new Flowable<Object>() /* NFI */ {
+                var f = new Flowable<>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Object> s) {
                         ref.set(s);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapEagerTest.java
@@ -721,7 +721,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         final UnicastProcessor<Integer> up = UnicastProcessor.create();
         up.onNext(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -832,7 +832,7 @@ public class FlowableConcatMapEagerTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .concatMapEager((Function<Integer, Publisher<Integer>>) _ -> new Flowable<Integer>() /* NFI */ {
+            .concatMapEager((Function<Integer, Publisher<Integer>>) _ -> new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -289,7 +289,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Flowable.range(1, n).concatMap(func, 2, ImmediateThinScheduler.INSTANCE)
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -534,7 +534,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void immediateInnerNextOuterError() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -558,7 +558,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
     public void immediateInnerNextOuterError2() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatTest.java
@@ -708,7 +708,7 @@ public class FlowableConcatTest {
         int n = 5000;
         final AtomicInteger counter = new AtomicInteger();
 
-        Flowable.range(1, n).concatMap(func).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(1, n).concatMap(func).subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -748,7 +748,7 @@ public class FlowableConcatTest {
         Flowable<Integer> f1 = Flowable.just(1, 2, 3);
         Flowable<Integer> f2 = Flowable.just(4, 5, 6);
         final AtomicBoolean completed = new AtomicBoolean(false);
-        f1.concatWith(f2).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        f1.concatWith(f2).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -763,7 +763,8 @@ public class FlowableConcatTest {
             @Override
             public void onNext(Integer t) {
                 request(2);
-            }});
+            }
+        });
 
         assertTrue(completed.get());
     }
@@ -1229,7 +1230,7 @@ public class FlowableConcatTest {
     public void immediateInnerNextOuterError() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1253,7 +1254,7 @@ public class FlowableConcatTest {
     public void immediateInnerNextOuterError2() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCreateTest.java
@@ -657,7 +657,7 @@ public class FlowableCreateTest extends RxJavaTest {
                 }
                 assertTrue(d.isDisposed());
             }, m)
-            .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+            .subscribe(new FlowableSubscriber<>() /* NFI */ {
                 @Override
                 public void onSubscribe(Subscription s) {
                 }
@@ -692,7 +692,7 @@ public class FlowableCreateTest extends RxJavaTest {
                 }
                 assertTrue(d.isDisposed());
             }, m)
-            .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+            .subscribe(new FlowableSubscriber<>() /* NFI */ {
                 @Override
                 public void onSubscribe(Subscription s) {
                 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDebounceTest.java
@@ -459,7 +459,7 @@ public class FlowableDebounceTest extends RxJavaTest {
             if (o != 1) {
                 return Flowable.never();
             }
-            return new Flowable<Integer>() /* NFI */ {
+            return new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDelayTest.java
@@ -827,7 +827,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable.empty()
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableSubscriber<Object>() /* NFI */ {
+        .subscribe(new DisposableSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }
@@ -856,7 +856,7 @@ public class FlowableDelayTest extends RxJavaTest {
 
         Flowable.error(new TestException())
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableSubscriber<Object>() /* NFI */ {
+        .subscribe(new DisposableSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDematerializeTest.java
@@ -228,7 +228,7 @@ public class FlowableDematerializeTest extends RxJavaTest {
     @Test
     @SuppressWarnings("unchecked")
     public void nonNotificationInstanceAfterDispose() {
-        new Flowable<Object>() /* NFI */ {
+        new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDistinctTest.java
@@ -142,10 +142,10 @@ public class FlowableDistinctTest extends RxJavaTest {
     public void fusedClear() {
         Flowable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
-                QueueSubscription<?> qs = (QueueSubscription<?>)s;
+                QueueSubscription<?> qs = (QueueSubscription<?>) s;
 
                 assertFalse(qs.isEmpty());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoAfterNextTest.java
@@ -34,7 +34,7 @@ public class FlowableDoAfterNextTest extends RxJavaTest {
 
     final Consumer<Integer> afterNext = e -> values.add(-e);
 
-    final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+    final TestSubscriber<Integer> ts = new TestSubscriber<>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoFinallyTest.java
@@ -329,12 +329,12 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
     public void clearIsEmpty() {
         Flowable.range(1, 5)
         .doFinally(this)
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 qs.requestFusion(QueueFuseable.ANY);
 
@@ -376,12 +376,12 @@ public class FlowableDoFinallyTest extends RxJavaTest implements Action {
         Flowable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 qs.requestFusion(QueueFuseable.ANY);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnRequestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableDoOnRequestTest.java
@@ -47,7 +47,7 @@ public class FlowableDoOnRequestTest extends RxJavaTest {
         //
                 .doOnRequest(requests::add)
                 //
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFilterTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFilterTest.java
@@ -65,7 +65,7 @@ public class FlowableFilterTest extends RxJavaTest {
         Flowable<String> f = w.filter(t1 -> t1.equals("three"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        TestSubscriber<String> ts = new TestSubscriber<String>() /* NFI */ {
+        var ts = new TestSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -106,7 +106,7 @@ public class FlowableFilterTest extends RxJavaTest {
         Flowable<Integer> f = w.filter(t1 -> t1 > 100);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapCompletableTest.java
@@ -299,10 +299,10 @@ public class FlowableFlatMapCompletableTest extends RxJavaTest {
         Flowable.range(1, 10)
         .flatMapCompletable(_ -> Completable.complete())
         .toFlowable()
-        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
-                QueueSubscription<?> qs = (QueueSubscription<?>)s;
+                QueueSubscription<?> qs = (QueueSubscription<?>) s;
                 try {
                     assertNull(qs.poll());
                 } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -348,7 +348,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -375,7 +375,7 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
         final PublishProcessor<Integer> pp3 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -402,7 +402,8 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     public void disposeInner() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() /* NFI */ {
+        Flowable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ ->
+                        new Maybe<>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -291,7 +291,7 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
         final PublishProcessor<Integer> pp1 = PublishProcessor.create();
         final PublishProcessor<Integer> pp2 = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -316,7 +316,8 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     public void disposeInner() {
         final TestSubscriber<Object> ts = new TestSubscriber<>();
 
-        Flowable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() /* NFI */ {
+        Flowable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ ->
+                        new Single<>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -607,7 +607,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void scalarReentrant() {
         final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -630,7 +630,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
     public void scalarReentrant2() {
         final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -791,7 +791,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
         Flowable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
         .flatMap((Function<Integer, Publisher<Integer>>) _ ->
-        Flowable.<Integer>fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        Flowable.<Integer>fromIterable(() -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlattenIterableTest.java
@@ -190,7 +190,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsImmediately() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 throw new TestException();
@@ -220,7 +220,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsImmediatelyJust() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 throw new TestException();
@@ -250,8 +250,9 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorHasNextThrowsSecondCall() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             int count;
+
             @Override
             public boolean hasNext() {
                 if (++count >= 2) {
@@ -284,7 +285,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorNextThrows() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -314,7 +315,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void iteratorNextThrowsAndUnsubscribes() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -391,7 +392,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
 
         final AtomicInteger counter = new AtomicInteger();
 
-        final Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        final Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 counter.getAndIncrement();
@@ -487,11 +488,11 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
     public void fusionMethods() {
         Flowable.just(1, 2)
         .flatMapIterable(Functions.justFunction(Arrays.asList(1, 2, 3)))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 assertEquals(QueueFuseable.SYNC, qs.requestFusion(QueueFuseable.ANY));
 
@@ -601,11 +602,11 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
             }
             return List.of(v);
         })
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 assertEquals(QueueFuseable.SYNC, qs.requestFusion(QueueFuseable.ANY));
 
@@ -688,11 +689,12 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>();
 
         Flowable.range(1, 3).hide()
-        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> new Iterable<Integer>() /* NFI */ {
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> new Iterable<>() /* NFI */ {
             int count;
+
             @Override
             public Iterator<Integer> iterator() {
-                return new Iterator<Integer>() /* NFI */ {
+                return new Iterator<>() /* NFI */ {
 
                     @Override
                     public boolean hasNext() {
@@ -776,7 +778,7 @@ public class FlowableFlattenIterableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         Flowable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
-        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> () -> new Iterator<Integer>() /* NFI */ {
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromIterableTest.java
@@ -61,7 +61,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
      */
     @Test
     public void rawIterable() {
-        Iterable<String> it = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> it = () -> new Iterator<>() /* NFI */ {
 
             int i;
 
@@ -170,7 +170,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(expectedCount);
 
         f.subscribeOn(Schedulers.computation())
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -191,7 +191,8 @@ public class FlowableFromIterableTest extends RxJavaTest {
             public void onNext(Integer t) {
                 latch.countDown();
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
@@ -200,7 +201,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
         final AtomicBoolean completed = new AtomicBoolean(false);
 
-        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultSubscriber<Object>() /* NFI */ {
+        Flowable.fromIterable(Collections.emptyList()).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -220,14 +221,15 @@ public class FlowableFromIterableTest extends RxJavaTest {
             @Override
             public void onNext(Object t) {
 
-            }});
+            }
+        });
         assertTrue(completed.get());
     }
 
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredWithBackpressure() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> iterable = () -> new Iterator<>() /* NFI */ {
 
             int count = 1;
 
@@ -258,7 +260,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredFastPath() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> iterable = () -> new Iterator<>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -282,7 +284,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
             }
 
         };
-        Flowable.fromIterable(iterable).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.fromIterable(iterable).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -320,7 +322,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsImmediately() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 throw new TestException("Forced failure");
@@ -348,8 +350,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsSecondTimeFastpath() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             int count;
+
             @Override
             public boolean hasNext() {
                 if (++count >= 2) {
@@ -380,8 +383,9 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void hasNextThrowsSecondTimeSlowpath() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             int count;
+
             @Override
             public boolean hasNext() {
                 if (++count >= 2) {
@@ -412,7 +416,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrowsFastpath() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -440,7 +444,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void nextThrowsSlowpath() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -468,7 +472,7 @@ public class FlowableFromIterableTest extends RxJavaTest {
 
     @Test
     public void deadOnArrival() {
-        Iterable<Integer> it = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> it = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;
@@ -511,12 +515,12 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void fusedAPICalls() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 assertFalse(qs.isEmpty());
 
@@ -772,11 +776,11 @@ public class FlowableFromIterableTest extends RxJavaTest {
     @Test
     public void fusionClear() {
         Flowable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 qs.requestFusion(QueueFuseable.ANY);
 
@@ -993,11 +997,11 @@ public class FlowableFromIterableTest extends RxJavaTest {
         AtomicReference<SimpleQueue<?>> queue = new AtomicReference<>();
 
         Flowable.fromIterable(List.of(1))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(@NonNull Subscription s) {
-                queue.set((SimpleQueue<?>)s);
-                ((QueueSubscription<?>)s).requestFusion(QueueFuseable.ANY);
+                queue.set((SimpleQueue<?>) s);
+                ((QueueSubscription<?>) s).requestFusion(QueueFuseable.ANY);
             }
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFromSourceTest.java
@@ -489,7 +489,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInline() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -536,7 +536,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void requestInline() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -556,7 +556,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInlineLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -575,7 +575,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void unsubscribeInlineExactLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
+        TestSubscriber<Integer> ts1 = new TestSubscriber<>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -636,7 +636,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
     @Test
     public void requestInlineLatest() {
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts1 = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -673,7 +673,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
 
             this.current = t;
 
-            final ResourceSubscriber<Integer> as = new ResourceSubscriber<Integer>() /* NFI */ {
+            var as = new ResourceSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -729,7 +729,7 @@ public class FlowableFromSourceTest extends RxJavaTest {
         @Override
         public void subscribe(final FlowableEmitter<Integer> t) {
 
-            processor.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+            processor.subscribe(new FlowableSubscriber<>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupByTest.java
@@ -116,7 +116,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         grouped.flatMap((Function<GroupedFlowable<Integer, String>, Flowable<String>>) f -> {
             groupCounter.incrementAndGet();
             return f.map(v -> "Event => key: " + f.getKey() + " value: " + v);
-        }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        }).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -193,25 +193,25 @@ public class FlowableGroupByTest extends RxJavaTest {
 
             return eventGroupedFlowable.map(event -> "Source: " + event.source + "  Message: " + event.message);
 
-        }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        }).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
-            @Override
-            public void onComplete() {
-                latch.countDown();
-            }
+                    @Override
+                    public void onComplete() {
+                        latch.countDown();
+                    }
 
-            @Override
-            public void onError(Throwable e) {
-                e.printStackTrace();
-                latch.countDown();
-            }
+                    @Override
+                    public void onError(Throwable e) {
+                        e.printStackTrace();
+                        latch.countDown();
+                    }
 
-            @Override
-            public void onNext(String outputMessage) {
-                System.out.println(outputMessage);
-                eventCounter.incrementAndGet();
-            }
-        });
+                    @Override
+                    public void onNext(String outputMessage) {
+                        System.out.println(outputMessage);
+                        eventCounter.incrementAndGet();
+                    }
+                });
 
         latch.await(5000, TimeUnit.MILLISECONDS);
         assertEquals(1, subscribeCounter.get());
@@ -259,7 +259,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                             .take(20) // limit to only 20 events on this group
                             .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
 
-                }).subscribe(new DefaultSubscriber<String>() /* NFI */ {
+                }).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -357,7 +357,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                         return group;
                     }
                 })
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -391,7 +391,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         Flowable.range(0, 100)
                 .groupBy(i -> i % 2)
-                .subscribe(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -915,7 +915,7 @@ public class FlowableGroupByTest extends RxJavaTest {
         final TestSubscriberEx<Integer> inner2 = new TestSubscriberEx<>();
 
         final TestSubscriberEx<GroupedFlowable<Integer, Integer>> outer
-                = new TestSubscriberEx<>(new DefaultSubscriber<GroupedFlowable<Integer, Integer>>() /* NFI */ {
+                = new TestSubscriberEx<>(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -956,7 +956,7 @@ public class FlowableGroupByTest extends RxJavaTest {
                 .groupBy(_ -> 1)
                 // flatten
                 .concatMap((Function<GroupedFlowable<Integer, Integer>, Flowable<Integer>>) g -> g)
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -979,7 +979,8 @@ public class FlowableGroupByTest extends RxJavaTest {
                         System.out.println(t);
                         //provoke possible request overflow
                         request(Long.MAX_VALUE - 1);
-                    }});
+                    }
+                });
         assertTrue(completed.get());
     }
 
@@ -1139,7 +1140,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void reentrantComplete() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        TestSubscriber<Integer> ts = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1161,7 +1162,7 @@ public class FlowableGroupByTest extends RxJavaTest {
     public void reentrantCompleteCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableGroupJoinTest.java
@@ -142,11 +142,11 @@ public class FlowableGroupJoinTest extends RxJavaTest {
                 PPF::new);
 
         q.subscribe(
-                new FlowableSubscriber<PPF>() /* NFI */ {
+                new FlowableSubscriber<>() /* NFI */ {
                     @Override
                     public void onNext(final PPF ppf) {
                         ppf.fruits.filter(t1 -> ppf.person.id == t1.personId)
-                        .subscribe(t1 -> subscriber.onNext(Arrays.asList(ppf.person.name, t1.fruit)));
+                                .subscribe(t1 -> subscriber.onNext(Arrays.asList(ppf.person.name, t1.fruit)));
                     }
 
                     @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIgnoreElementsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableIgnoreElementsTest.java
@@ -101,7 +101,7 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
                 //
                 .doOnNext(_ -> upstreamCount.incrementAndGet())
                 //
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -231,12 +231,12 @@ public class FlowableIgnoreElementsTest extends RxJavaTest {
     @Test
     public void fusedAPICalls() {
         Flowable.just(1).hide().ignoreElements().<Integer>toFlowable()
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
                 @SuppressWarnings("unchecked")
-                QueueSubscription<Integer> qs = (QueueSubscription<Integer>)s;
+                QueueSubscription<Integer> qs = (QueueSubscription<Integer>) s;
 
                 try {
                     assertNull(qs.poll());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeDelayErrorTest.java
@@ -292,7 +292,7 @@ public class FlowableMergeDelayErrorTest extends RxJavaTest {
         final Flowable<Flowable<String>> f1 = Flowable.error(new RuntimeException("unit test"));
 
         final CountDownLatch latch = new CountDownLatch(1);
-        Flowable.mergeDelayError(f1).subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        Flowable.mergeDelayError(f1).subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onComplete() {
                 fail("Expected onError path");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeMaxConcurrentTest.java
@@ -256,7 +256,7 @@ public class FlowableMergeMaxConcurrentTest extends RxJavaTest {
 
         final CountDownLatch cdl = new CountDownLatch(5);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(0L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeTest.java
@@ -220,7 +220,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicReference<Throwable> error = new AtomicReference<>();
 
         Flowable<String> m = Flowable.merge(Flowable.unsafeCreate(f1), Flowable.unsafeCreate(f2));
-        m.subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        m.subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -474,7 +474,7 @@ public class FlowableMergeTest extends RxJavaTest {
     private Flowable<Long> createFlowableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
         return Flowable.unsafeCreate(child -> Flowable.interval(1, TimeUnit.SECONDS, scheduler)
         .take(5)
-        .subscribe(new FlowableSubscriber<Long>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(final Subscription s) {
                 child.onSubscribe(new Subscription() /* NFI */ {
@@ -618,7 +618,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Flowable<Integer> f2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 System.err.println("testSubscriber received => " + t + "  on thread " + Thread.currentThread());
@@ -655,7 +655,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Flowable<Integer> f1 = createInfiniteFlowable(generated1).subscribeOn(Schedulers.computation());
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -692,7 +692,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Flowable<Integer> f2 = createInfiniteFlowable(generated2).subscribeOn(Schedulers.computation());
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t < 100) {
@@ -728,7 +728,7 @@ public class FlowableMergeTest extends RxJavaTest {
         Flowable<Flowable<Integer>> f1 = createInfiniteFlowable(generated1)
         .map(Flowable::just);
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t < 100) {
@@ -774,7 +774,7 @@ public class FlowableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Flowable<Flowable<Integer>> f1 = createInfiniteFlowable(generated1).map(_ -> Flowable.just(1, 2, 3));
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<Integer>() /* NFI */ {
             int i;
 
             @Override
@@ -919,7 +919,7 @@ public class FlowableMergeTest extends RxJavaTest {
     }
 
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -1100,7 +1100,7 @@ public class FlowableMergeTest extends RxJavaTest {
                 .mergeWith(Flowable.fromIterable(Arrays.asList(3, 4)));
         final int expectedCount = 4;
         final CountDownLatch latch = new CountDownLatch(expectedCount);
-        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        f.subscribeOn(Schedulers.computation()).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -1122,12 +1122,13 @@ public class FlowableMergeTest extends RxJavaTest {
                 latch.countDown();
                 request(2);
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
 
     private static Consumer<Integer> printCount() {
-        return new Consumer<Integer>() /* NFI */ {
+        return new Consumer<>() /* NFI */ {
             long count;
 
             @Override
@@ -1182,7 +1183,7 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(req) /* NFI */ {
+            var ts = new TestSubscriberEx<Integer>(req) /* NFI */ {
                 int remaining = req;
 
                 @Override
@@ -1201,7 +1202,7 @@ public class FlowableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(req) /* NFI */ {
+            var ts = new TestSubscriberEx<Integer>(req) /* NFI */ {
                 int remaining = req;
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableObserveOnTest.java
@@ -265,7 +265,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final AtomicLong completeTime = new AtomicLong();
         // use subscribeOn to make async, observeOn to move
         Flowable.range(1, 2).subscribeOn(Schedulers.newThread()).observeOn(Schedulers.newThread())
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -355,7 +355,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
     @Test
     public void backpressureWithTakeAfter() {
         final AtomicInteger generated = new AtomicInteger();
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -372,7 +372,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 System.err.println("c t = " + t + " thread " + Thread.currentThread());
@@ -400,7 +400,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
     public void backpressureWithTakeAfterAndMultipleBatches() {
         int numForBatches = Flowable.bufferSize() * 3 + 1; // should be 4 batches == ((3*n)+1) items
         final AtomicInteger generated = new AtomicInteger();
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -417,7 +417,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             }
         });
 
-        TestSubscriber<Integer> testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 //                System.err.println("c t = " + t + " thread " + Thread.currentThread());
@@ -439,7 +439,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
     @Test
     public void backpressureWithTakeBefore() {
         final AtomicInteger generated = new AtomicInteger();
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -479,7 +479,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             subscriber.onComplete();
         });
 
-        TestSubscriberEx<Integer> testSubscriber = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
+        var testSubscriber = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -534,7 +534,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
             final PublishProcessor<Long> processor = PublishProcessor.create();
 
             final AtomicLong counter = new AtomicLong();
-            TestSubscriberEx<Long> ts = new TestSubscriberEx<>(new DefaultSubscriber<Long>() /* NFI */ {
+            TestSubscriberEx<Long> ts = new TestSubscriberEx<>(new DefaultSubscriber<>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -630,7 +630,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100).observeOn(Schedulers.computation())
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     boolean first = true;
 
@@ -672,7 +672,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
         Flowable.range(1, 1000000)
                 .doOnRequest(requests::add)
                 .observeOn(Schedulers.cached())
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -1165,13 +1165,14 @@ public class FlowableObserveOnTest extends RxJavaTest {
         final CountDownLatch cdl = new CountDownLatch(1);
 
         up.observeOn(Schedulers.single())
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             Subscription upstream;
             int count;
+
             @Override
             public void onSubscribe(Subscription s) {
                 this.upstream = s;
-                ((QueueSubscription<?>)s).requestFusion(QueueFuseable.ANY);
+                ((QueueSubscription<?>) s).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -1211,7 +1212,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
                 oo.sourceMode = QueueFuseable.SYNC;
                 oo.requested.lazySet(1);
-                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
+                oo.queue = new SimpleQueue<>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {
@@ -1262,7 +1263,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
                 oo.sourceMode = QueueFuseable.SYNC;
                 oo.requested.lazySet(1);
-                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
+                oo.queue = new SimpleQueue<>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {
@@ -1314,7 +1315,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
                 oo.sourceMode = QueueFuseable.ASYNC;
                 oo.requested.lazySet(1);
-                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
+                oo.queue = new SimpleQueue<>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {
@@ -1365,7 +1366,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
                 oo.sourceMode = QueueFuseable.ASYNC;
                 oo.requested.lazySet(1);
-                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
+                oo.queue = new SimpleQueue<>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {
@@ -1429,7 +1430,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void syncFusedCancelAfterRequest() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1464,7 +1465,7 @@ public class FlowableObserveOnTest extends RxJavaTest {
 
     @Test
     public void syncFusedCancelAfterRequestConditional() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferStrategyTest.java
@@ -55,7 +55,7 @@ public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
     }
 
     private TestSubscriber<Long> createTestSubscriber() {
-        return new TestSubscriber<>(new DefaultSubscriber<Long>() /* NFI */ {
+        return new TestSubscriber<>(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             protected void onStart() {
@@ -283,7 +283,7 @@ public class FlowableOnBackpressureBufferStrategyTest extends RxJavaTest {
         Consumer<Integer> onDropped = _ -> { throw new TestException(); };
 
         TestSubscriberEx<Integer> ts = pp.onBackpressureBuffer(1, null, BackpressureOverflowStrategy.DROP_OLDEST, onDropped)
-        .subscribeWith(new TestSubscriberEx<Integer>(0L));
+        .subscribeWith(new TestSubscriberEx<>(0L));
 
         ts.assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureBufferTest.java
@@ -54,7 +54,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() /* NFI */ {
+        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             protected void onStart() {
@@ -111,7 +111,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
     public void fixBackpressureBoundedBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch backpressureCallback = new CountDownLatch(1);
-        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() /* NFI */ {
+        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             protected void onStart() {
@@ -364,7 +364,7 @@ public class FlowableOnBackpressureBufferTest extends RxJavaTest {
         Consumer<Integer> onDropped = _ -> { throw new TestException(); };
 
         TestSubscriberEx<Integer> ts = pp.onBackpressureBuffer(1, false, false, () -> { }, onDropped)
-        .subscribeWith(new TestSubscriberEx<Integer>(0L));
+        .subscribeWith(new TestSubscriberEx<>(0L));
 
         ts.assertEmpty();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureDropTest.java
@@ -51,7 +51,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
     public void fixBackpressureWithBuffer() throws InterruptedException {
         final CountDownLatch l1 = new CountDownLatch(100);
         final CountDownLatch l2 = new CountDownLatch(150);
-        TestSubscriber<Long> ts = new TestSubscriber<>(new DefaultSubscriber<Long>() /* NFI */ {
+        var ts = new TestSubscriber<>(new DefaultSubscriber<Long>() /* NFI */ {
 
             @Override
             protected void onStart() {
@@ -93,7 +93,7 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
     public void requestOverflow() throws InterruptedException {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        range(n).onBackpressureDrop().subscribe(new DefaultSubscriber<Long>() /* NFI */ {
+        range(n).onBackpressureDrop().subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -114,7 +114,8 @@ public class FlowableOnBackpressureDropTest extends RxJavaTest {
                 count.incrementAndGet();
                 //cause overflow of requested if not handled properly in onBackpressureDrop operator
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertEquals(n, count.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureLatestTest.java
@@ -169,7 +169,7 @@ public class FlowableOnBackpressureLatestTest extends RxJavaTest {
 
     @Test
     public void asynchronousDrop() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>(1L) /* NFI */ {
             final Random rnd = new Random();
             @Override
             public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceTest.java
@@ -135,7 +135,7 @@ public class FlowableOnBackpressureReduceTest extends RxJavaTest {
     }
 
     private <T> TestSubscriberEx<T> createDelayedSubscriber() {
-        return new TestSubscriberEx<T>(1L) /* NFI */ {
+        return new TestSubscriberEx<>(1L) /* NFI */ {
             final Random rnd = new Random();
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnBackpressureReduceWithTest.java
@@ -175,7 +175,7 @@ public class FlowableOnBackpressureReduceWithTest extends RxJavaTest {
     }
 
     private <T> TestSubscriberEx<T> createDelayedSubscriber() {
-        return new TestSubscriberEx<T>(1L) /* NFI */ {
+        return new TestSubscriberEx<>(1L) /* NFI */ {
             final Random rnd = new Random();
 
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishFunctionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishFunctionTest.java
@@ -124,7 +124,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
 
         final AtomicInteger startCount = new AtomicInteger();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onStart() {
                 startCount.incrementAndGet();
@@ -312,7 +312,7 @@ public class FlowablePublishFunctionTest extends RxJavaTest {
     public void completeCancelRaceNoRequest() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowablePublishTest.java
@@ -148,7 +148,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts2 = new TestSubscriber<>();
 
-        final TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (values().size() == 2) {
@@ -512,7 +512,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         ConnectableFlowable<Integer> cf = pp.publish();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -710,7 +710,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
     @Test
     public void dryRunCrash() {
-        final TestSubscriber<Object> ts = new TestSubscriber<Object>(1L) /* NFI */ {
+        var ts = new TestSubscriber<>(1L) /* NFI */ {
             @Override
             public void onNext(Object t) {
                 super.onNext(t);
@@ -829,7 +829,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         cf.connect();
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -857,7 +857,7 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts2 = new TestSubscriber<>(0);
 
-        TestSubscriber<Integer> ts1 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts1 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -991,7 +991,7 @@ public class FlowablePublishTest extends RxJavaTest {
             return Flowable.<Integer>never();
         }).test();
 
-        ref.get().subscribe(new TestSubscriber<Integer>() /* NFI */ {
+        ref.get().subscribe(new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1014,7 +1014,7 @@ public class FlowablePublishTest extends RxJavaTest {
             return Flowable.<Integer>never();
         }).test();
 
-        ref.get().subscribe(new TestSubscriber<Integer>(1L) /* NFI */ {
+        ref.get().subscribe(new TestSubscriber<>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1062,13 +1062,13 @@ public class FlowablePublishTest extends RxJavaTest {
 
         final AtomicReference<InnerSubscription<Integer>> ref = new AtomicReference<>();
 
-        cf.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        cf.subscribe(new FlowableSubscriber<>() /* NFI */ {
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Subscription s) {
                 ts1.onSubscribe(new BooleanSubscription());
                 // pretend to be cancelled without removing it from the subscriber list
-                ref.set((InnerSubscription<Integer>)s);
+                ref.set((InnerSubscription<Integer>) s);
             }
 
             @Override
@@ -1417,7 +1417,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void crossCancelOnComplete() {
         TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -1444,7 +1444,7 @@ public class FlowablePublishTest extends RxJavaTest {
     @Test
     public void crossCancelOnError() {
         TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeLongTest.java
@@ -197,7 +197,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
     public void requestOverflow() {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        Flowable.rangeLong(1, n).subscribe(new DefaultSubscriber<Long>() /* NFI */ {
+        Flowable.rangeLong(1, n).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -218,14 +218,15 @@ public class FlowableRangeLongTest extends RxJavaTest {
             public void onNext(Long t) {
                 count.incrementAndGet();
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertEquals(n, count.get());
     }
 
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Flowable.rangeLong(1, 0).subscribe(new DefaultSubscriber<Long>() /* NFI */ {
+        Flowable.rangeLong(1, 0).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -245,7 +246,8 @@ public class FlowableRangeLongTest extends RxJavaTest {
             @Override
             public void onNext(Long t) {
 
-            }});
+            }
+        });
         assertTrue(completed.get());
     }
 
@@ -383,7 +385,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void slowPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Long>(2L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -400,7 +402,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fastPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
+        var ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -417,7 +419,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalSlowPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -435,7 +437,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancel() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
+        var ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -453,7 +455,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -470,7 +472,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne2() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Long>(1L) /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -487,7 +489,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void fastPathCancelExact() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
+        var ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);
@@ -506,7 +508,7 @@ public class FlowableRangeLongTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancelExact() {
-        TestSubscriber<Long> ts = new TestSubscriber<Long>() /* NFI */ {
+        var ts = new TestSubscriber<Long>() /* NFI */ {
             @Override
             public void onNext(Long t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRangeTest.java
@@ -197,7 +197,7 @@ public class FlowableRangeTest extends RxJavaTest {
     public void requestOverflow() {
         final AtomicInteger count = new AtomicInteger();
         int n = 10;
-        Flowable.range(1, n).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(1, n).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -218,14 +218,15 @@ public class FlowableRangeTest extends RxJavaTest {
             public void onNext(Integer t) {
                 count.incrementAndGet();
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertEquals(n, count.get());
     }
 
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Flowable.range(1, 0).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(1, 0).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -245,7 +246,8 @@ public class FlowableRangeTest extends RxJavaTest {
             @Override
             public void onNext(Integer t) {
 
-            }});
+            }
+        });
         assertTrue(completed.get());
     }
 
@@ -394,7 +396,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void slowPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -411,7 +413,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void fastPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -428,7 +430,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalSlowPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -446,7 +448,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancel() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -464,7 +466,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -481,7 +483,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalRequestOneByOne2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -498,7 +500,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void fastPathCancelExact() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -517,7 +519,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalFastPathCancelExact() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -537,7 +539,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalCancel1() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -557,7 +559,7 @@ public class FlowableRangeTest extends RxJavaTest {
 
     @Test
     public void conditionalCancel2() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(2L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(2L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayEagerTruncateTest.java
@@ -665,7 +665,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(true) /* NFI */ {
+        var buf = new BoundedReplayBuffer<Integer>(true) /* NFI */ {
             @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
@@ -997,7 +997,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1344,7 +1344,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1366,7 +1366,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1388,7 +1388,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1410,7 +1410,7 @@ public class FlowableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -667,7 +667,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+        var buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
@@ -705,7 +705,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test(expected = IllegalStateException.class)
     public void boundedRemoveFirstOneItemOnly() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+        var buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             @Serial
             private static final long serialVersionUID = -9081211580719235896L;
 
@@ -1016,7 +1016,7 @@ public class FlowableReplayTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay().autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1039,7 +1039,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay()
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+                    var ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onError(Throwable t) {
                             super.onError(t);
@@ -1062,7 +1062,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay()
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+                    var ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onComplete() {
                             super.onComplete();
@@ -1409,7 +1409,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1431,7 +1431,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1453,7 +1453,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1475,7 +1475,7 @@ public class FlowableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1873,7 +1873,7 @@ public class FlowableReplayTest extends RxJavaTest {
         .doOnNext(_ -> count.getAndIncrement())
         .replay(1000).autoConnect();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();
@@ -1896,7 +1896,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay(1000)
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+                    var ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onError(Throwable t) {
                             super.onError(t);
@@ -1919,7 +1919,7 @@ public class FlowableReplayTest extends RxJavaTest {
                     .replay(1000)
                     .autoConnect();
 
-                    TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+                    var ts = new TestSubscriber<Integer>() /* NFI */ {
                         @Override
                         public void onComplete() {
                             super.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryTest.java
@@ -45,7 +45,7 @@ public class FlowableRetryTest extends RxJavaTest {
     public void iterativeBackoff() {
         Subscriber<String> consumer = TestHelper.mockSubscriber();
 
-        Flowable<String> producer = Flowable.unsafeCreate(new Publisher<String>() /* NFI */ {
+        Flowable<String> producer = Flowable.unsafeCreate(new Publisher<>() /* NFI */ {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableRetryWithPredicateTest.java
@@ -59,8 +59,9 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryTwice() {
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<>() /* NFI */ {
             int count;
+
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
                 t1.onSubscribe(new BooleanSubscription());
@@ -120,8 +121,9 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryOnSpecificException() {
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<>() /* NFI */ {
             int count;
+
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
                 t1.onSubscribe(new BooleanSubscription());
@@ -157,8 +159,9 @@ public class FlowableRetryWithPredicateTest extends RxJavaTest {
     public void retryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
+        Flowable<Integer> source = Flowable.unsafeCreate(new Publisher<>() /* NFI */ {
             int count;
+
             @Override
             public void subscribe(Subscriber<? super Integer> t1) {
                 t1.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableScanTest.java
@@ -108,7 +108,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -142,7 +142,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -176,7 +176,7 @@ public class FlowableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Flowable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -302,7 +302,7 @@ public class FlowableScanTest extends RxJavaTest {
             subscriber.onSubscribe(p);
         }).scan(100, Integer::sum);
 
-        f.subscribe(new TestSubscriber<Integer>(1L) /* NFI */ {
+        f.subscribe(new TestSubscriber<>(1L) /* NFI */ {
 
             @Override
             public void onNext(Integer integer) {
@@ -511,7 +511,7 @@ public class FlowableScanTest extends RxJavaTest {
 
     @Test
     public void scanTake() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSequenceEqualTest.java
@@ -347,7 +347,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void cancelAndDrainRaceFlowable() {
-        Flowable<Object> neverNever = new Flowable<Object>() /* NFI */ {
+        var neverNever = new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
             }
@@ -376,15 +376,15 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void sourceOverflowsFlowable() {
-        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
-            @Override
-            protected void subscribeActual(Subscriber<? super Object> s) {
-                s.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < 10; i++) {
-                    s.onNext(i);
-                }
-            }
-        }, 8)
+        Flowable.sequenceEqual(Flowable.never(), new Flowable<>() /* NFI */ {
+                    @Override
+                    protected void subscribeActual(Subscriber<? super Object> s) {
+                        s.onSubscribe(new BooleanSubscription());
+                        for (int i = 0; i < 10; i++) {
+                            s.onNext(i);
+                        }
+                    }
+                }, 8)
         .toFlowable()
         .test()
         .assertFailure(MissingBackpressureException.class);
@@ -394,14 +394,14 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void doubleErrorFlowable() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
-                @Override
-                protected void subscribeActual(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onError(new TestException("First"));
-                    s.onError(new TestException("Second"));
-                }
-            }, 8)
+            Flowable.sequenceEqual(Flowable.never(), new Flowable<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(Subscriber<? super Object> s) {
+                            s.onSubscribe(new BooleanSubscription());
+                            s.onError(new TestException("First"));
+                            s.onError(new TestException("Second"));
+                        }
+                    }, 8)
             .toFlowable()
             .to(TestHelper.<Boolean>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
@@ -437,7 +437,7 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void cancelAndDrainRace() {
-        Flowable<Object> neverNever = new Flowable<Object>() /* NFI */ {
+        var neverNever = new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
             }
@@ -465,15 +465,15 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void sourceOverflows() {
-        Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
-            @Override
-            protected void subscribeActual(Subscriber<? super Object> s) {
-                s.onSubscribe(new BooleanSubscription());
-                for (int i = 0; i < 10; i++) {
-                    s.onNext(i);
-                }
-            }
-        }, 8)
+        Flowable.sequenceEqual(Flowable.never(), new Flowable<>() /* NFI */ {
+                    @Override
+                    protected void subscribeActual(Subscriber<? super Object> s) {
+                        s.onSubscribe(new BooleanSubscription());
+                        for (int i = 0; i < 10; i++) {
+                            s.onNext(i);
+                        }
+                    }
+                }, 8)
         .test()
         .assertFailure(MissingBackpressureException.class);
     }
@@ -482,14 +482,14 @@ public class FlowableSequenceEqualTest extends RxJavaTest {
     public void doubleError() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            Flowable.sequenceEqual(Flowable.never(), new Flowable<Object>() /* NFI */ {
-                @Override
-                protected void subscribeActual(Subscriber<? super Object> s) {
-                    s.onSubscribe(new BooleanSubscription());
-                    s.onError(new TestException("First"));
-                    s.onError(new TestException("Second"));
-                }
-            }, 8)
+            Flowable.sequenceEqual(Flowable.never(), new Flowable<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(Subscriber<? super Object> s) {
+                            s.onSubscribe(new BooleanSubscription());
+                            s.onError(new TestException("First"));
+                            s.onError(new TestException("Second"));
+                        }
+                    }, 8)
             .to(TestHelper.<Boolean>testConsumer())
             .assertFailureAndMessage(TestException.class, "First");
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSingleTest.java
@@ -82,7 +82,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -118,7 +118,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {
@@ -153,7 +153,7 @@ public class FlowableSingleTest extends RxJavaTest {
                 .singleElement()
                 //
                 .toFlowable()
-                .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSkipWhileTest.java
@@ -38,8 +38,9 @@ public class FlowableSkipWhileTest extends RxJavaTest {
         return v < 5;
     };
 
-    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() /* NFI */ {
+    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<>() /* NFI */ {
         int index;
+
         @Override
         public boolean test(Integer value) {
             return index++ < 3;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSubscribeOnTest.java
@@ -165,7 +165,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
     @Test
     public void backpressureReschedulesCorrectly() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(10);
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<>(new DefaultSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -213,7 +213,7 @@ public class FlowableSubscribeOnTest extends RxJavaTest {
                 }
 
             });
-            Subscriber<Integer> parent = new DefaultSubscriber<Integer>() /* NFI */ {
+            var parent = new DefaultSubscriber<Integer>() /* NFI */ {
 
                 @Override
                 public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchIfEmptyTest.java
@@ -84,7 +84,7 @@ public class FlowableSwitchIfEmptyTest extends RxJavaTest {
 
         Flowable.<Long>empty()
                 .switchIfEmpty(withProducer)
-                .lift((FlowableOperator<Long, Long>) _ -> new DefaultSubscriber<Long>() /* NFI */ {
+                .lift((FlowableOperator<Long, Long>) _ -> new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onComplete() {
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -370,7 +370,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         publishCompleted(o3, 55);
 
         final TestSubscriberEx<String> testSubscriber = new TestSubscriberEx<>();
-        Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        Flowable.switchOnNext(o).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             private int requested;
 
@@ -431,7 +431,7 @@ public class FlowableSwitchTest extends RxJavaTest {
         .share()
         ;
 
-        TestSubscriberEx<String> ts = new TestSubscriberEx<String>() /* NFI */ {
+        var ts = new TestSubscriberEx<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 super.onNext(t);
@@ -805,7 +805,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void innerCompletesReentrant() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -826,7 +826,7 @@ public class FlowableSwitchTest extends RxJavaTest {
     public void innerErrorsReentrant() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1133,7 +1133,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void innerOnSubscribeOuterCancelRace() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+        var ts = new TestSubscriber<Integer>();
 
         Flowable.just(1)
         .hide()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTest.java
@@ -117,7 +117,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     }
 
     private Function<Integer, Integer> newSlowProcessor() {
-        return new Function<Integer, Integer>() /* NFI */ {
+        return new Function<>() /* NFI */ {
             int c;
 
             @Override
@@ -150,7 +150,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     public void ignoreRequest1() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
         Flowable.range(0, 100000).takeLast(100000)
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -177,7 +177,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     public void ignoreRequest2() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
         Flowable.range(0, 100000).takeLast(100000)
-        .subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -202,7 +202,8 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest3() {
         // If `takeLast` does not ignore `request` properly, it will enter an infinite loop.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(0, 100000).takeLast(100000)
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -228,7 +229,8 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void ignoreRequest4() {
         // If `takeLast` does not ignore `request` properly, StackOverflowError will be thrown.
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(0, 100000).takeLast(100000)
+        .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -254,7 +256,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void unsubscribeTakesEffectEarlyOnFastPath() {
         final AtomicInteger count = new AtomicInteger();
-        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(0, 100000).takeLast(100000).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -282,7 +284,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void requestOverflow() {
         final List<Integer> list = new ArrayList<>();
-        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        Flowable.range(1, 100).takeLast(50).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -303,7 +305,8 @@ public class FlowableTakeLastTest extends RxJavaTest {
             public void onNext(Integer t) {
                 list.add(t);
                 request(Long.MAX_VALUE - 1);
-            }});
+            }
+        });
         assertEquals(50, list.size());
     }
 
@@ -342,7 +345,7 @@ public class FlowableTakeLastTest extends RxJavaTest {
     @Test
     public void cancelThenRequest() {
         Flowable.never().takeLast(2)
-        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Object t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeTest.java
@@ -348,7 +348,7 @@ public class FlowableTakeTest extends RxJavaTest {
     public void takeFinalValueThrows() {
         Flowable<Integer> source = Flowable.just(1).take(1);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeWhileTest.java
@@ -76,7 +76,7 @@ public class FlowableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhile2() {
         Flowable<String> w = Flowable.just("one", "two", "three");
-        Flowable<String> take = w.takeWhile(new Predicate<String>() /* NFI */ {
+        Flowable<String> take = w.takeWhile(new Predicate<>() /* NFI */ {
             int index;
 
             @Override
@@ -144,14 +144,14 @@ public class FlowableTakeWhileTest extends RxJavaTest {
 
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         Flowable<String> take = Flowable.unsafeCreate(w)
-                .takeWhile(new Predicate<String>() /* NFI */ {
-            int index;
+                .takeWhile(new Predicate<>() /* NFI */ {
+                    int index;
 
-            @Override
-            public boolean test(String s) {
-                return index++ < 1;
-            }
-        });
+                    @Override
+                    public boolean test(String s) {
+                        return index++ < 1;
+                    }
+                });
         take.subscribe(subscriber);
 
         // wait for the Flowable to complete

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -251,7 +251,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
         TestScheduler sch = new TestScheduler();
         final PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimeoutWithSelectorTest.java
@@ -495,7 +495,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
+                var pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -539,7 +539,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
+                var pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -584,7 +584,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
+                var pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -629,7 +629,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
+                var pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -672,7 +672,7 @@ public class FlowableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Subscriber<?>[] sub = { null, null };
 
-                final Flowable<Integer> pp2 = new Flowable<Integer>() /* NFI */ {
+                var pp2 = new Flowable<Integer>() /* NFI */ {
 
                     int count;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTimerTest.java
@@ -232,7 +232,7 @@ public class FlowableTimerTest extends RxJavaTest {
     public void onceObserverThrows() {
         Flowable<Long> source = Flowable.timer(100, TimeUnit.MILLISECONDS, scheduler);
 
-        source.safeSubscribe(new DefaultSubscriber<Long>() /* NFI */ {
+        source.safeSubscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {
@@ -263,7 +263,7 @@ public class FlowableTimerTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(subscriber);
 
-        source.safeSubscribe(new DefaultSubscriber<Long>() /* NFI */ {
+        source.safeSubscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToFutureTest.java
@@ -112,7 +112,7 @@ public class FlowableToFutureTest extends RxJavaTest {
 
     @Test
     public void cancellationDuringFutureGet() throws Exception {
-        Future<Object> future = new Future<Object>() /* NFI */ {
+        var future = new Future<>() /* NFI */ {
             private AtomicBoolean isCancelled = new AtomicBoolean(false);
             private AtomicBoolean isDone = new AtomicBoolean(false);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMapTest.java
@@ -134,7 +134,7 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -3296811238780863394L;
@@ -274,7 +274,7 @@ public class FlowableToMapTest extends RxJavaTest {
     public void toMapWithFactory() {
         Flowable<String> source = Flowable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -3296811238780863394L;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableToMultimapTest.java
@@ -78,7 +78,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactoryFlowable() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -2084477070717362859L;
@@ -270,7 +270,7 @@ public class FlowableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactory() {
         Flowable<String> source = Flowable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -2084477070717362859L;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithFlowableTest.java
@@ -46,7 +46,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
+        var wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -103,7 +103,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
+        var wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -159,7 +159,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
+        var wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -209,7 +209,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
 
         final List<Subscriber<Object>> values = new ArrayList<>();
 
-        Subscriber<Flowable<Integer>> wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
+        var wo = new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Flowable<Integer> args) {
                 final Subscriber<Object> mo = TestHelper.mockSubscriber();
@@ -279,7 +279,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
     public void reentrant() {
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -377,7 +377,7 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
             TestSubscriberEx<Flowable<Object>> ts = Flowable.error(new TestException("main"))
-            .window(new Flowable<Object>() /* NFI */ {
+            .window(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -413,14 +413,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
                 final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
                 final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-                TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
+                TestSubscriberEx<Flowable<Object>> ts = new Flowable<>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> subscriber) {
                         subscriber.onSubscribe(new BooleanSubscription());
                         refMain.set(subscriber);
                     }
                 }
-                .window(new Flowable<Object>() /* NFI */ {
+                .window(new Flowable<>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Subscriber<? super Object> subscriber) {
                         subscriber.onSubscribe(new BooleanSubscription());
@@ -453,14 +453,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
+            TestSubscriber<Flowable<Object>> ts = new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() /* NFI */ {
+            .window(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -486,14 +486,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
         final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
         final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-        TestSubscriberEx<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
+        TestSubscriberEx<Flowable<Object>> ts = new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
                 refMain.set(subscriber);
             }
         }
-        .window(new Flowable<Object>() /* NFI */ {
+        .window(new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> subscriber) {
                 subscriber.onSubscribe(new BooleanSubscription());
@@ -518,14 +518,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() /* NFI */ {
+            .window(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     final AtomicInteger counter = new AtomicInteger();
@@ -568,14 +568,14 @@ public class FlowableWindowWithFlowableTest extends RxJavaTest {
             final AtomicReference<Subscriber<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Subscriber<? super Object>> ref = new AtomicReference<>();
 
-            final TestSubscriber<Flowable<Object>> ts = new Flowable<Object>() /* NFI */ {
+            final TestSubscriber<Flowable<Object>> ts = new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
                     refMain.set(subscriber);
                 }
             }
-            .window(new Flowable<Object>() /* NFI */ {
+            .window(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Object> subscriber) {
                     final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithSizeTest.java
@@ -170,7 +170,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(new DefaultSubscriber<Flowable<Integer>>() /* NFI */ {
+        source.subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onStart() {
                 request(1);
@@ -178,7 +178,7 @@ public class FlowableWindowWithSizeTest extends RxJavaTest {
 
             @Override
             public void onNext(Flowable<Integer> t) {
-                t.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                t.subscribe(new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onNext(Integer t) {
                         list.add(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -99,7 +99,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     }
 
     private Consumer<Flowable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
-        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -191,7 +191,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
     public void reentrant() {
         final FlowableProcessor<Integer> pp = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -122,7 +122,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
     }
 
     private <T> Consumer<Flowable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
-        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<T>() /* NFI */ {
+        return stringFlowable -> stringFlowable.subscribe(new DefaultSubscriber<>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -549,7 +549,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -577,7 +577,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -605,7 +605,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -633,7 +633,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
         final FlowableProcessor<Integer> ps = PublishProcessor.<Integer>create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -861,8 +861,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -902,8 +903,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -942,8 +944,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -983,8 +986,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -1023,8 +1027,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -1064,8 +1069,9 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         pp.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Flowable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Flowable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWithLatestFromTest.java
@@ -613,7 +613,7 @@ public class FlowableWithLatestFromTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Flowable.just(1)
-            .withLatestFrom(new Flowable<Integer>() /* NFI */ {
+            .withLatestFrom(new Flowable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
                     s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipIterableTest.java
@@ -227,7 +227,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> r2 = () -> new Iterator<>() /* NFI */ {
             int count;
 
             @Override
@@ -270,7 +270,7 @@ public class FlowableZipIterableTest extends RxJavaTest {
         Subscriber<String> subscriber = TestHelper.mockSubscriber();
         InOrder io = inOrder(subscriber);
 
-        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> r2 = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableZipTest.java
@@ -679,7 +679,7 @@ public class FlowableZipTest extends RxJavaTest {
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
         Flowable.zip(Flowable.just(1),
-                Flowable.just(1), Integer::sum).subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+                Flowable.just(1), Integer::sum).subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -746,7 +746,7 @@ public class FlowableZipTest extends RxJavaTest {
                 .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteFlowable), (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
-        os.subscribe(new DefaultSubscriber<String>() /* NFI */ {
+        os.subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -953,7 +953,7 @@ public class FlowableZipTest extends RxJavaTest {
     }
 
     private Flowable<Integer> createInfiniteFlowable(final AtomicInteger generated) {
-        Flowable<Integer> flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var flowable = Flowable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -1029,7 +1029,7 @@ public class FlowableZipTest extends RxJavaTest {
     public void unboundedDownstreamOverrequesting() {
         Flowable<Integer> source = Flowable.range(1, 2).zipWith(Flowable.range(1, 2), (t1, t2) -> t1 + 10 * t2);
 
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1348,12 +1348,12 @@ public class FlowableZipTest extends RxJavaTest {
 
             @SuppressWarnings("rawtypes")
             final Subscriber[] sub = { null };
-            TestSubscriberEx<Object> ts = Flowable.zip(pp, new Flowable<Object>() /* NFI */ {
-                @Override
-                protected void subscribeActual(Subscriber<? super Object> s) {
-                    sub[0] = s;
-                }
-            }, (a, _) -> a)
+            TestSubscriberEx<Object> ts = Flowable.zip(pp, new Flowable<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(Subscriber<? super Object> s) {
+                            sub[0] = s;
+                        }
+                    }, (a, _) -> a)
             .to(TestHelper.<Object>testConsumer());
 
             pp.onError(new TestException("First"));
@@ -1515,7 +1515,7 @@ public class FlowableZipTest extends RxJavaTest {
 
     @Test
     public void cancelOnBackpressureBoundary() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeAmbTest.java
@@ -106,16 +106,16 @@ public class MaybeAmbTest extends RxJavaTest {
 
     @Test
     public void disposeNoFurtherSignals() {
-        TestObserver<Integer> to = Maybe.ambArray(new Maybe<Integer>() /* NFI */ {
-            @Override
-            protected void subscribeActual(
-                    MaybeObserver<? super Integer> observer) {
-                observer.onSubscribe(Disposable.empty());
-                observer.onSuccess(1);
-                observer.onSuccess(2);
-                observer.onComplete();
-            }
-        }, Maybe.<Integer>never())
+        var to = Maybe.ambArray(new Maybe<>() /* NFI */ {
+                    @Override
+                    protected void subscribeActual(
+                            MaybeObserver<? super Integer> observer) {
+                        observer.onSubscribe(Disposable.empty());
+                        observer.onSuccess(1);
+                        observer.onSuccess(2);
+                        observer.onComplete();
+                    }
+                }, Maybe.<Integer>never())
         .test();
 
         to.dispose();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCacheTest.java
@@ -245,7 +245,7 @@ public class MaybeCacheTest extends RxJavaTest {
 
         final Disposable[] dout = { null };
 
-        source.subscribe(new MaybeObserver<Integer>() /* NFI */ {
+        source.subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeConcatArrayTest.java
@@ -114,14 +114,14 @@ public class MaybeConcatArrayTest extends RxJavaTest {
             final MaybeObserver<?>[] o = { null };
             Maybe.concatArray(MaybeConcatConfig.DELAY_ERROR, Maybe.just(1),
                     Maybe.error(new IOException()),
-            new Maybe<Integer>() /* NFI */ {
-                @Override
-                protected void subscribeActual(MaybeObserver<? super Integer> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onSuccess(2);
-                    o[0] = observer;
-                }
-            })
+                            new Maybe<>() /* NFI */ {
+                                @Override
+                                protected void subscribeActual(MaybeObserver<? super Integer> observer) {
+                                    observer.onSubscribe(Disposable.empty());
+                                    observer.onSuccess(2);
+                                    o[0] = observer;
+                                }
+                            })
             .test()
             .assertFailure(IOException.class, 1, 2);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeCreateTest.java
@@ -71,7 +71,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -110,7 +110,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -149,7 +149,7 @@ public class MaybeCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -184,7 +184,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -219,7 +219,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -254,7 +254,7 @@ public class MaybeCreateTest extends RxJavaTest {
             }
 
             assertTrue(e.isDisposed());
-        }).subscribe(new MaybeObserver<Object>() /* NFI */ {
+        }).subscribe(new MaybeObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDelaySubscriptionTest.java
@@ -115,7 +115,7 @@ public class MaybeDelaySubscriptionTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Flowable<Integer> f = new Flowable<Integer>() /* NFI */ {
+            var f = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDetachTest.java
@@ -61,7 +61,7 @@ public class MaybeDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Object> to = new Maybe<Object>() /* NFI */ {
+        var to = new Maybe<>() /* NFI */ {
             @Override
             protected void subscribeActual(MaybeObserver<? super Object> observer) {
                 observer.onSubscribe(wr.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoAfterSuccessTest.java
@@ -34,7 +34,7 @@ public class MaybeDoAfterSuccessTest extends RxJavaTest {
 
     final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+    TestObserver<Integer> to = new TestObserver<>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableFlowableTest.java
@@ -229,7 +229,8 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.just(1)
-        .flattenAsFlowable(_ -> Arrays.asList(1, 2, 3)).subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .flattenAsFlowable(_ -> Arrays.asList(1, 2, 3))
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             QueueSubscription<Integer> qs;
             @SuppressWarnings("unchecked")
             @Override
@@ -362,7 +363,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {
@@ -396,7 +397,7 @@ public class MaybeFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Maybe.just(1)
-        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
+        .flattenAsFlowable(_ -> (Iterable<Integer>) () -> new Iterator<>() /* NFI */ {
             int count;
             @Override
             public boolean hasNext() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeFlatMapIterableObservableTest.java
@@ -215,12 +215,13 @@ public class MaybeFlatMapIterableObservableTest extends RxJavaTest {
     public void fusedEmptyCheck() {
         Maybe.just(1)
         .flattenAsObservable(_ -> Arrays.asList(1, 2, 3))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             QueueDisposable<Integer> qd;
+
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Disposable d) {
-                qd = (QueueDisposable<Integer>)d;
+                qd = (QueueDisposable<Integer>) d;
 
                 assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeMergeArrayTest.java
@@ -61,11 +61,12 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @Test
     public void fusedEmptyCheck() {
         Maybe.mergeArray(Maybe.just(1), Maybe.<Integer>empty(), Maybe.just(2))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             QueueSubscription<Integer> qs;
+
             @Override
             public void onSubscribe(Subscription s) {
-                qs = (QueueSubscription<Integer>)s;
+                qs = (QueueSubscription<Integer>) s;
 
                 assertEquals(QueueFuseable.ASYNC, qs.requestFusion(QueueFuseable.ANY));
             }
@@ -176,12 +177,12 @@ public class MaybeMergeArrayTest extends RxJavaTest {
     @Test
     public void smallOffer2Throws() {
         Maybe.mergeArray(Maybe.never(), Maybe.never())
-        .subscribe(new FlowableSubscriber<Object>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @SuppressWarnings("rawtypes")
             @Override
             public void onSubscribe(Subscription s) {
-                MergeMaybeObserver o = (MergeMaybeObserver)s;
+                MergeMaybeObserver o = (MergeMaybeObserver) s;
 
                 try {
                     o.queue.offer(1, 2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeUnsubscribeOnTest.java
@@ -100,7 +100,7 @@ public class MaybeUnsubscribeOnTest extends RxJavaTest {
 
             final Disposable[] ds = { null };
             pp.singleElement().unsubscribeOn(Schedulers.computation())
-            .subscribe(new MaybeObserver<Integer>() /* NFI */ {
+            .subscribe(new MaybeObserver<>() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     ds[0] = d;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeZipArrayTest.java
@@ -150,13 +150,13 @@ public class MaybeZipArrayTest extends RxJavaTest {
         AtomicReference<MaybeObserver<? super Integer>> ref1 = new AtomicReference<>();
         AtomicReference<MaybeObserver<? super Integer>> ref2 = new AtomicReference<>();
 
-        Maybe<Integer> m1 = new Maybe<Integer>() /* NFI */ {
+        var m1 = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 ref1.set(observer);
             }
         };
-        Maybe<Integer> m2 = new Maybe<Integer>() /* NFI */ {
+        var m2 = new Maybe<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull MaybeObserver<? super Integer> observer) {
                 ref2.set(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapMaybeTest.java
@@ -254,13 +254,13 @@ public class FlowableConcatMapMaybeTest extends RxJavaTest {
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapMaybe(
-                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
-                            @Override
-                            protected void subscribeActual(
-                                    MaybeObserver<? super Integer> observer) {
-                                observer.onSubscribe(Disposable.empty());
-                                obs.set(observer);
-                            }
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(
+                                MaybeObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            obs.set(observer);
+                        }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableConcatMapSingleTest.java
@@ -186,13 +186,13 @@ public class FlowableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestSubscriberEx<Integer> ts = pp.concatMapSingle(
-                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
-                            @Override
-                            protected void subscribeActual(
-                                    SingleObserver<? super Integer> observer) {
-                                observer.onSubscribe(Disposable.empty());
-                                obs.set(observer);
-                            }
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(
+                                SingleObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            obs.set(observer);
+                        }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapMaybeTest.java
@@ -338,7 +338,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         MaybeObserver<? super Integer> observer) {
@@ -488,7 +488,7 @@ public class FlowableSwitchMapMaybeTest extends RxJavaTest {
 
     @Test
     public void requestMoreOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/FlowableSwitchMapSingleTest.java
@@ -300,7 +300,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
                     s.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         SingleObserver<? super Integer> observer) {
@@ -449,7 +449,7 @@ public class FlowableSwitchMapSingleTest extends RxJavaTest {
 
     @Test
     public void requestMoreOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -220,14 +220,14 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
 
             final AtomicReference<MaybeObserver<? super Integer>> obs = new AtomicReference<>();
 
-            TestObserverEx<Integer> to = ps.concatMapMaybe(
-                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
-                            @Override
-                            protected void subscribeActual(
-                                    MaybeObserver<? super Integer> observer) {
-                                observer.onSubscribe(Disposable.empty());
-                                obs.set(observer);
-                            }
+            var to = ps.concatMapMaybe(
+                    (Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(
+                                MaybeObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            obs.set(observer);
+                        }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -153,13 +153,13 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
             final AtomicReference<SingleObserver<? super Integer>> obs = new AtomicReference<>();
 
             TestObserverEx<Integer> to = ps.concatMapSingle(
-                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
-                            @Override
-                            protected void subscribeActual(
-                                    SingleObserver<? super Integer> observer) {
-                                observer.onSubscribe(Disposable.empty());
-                                obs.set(observer);
-                            }
+                    (Function<Integer, SingleSource<Integer>>) _ -> new Single<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(
+                                SingleObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            obs.set(observer);
+                        }
                     }
             ).to(TestHelper.<Integer>testConsumer());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -318,7 +318,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
                     observer.onError(new TestException("outer"));
                 }
             }
-            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<Integer>() /* NFI */ {
+            .switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> new Maybe<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         MaybeObserver<? super Integer> observer) {
@@ -478,7 +478,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
     public void drainReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -297,7 +297,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
                     observer.onError(new TestException("outer"));
                 }
             }
-            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
+            .switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> new Single<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(
                         SingleObserver<? super Integer> observer) {
@@ -456,7 +456,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
     public void drainReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableBufferTest.java
@@ -673,7 +673,7 @@ public class ObservableBufferTest extends RxJavaTest {
         final Observer<Object> o = TestHelper.mockObserver();
 
         final CountDownLatch cdl = new CountDownLatch(1);
-        DisposableObserver<Object> observer = new DisposableObserver<Object>() /* NFI */ {
+        var observer = new DisposableObserver<>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 o.onNext(t);
@@ -1200,7 +1200,7 @@ public class ObservableBufferTest extends RxJavaTest {
     public void openClosebadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Object>() /* NFI */ {
+            new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     Disposable bs1 = Disposable.empty();
@@ -1317,11 +1317,11 @@ public class ObservableBufferTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
             Observable.never()
-            .buffer(new Observable<Object>() /* NFI */ {
+            .buffer(new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
 
-                    assertFalse(((Disposable)observer).isDisposed());
+                    assertFalse(((Disposable) observer).isDisposed());
 
                     Disposable bs1 = Disposable.empty();
                     Disposable bs2 = Disposable.empty();
@@ -1338,7 +1338,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
                     observer.onError(new IOException());
 
-                    assertTrue(((Disposable)observer).isDisposed());
+                    assertTrue(((Disposable) observer).isDisposed());
 
                     observer.onComplete();
                     observer.onNext(1);
@@ -1429,7 +1429,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
     @Test
     public void bufferExactBoundaryBadSource() {
-        Observable<Integer> ps = new Observable<Integer>() /* NFI */ {
+        var ps = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -1440,7 +1440,7 @@ public class ObservableBufferTest extends RxJavaTest {
         };
 
         final AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
-        Observable<Integer> b = new Observable<Integer>() /* NFI */ {
+        var b = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -1480,7 +1480,7 @@ public class ObservableBufferTest extends RxJavaTest {
         TestObserver<List<Integer>> to = new TestObserver<>();
 
         BufferExactUnboundedObserver<Integer, List<Integer>> sub = new BufferExactUnboundedObserver<>(
-                to, Functions.justSupplier(new ArrayList<Integer>()), 1, TimeUnit.SECONDS, sch);
+                to, Functions.justSupplier(new ArrayList<>()), 1, TimeUnit.SECONDS, sch);
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1518,7 +1518,7 @@ public class ObservableBufferTest extends RxJavaTest {
         TestObserver<List<Integer>> to = new TestObserver<>();
 
         BufferSkipBoundedObserver<Integer, List<Integer>> sub = new BufferSkipBoundedObserver<>(
-                to, Functions.justSupplier(new ArrayList<Integer>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
+                to, Functions.justSupplier(new ArrayList<>()), 1, 1, TimeUnit.SECONDS, sch.createWorker());
 
         sub.onSubscribe(Disposable.empty());
 
@@ -1564,7 +1564,7 @@ public class ObservableBufferTest extends RxJavaTest {
 
         BufferExactBoundedObserver<Integer, List<Integer>> sub =
                 new BufferExactBoundedObserver<>(
-                        to, Functions.justSupplier(new ArrayList<Integer>()),
+                        to, Functions.justSupplier(new ArrayList<>()),
                         1, TimeUnit.SECONDS, 1, false, sch.createWorker())
         ;
 
@@ -1600,7 +1600,7 @@ public class ObservableBufferTest extends RxJavaTest {
         TestObserver<List<Integer>> to = new TestObserver<>();
 
         BufferExactObserver<Integer, List<Integer>> sub = new BufferExactObserver<>(
-                to, 1, Functions.justSupplier(new ArrayList<Integer>())
+                to, 1, Functions.justSupplier(new ArrayList<>())
         );
 
         sub.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCollectTest.java
@@ -100,7 +100,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissionsObservable() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
+        var throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 
@@ -199,7 +199,7 @@ public final class ObservableCollectTest extends RxJavaTest {
     public void collectorFailureDoesNotResultInErrorAndOnNextEmissions() {
         final RuntimeException e = new RuntimeException();
         final AtomicBoolean added = new AtomicBoolean();
-        BiConsumer<Object, Integer> throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
+        var throwOnFirstOnly = new BiConsumer<Object, Integer>() /* NFI */ {
 
             boolean once = true;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -449,7 +449,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observer<List<Object>> observer = new DefaultObserver<List<Object>>() /* NFI */ {
+            var observer = new DefaultObserver<List<Object>>() /* NFI */ {
 
                 @Override
                 public void onNext(List<Object> t) {
@@ -943,7 +943,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -1015,7 +1015,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
                 TestObserverEx<Object[]> to = new TestObserverEx<>();
                 AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
-                Observable<Object> o = new Observable<Object>() /* NFI */ {
+                var o = new Observable<>() /* NFI */ {
                     @Override
                     public void subscribeActual(Observer<? super Object> observer) {
                         ref.set(observer);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -585,7 +585,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         final UnicastSubject<Integer> us = UnicastSubject.create();
         us.onNext(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -236,7 +236,8 @@ public class ObservableConcatMapSchedulerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, n)
-        .concatMap(func, 2, ImmediateThinScheduler.INSTANCE).subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        .concatMap(func, 2, ImmediateThinScheduler.INSTANCE)
+        .subscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 // Consume after sleep for 1 ms
@@ -471,7 +472,7 @@ public class ObservableConcatMapSchedulerTest {
     public void immediateInnerNextOuterError() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -495,7 +496,7 @@ public class ObservableConcatMapSchedulerTest {
     public void immediateInnerNextOuterError2() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        final TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
@@ -249,7 +249,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         try {
             Observable.just(1).hide()
-            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<Integer>() /* NFI */ {
+            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     o[0] = observer;
@@ -275,7 +275,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         Observable.fromArray(Observable.just(1), Observable.just(2))
         .hide()
         .concatMap(Functions.<Observable<Integer>>identity())
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -305,7 +305,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         Observable.fromArray(Observable.just(1), Observable.<Integer>error(new TestException()))
         .hide()
         .concatMap(Functions.<Observable<Integer>>identity())
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
@@ -663,30 +663,30 @@ public class ObservableConcatTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, n)
-        .concatMap(func).subscribe(new DefaultObserver<Integer>() /* NFI */ {
-            @Override
-            public void onNext(Integer t) {
-                // Consume after sleep for 1 ms
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                    // ignored
-                }
-                if (counter.getAndIncrement() % 100 == 0) {
-                    System.out.println("testIssue2890NoStackoverflow -> " + counter.get());
-                }
-            }
+        .concatMap(func).subscribe(new DefaultObserver<>() /* NFI */ {
+                    @Override
+                    public void onNext(Integer t) {
+                        // Consume after sleep for 1 ms
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
+                            // ignored
+                        }
+                        if (counter.getAndIncrement() % 100 == 0) {
+                            System.out.println("testIssue2890NoStackoverflow -> " + counter.get());
+                        }
+                    }
 
-            @Override
-            public void onComplete() {
-                executor.shutdown();
-            }
+                    @Override
+                    public void onComplete() {
+                        executor.shutdown();
+                    }
 
-            @Override
-            public void onError(Throwable e) {
-                executor.shutdown();
-            }
-        });
+                    @Override
+                    public void onError(Throwable e) {
+                        executor.shutdown();
+                    }
+                });
 
         long awaitTerminationTimeout = 100_000;
         if (!executor.awaitTermination(awaitTerminationTimeout, TimeUnit.MILLISECONDS)) {
@@ -1033,7 +1033,7 @@ public class ObservableConcatTest extends RxJavaTest {
         final Disposable[] disposable = { null };
 
         Observable.concatArray(Observable.just(1), Observable.<Integer>error(new TestException()))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -1063,7 +1063,7 @@ public class ObservableConcatTest extends RxJavaTest {
         Observable.concatArray(
                 ObservableConcatConfig.DELAY_ERROR,
                 Observable.just(1), Observable.<Integer>error(new TestException()))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCreateTest.java
@@ -279,7 +279,7 @@ public class ObservableCreateTest extends RxJavaTest {
             }
             assertTrue(d.isDisposed());
         })
-        .subscribe(new Observer<Object>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }
@@ -312,7 +312,7 @@ public class ObservableCreateTest extends RxJavaTest {
             }
             assertTrue(d.isDisposed());
         })
-        .subscribe(new Observer<Object>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDelayTest.java
@@ -794,7 +794,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable.empty()
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableObserver<Object>() /* NFI */ {
+        .subscribe(new DisposableObserver<>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }
@@ -823,7 +823,7 @@ public class ObservableDelayTest extends RxJavaTest {
 
         Observable.error(new TestException())
         .delay(1, TimeUnit.MILLISECONDS, scheduler)
-        .subscribe(new DisposableObserver<Object>() /* NFI */ {
+        .subscribe(new DisposableObserver<>() /* NFI */ {
             @Override
             public void onNext(Object value) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDematerializeTest.java
@@ -211,7 +211,7 @@ public class ObservableDematerializeTest extends RxJavaTest {
     @Test
     @SuppressWarnings("unchecked")
     public void nonNotificationInstanceAfterDispose() {
-        new Observable<Object>() /* NFI */ {
+        new Observable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDistinctTest.java
@@ -143,10 +143,10 @@ public class ObservableDistinctTest extends RxJavaTest {
     public void fusedClear() {
         Observable.just(1, 1, 2, 1, 3, 2, 4, 5, 4)
         .distinct()
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
-                QueueDisposable<?> qd = (QueueDisposable<?>)d;
+                QueueDisposable<?> qd = (QueueDisposable<?>) d;
 
                 assertFalse(qd.isEmpty());
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoAfterNextTest.java
@@ -35,7 +35,7 @@ public class ObservableDoAfterNextTest extends RxJavaTest {
 
     final Consumer<Integer> afterNext = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+    final TestObserver<Integer> to = new TestObserver<>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableDoFinallyTest.java
@@ -333,12 +333,12 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
     public void clearIsEmpty() {
         Observable.range(1, 5)
         .doFinally(this)
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
                 @SuppressWarnings("unchecked")
-                QueueDisposable<Integer> qd = (QueueDisposable<Integer>)d;
+                QueueDisposable<Integer> qd = (QueueDisposable<Integer>) d;
 
                 qd.requestFusion(QueueFuseable.ANY);
 
@@ -380,12 +380,12 @@ public class ObservableDoFinallyTest extends RxJavaTest implements Action {
         Observable.range(1, 5)
         .doFinally(this)
         .filter(Functions.alwaysTrue())
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
                 @SuppressWarnings("unchecked")
-                QueueDisposable<Integer> qd = (QueueDisposable<Integer>)d;
+                QueueDisposable<Integer> qd = (QueueDisposable<Integer>) d;
 
                 qd.requestFusion(QueueFuseable.ANY);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -296,10 +296,10 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
         Observable.range(1, 10)
         .flatMapCompletable(_ -> Completable.complete())
         .toObservable()
-        .subscribe(new Observer<Object>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
-                QueueDisposable<?> qd = (QueueDisposable<?>)d;
+                QueueDisposable<?> qd = (QueueDisposable<?>) d;
                 try {
                     assertNull(qd.poll());
                 } catch (Throwable ex) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -290,7 +290,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -317,7 +317,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
         final PublishSubject<Integer> ps2 = PublishSubject.create();
         final PublishSubject<Integer> ps3 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -344,18 +344,18 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<Object>() /* NFI */ {
-            @Override
-            protected void subscribeActual(MaybeObserver<? super Object> observer) {
-                observer.onSubscribe(Disposable.empty());
+        Observable.just(1).flatMapMaybe((Function<Integer, MaybeSource<Object>>) _ -> new Maybe<>() /* NFI */ {
+                    @Override
+                    protected void subscribeActual(MaybeObserver<? super Object> observer) {
+                        observer.onSubscribe(Disposable.empty());
 
-                assertFalse(((Disposable)observer).isDisposed());
+                        assertFalse(((Disposable) observer).isDisposed());
 
-                to.dispose();
+                        to.dispose();
 
-                assertTrue(((Disposable)observer).isDisposed());
-            }
-        })
+                        assertTrue(((Disposable) observer).isDisposed());
+                    }
+                })
         .subscribe(to);
 
         to

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -252,7 +252,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -277,16 +277,17 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     public void disposeInner() {
         final TestObserver<Object> to = new TestObserver<>();
 
-        Observable.just(1).flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<Object>() /* NFI */ {
+        Observable.just(1)
+        .flatMapSingle((Function<Integer, SingleSource<Object>>) _ -> new Single<>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());
 
-                assertFalse(((Disposable)observer).isDisposed());
+                assertFalse(((Disposable) observer).isDisposed());
 
                 to.dispose();
 
-                assertTrue(((Disposable)observer).isDisposed());
+                assertTrue(((Disposable) observer).isDisposed());
             }
         })
         .subscribe(to);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -490,7 +490,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarReentrant() {
         final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -513,7 +513,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarReentrant2() {
         final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -667,7 +667,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         Observable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
         .flatMap((Function<Integer, Observable<Integer>>) _ ->
-        Observable.<Integer>fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        Observable.<Integer>fromIterable(() -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlattenIterableTest.java
@@ -44,7 +44,7 @@ public class ObservableFlattenIterableTest extends RxJavaTest {
         final AtomicInteger counter = new AtomicInteger();
         Observable.range(1, 5)
         .doOnNext(_ -> counter.getAndIncrement())
-        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
+        .flatMapIterable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFromIterableTest.java
@@ -57,7 +57,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
      */
     @Test
     public void rawIterable() {
-        Iterable<String> it = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> it = () -> new Iterator<>() /* NFI */ {
 
             int i;
 
@@ -134,7 +134,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredWithBackpressure() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> iterable = () -> new Iterator<>() /* NFI */ {
 
             int count = 1;
 
@@ -165,7 +165,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void doesNotCallIteratorHasNextMoreThanRequiredFastPath() {
         final AtomicBoolean called = new AtomicBoolean(false);
-        Iterable<Integer> iterable = () -> new Iterator<Integer>() /* NFI */ {
+        Iterable<Integer> iterable = () -> new Iterator<>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -189,7 +189,7 @@ public class ObservableFromIterableTest extends RxJavaTest {
             }
 
         };
-        Observable.fromIterable(iterable).subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        Observable.fromIterable(iterable).subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -282,11 +282,11 @@ public class ObservableFromIterableTest extends RxJavaTest {
     @Test
     public void fusionClear() {
         Observable.fromIterable(Arrays.asList(1, 2, 3))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 @SuppressWarnings("unchecked")
-                QueueDisposable<Integer> qd = (QueueDisposable<Integer>)d;
+                QueueDisposable<Integer> qd = (QueueDisposable<Integer>) d;
 
                 qd.requestFusion(QueueFuseable.ANY);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
@@ -106,7 +106,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         grouped.flatMap((Function<GroupedObservable<Integer, String>, Observable<String>>) o -> {
             groupCounter.incrementAndGet();
             return o.map(v -> "Event => key: " + o.getKey() + " value: " + v);
-        }).subscribe(new DefaultObserver<String>() /* NFI */ {
+        }).subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -180,7 +180,7 @@ public class ObservableGroupByTest extends RxJavaTest {
 
             return eventGroupedObservable.map(event -> "Source: " + event.source + "  Message: " + event.message);
 
-        }).subscribe(new DefaultObserver<String>() /* NFI */ {
+        }).subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -246,7 +246,7 @@ public class ObservableGroupByTest extends RxJavaTest {
                             .take(20) // limit to only 20 events on this group
                             .map(event -> "testUnsubscribe => Source: " + event.source + "  Message: " + event.message);
 
-                }).subscribe(new DefaultObserver<String>() /* NFI */ {
+                }).subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -344,7 +344,7 @@ public class ObservableGroupByTest extends RxJavaTest {
                         return group;
                     }
                 })
-                .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -378,7 +378,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         final AtomicInteger eventCounter = new AtomicInteger();
         Observable.range(0, 100)
                 .groupBy(i -> i % 2)
-                .subscribe(new DefaultObserver<GroupedObservable<Integer, Integer>>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -896,7 +896,7 @@ public class ObservableGroupByTest extends RxJavaTest {
         final TestObserverEx<Integer> inner2 = new TestObserverEx<>();
 
         final TestObserverEx<GroupedObservable<Integer, Integer>> outer
-                = new TestObserverEx<>(new DefaultObserver<GroupedObservable<Integer, Integer>>() /* NFI */ {
+                = new TestObserverEx<>(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -962,7 +962,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void reentrantComplete() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -984,7 +984,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void reentrantCompleteCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupJoinTest.java
@@ -143,7 +143,7 @@ public class ObservableGroupJoinTest extends RxJavaTest {
                 PPF::new);
 
         q.subscribe(
-                new Observer<PPF>() /* NFI */ {
+                new Observer<>() /* NFI */ {
                     @Override
                     public void onNext(final PPF ppf) {
                         ppf.fruits.filter(t1 -> ppf.person.id == t1.personId).subscribe(t1 -> observer.onNext(Arrays.asList(ppf.person.name, t1.fruit)));

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeDelayErrorTest.java
@@ -291,7 +291,7 @@ public class ObservableMergeDelayErrorTest extends RxJavaTest {
 
         final CountDownLatch latch = new CountDownLatch(1);
         Observable.merge(o1, ObservableMergeConfig.DELAY_ERROR)
-        .subscribe(new DefaultObserver<String>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onComplete() {
                 fail("Expected onError path");

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeTest.java
@@ -203,7 +203,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger totalCounter = new AtomicInteger();
 
         Observable<String> m = Observable.mergeArray(Observable.unsafeCreate(o1), Observable.unsafeCreate(o2));
-        m.subscribe(new DefaultObserver<String>() /* NFI */ {
+        m.subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -460,7 +460,7 @@ public class ObservableMergeTest extends RxJavaTest {
     private Observable<Long> createObservableOf5IntervalsOf1SecondIncrementsWithSubscriptionHook(final Scheduler scheduler, final AtomicBoolean unsubscribed) {
         return Observable.unsafeCreate(child -> Observable.interval(1, TimeUnit.SECONDS, scheduler)
         .take(5)
-        .subscribe(new Observer<Long>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(final Disposable d) {
                 child.onSubscribe(Disposable.fromRunnable(() -> {
@@ -596,7 +596,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() /* NFI */ {
+        var testObserver = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 System.err.println("TestObserver received => " + t + "  on thread " + Thread.currentThread());
@@ -636,7 +636,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Observable<Integer> o1 = createInfiniteObservable(generated1).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> testObserver = new TestObserverEx<Integer>() /* NFI */ {
+        var testObserver = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -675,7 +675,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated2 = new AtomicInteger();
         Observable<Integer> o2 = createInfiniteObservable(generated2).subscribeOn(Schedulers.computation());
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t < 100) {
@@ -725,7 +725,7 @@ public class ObservableMergeTest extends RxJavaTest {
         final AtomicInteger generated1 = new AtomicInteger();
         Observable<Observable<Integer>> o1 = createInfiniteObservable(generated1).map(_ -> Observable.just(1, 2, 3));
 
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             int i;
 
             @Override
@@ -870,7 +870,7 @@ public class ObservableMergeTest extends RxJavaTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -945,7 +945,7 @@ public class ObservableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeFullScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+            var to = new TestObserverEx<Integer>() /* NFI */ {
                 int remaining = req;
 
                 @Override
@@ -963,7 +963,7 @@ public class ObservableMergeTest extends RxJavaTest {
     @Test
     public void slowMergeHiddenScalar() {
         for (final int req : new int[] { 16, 32, 64, 128, 256 }) {
-            TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+            var to = new TestObserverEx<Integer>() /* NFI */ {
                 int remaining = req;
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
@@ -269,7 +269,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
         // use subscribeOn to make async, observeOn to move
         Observable.range(1, 2).subscribeOn(Schedulers.newThread())
         .observeOn(Schedulers.newThread())
-        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -359,7 +359,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
     @Test
     public void backpressureWithTakeBefore() {
         final AtomicInteger generated = new AtomicInteger();
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -576,13 +576,14 @@ public class ObservableObserveOnTest extends RxJavaTest {
         final CountDownLatch cdl = new CountDownLatch(1);
 
         us.observeOn(Schedulers.single())
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             Disposable upstream;
             int count;
+
             @Override
             public void onSubscribe(Disposable d) {
                 this.upstream = d;
-                ((QueueDisposable<?>)d).requestFusion(QueueFuseable.ANY);
+                ((QueueDisposable<?>) d).requestFusion(QueueFuseable.ANY);
             }
 
             @Override
@@ -620,7 +621,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
                 @SuppressWarnings("unchecked")
                 ObserveOnObserver<Integer> oo = (ObserveOnObserver<Integer>)observer;
 
-                oo.queue = new SimpleQueue<Integer>() /* NFI */ {
+                oo.queue = new SimpleQueue<>() /* NFI */ {
 
                     @Override
                     public boolean offer(Integer value) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservablePublishTest.java
@@ -146,7 +146,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         final TestObserver<Integer> to2 = new TestObserver<>();
 
-        final TestObserver<Integer> to1 = new TestObserver<Integer>() /* NFI */ {
+        var to1 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (values().size() == 2) {
@@ -433,7 +433,7 @@ public class ObservablePublishTest extends RxJavaTest {
 
         ConnectableObservable<Integer> co = ps.publish();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLongTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeLongTest.java
@@ -105,7 +105,7 @@ public class ObservableRangeLongTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Observable.rangeLong(1L, 0L).subscribe(new DefaultObserver<Long>() /* NFI */ {
+        Observable.rangeLong(1L, 0L).subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -125,7 +125,8 @@ public class ObservableRangeLongTest extends RxJavaTest {
             @Override
             public void onNext(Long t) {
 
-            }});
+            }
+        });
         assertTrue(completed.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRangeTest.java
@@ -106,7 +106,7 @@ public class ObservableRangeTest extends RxJavaTest {
     @Test
     public void emptyRangeSendsOnCompleteEagerlyWithRequestZero() {
         final AtomicBoolean completed = new AtomicBoolean(false);
-        Observable.range(1, 0).subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        Observable.range(1, 0).subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -126,7 +126,8 @@ public class ObservableRangeTest extends RxJavaTest {
             @Override
             public void onNext(Integer t) {
 
-            }});
+            }
+        });
         assertTrue(completed.get());
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRedoTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRedoTest.java
@@ -28,8 +28,9 @@ public class ObservableRedoTest extends RxJavaTest {
 
         Observable.just(1)
         .repeatWhen((Function<Observable<Object>, ObservableSource<Object>>) o ->
-        o.map(new Function<Object, Object>() /* NFI */ {
+        o.map(new Function<>() /* NFI */ {
             int count;
+
             @Override
             public Object apply(Object v) throws Exception {
                 if (++count == 1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReduceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReduceTest.java
@@ -215,7 +215,7 @@ public class ObservableReduceTest extends RxJavaTest {
     public void reduceMaybeBadSource() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
-            new Observable<Object>() /* NFI */ {
+            new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayEagerTruncateTest.java
@@ -649,7 +649,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+        var buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             @Serial
             private static final long serialVersionUID = -5182053207244406872L;
 
@@ -1201,7 +1201,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1223,7 +1223,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1245,7 +1245,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1267,7 +1267,7 @@ public class ObservableReplayEagerTruncateTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableReplayTest.java
@@ -649,7 +649,7 @@ public class ObservableReplayTest extends RxJavaTest {
 
     @Test
     public void boundedReplayBuffer() {
-        BoundedReplayBuffer<Integer> buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
+        var buf = new BoundedReplayBuffer<Integer>(false) /* NFI */ {
             @Serial
             private static final long serialVersionUID = -5182053207244406872L;
 
@@ -1201,7 +1201,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNext() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1223,7 +1223,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextBound() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1245,7 +1245,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancel() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1267,7 +1267,7 @@ public class ObservableReplayTest extends RxJavaTest {
     public void reentrantOnNextCancelBounded() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryTest.java
@@ -45,7 +45,7 @@ public class ObservableRetryTest extends RxJavaTest {
     public void iterativeBackoff() {
         Observer<String> consumer = TestHelper.mockObserver();
 
-        Observable<String> producer = Observable.unsafeCreate(new ObservableSource<String>() /* NFI */ {
+        var producer = Observable.unsafeCreate(new ObservableSource<String>() /* NFI */ {
 
             private AtomicInteger count = new AtomicInteger(4);
             long last = System.currentTimeMillis();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableRetryWithPredicateTest.java
@@ -59,7 +59,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryTwice() {
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
+        var source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -120,7 +120,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
 
     @Test
     public void retryOnSpecificException() {
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
+        var source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {
@@ -157,7 +157,7 @@ public class ObservableRetryWithPredicateTest extends RxJavaTest {
     public void retryOnSpecificExceptionAndNotOther() {
         final IOException ioe = new IOException();
         final TestException te = new TestException();
-        Observable<Integer> source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
+        var source = Observable.unsafeCreate(new ObservableSource<Integer>() /* NFI */ {
             int count;
             @Override
             public void subscribe(Observer<? super Integer> t1) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScanTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableScanTest.java
@@ -107,7 +107,7 @@ public class ObservableScanTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         Observable.range(1, 100)
                 .scan(0, Integer::sum)
-                .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSkipWhileTest.java
@@ -37,8 +37,9 @@ public class ObservableSkipWhileTest extends RxJavaTest {
         return v < 5;
     };
 
-    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<Integer>() /* NFI */ {
+    private static final Predicate<Integer> INDEX_LESS_THAN_THREE = new Predicate<>() /* NFI */ {
         int index;
+
         @Override
         public boolean test(Integer value) {
             return index++ < 3;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchIfEmptyTest.java
@@ -57,7 +57,7 @@ public class ObservableSwitchIfEmptyTest extends RxJavaTest {
 
         Observable.<Long>empty()
                 .switchIfEmpty(withProducer)
-                .lift((ObservableOperator<Long, Long>) _ -> new DefaultObserver<Long>() /* NFI */ {
+                .lift((ObservableOperator<Long, Long>) _ -> new DefaultObserver<>() /* NFI */ {
                     @Override
                     public void onComplete() {
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -372,7 +372,7 @@ public class ObservableSwitchTest extends RxJavaTest {
         .share()
         ;
 
-        TestObserverEx<String> to = new TestObserverEx<String>() /* NFI */ {
+        var to = new TestObserverEx<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 super.onNext(t);
@@ -741,7 +741,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void innerCompletesReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -762,7 +762,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void innerErrorsReentrant() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -807,7 +807,7 @@ public class ObservableSwitchTest extends RxJavaTest {
             try {
 
                 final AtomicReference<Observer<? super Integer>> obs1 = new AtomicReference<>();
-                final Observable<Integer> ps1 = new Observable<Integer>() /* NFI */ {
+                var ps1 = new Observable<Integer>() /* NFI */ {
                     @Override
                     protected void subscribeActual(
                             Observer<? super Integer> observer) {
@@ -815,7 +815,7 @@ public class ObservableSwitchTest extends RxJavaTest {
                     }
                 };
                 final AtomicReference<Observer<? super Integer>> obs2 = new AtomicReference<>();
-                final Observable<Integer> ps2 = new Observable<Integer>() /* NFI */ {
+                var ps2 = new Observable<Integer>() /* NFI */ {
                     @Override
                     protected void subscribeActual(
                             Observer<? super Integer> observer) {
@@ -1027,7 +1027,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void mainCompleteCancelRace() {
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             AtomicReference<Observer<? super Integer>> ref = new AtomicReference<>();
-            Observable<Integer> o = new Observable<Integer>() /* NFI */ {
+            var o = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref.set(observer);
@@ -1052,14 +1052,14 @@ public class ObservableSwitchTest extends RxJavaTest {
 
         for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
             AtomicReference<Observer<? super Integer>> ref1 = new AtomicReference<>();
-            Observable<Integer> o1 = new Observable<Integer>() /* NFI */ {
+            var o1 = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref1.set(observer);
                 }
             };
             AtomicReference<Observer<? super Integer>> ref2 = new AtomicReference<>();
-            Observable<Integer> o2 = new Observable<Integer>() /* NFI */ {
+            var o2 = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                     ref2.set(observer);
@@ -1083,14 +1083,14 @@ public class ObservableSwitchTest extends RxJavaTest {
     @Test
     public void innerNoSubscriptionYet() {
         AtomicReference<Observer<? super Integer>> ref1 = new AtomicReference<>();
-        Observable<Integer> o1 = new Observable<Integer>() /* NFI */ {
+        var o1 = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                 ref1.set(observer);
             }
         };
         AtomicReference<Observer<? super Integer>> ref2 = new AtomicReference<>();
-        Observable<Integer> o2 = new Observable<Integer>() /* NFI */ {
+        var o2 = new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {
                 ref2.set(observer);
@@ -1197,7 +1197,7 @@ public class ObservableSwitchTest extends RxJavaTest {
 
     @Test
     public void innerOnSubscribeOuterCancelRace() {
-        TestObserver<Integer> to = new TestObserver<Integer>();
+        var to = new TestObserver<Integer>();
 
         Observable.just(1)
         .hide()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTest.java
@@ -110,7 +110,7 @@ public class ObservableTakeLastTest extends RxJavaTest {
     }
 
     private Function<Integer, Integer> newSlowProcessor() {
-        return new Function<Integer, Integer>() /* NFI */ {
+        return new Function<>() /* NFI */ {
             int c;
 
             @Override
@@ -141,7 +141,7 @@ public class ObservableTakeLastTest extends RxJavaTest {
     public void unsubscribeTakesEffectEarlyOnFastPath() {
         final AtomicInteger count = new AtomicInteger();
         Observable.range(0, 100000).takeLast(100000)
-        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeTest.java
@@ -253,7 +253,7 @@ public class ObservableTakeTest extends RxJavaTest {
     public void takeFinalValueThrows() {
         Observable<Integer> source = Observable.just(1).take(1);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 throw new TestException();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeWhileTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeWhileTest.java
@@ -71,7 +71,7 @@ public class ObservableTakeWhileTest extends RxJavaTest {
     @Test
     public void takeWhile2() {
         Observable<String> w = Observable.just("one", "two", "three");
-        Observable<String> take = w.takeWhile(new Predicate<String>() /* NFI */ {
+        Observable<String> take = w.takeWhile(new Predicate<>() /* NFI */ {
             int index;
 
             @Override
@@ -132,14 +132,14 @@ public class ObservableTakeWhileTest extends RxJavaTest {
 
         Observer<String> observer = TestHelper.mockObserver();
         Observable<String> take = Observable.unsafeCreate(w)
-                .takeWhile(new Predicate<String>() /* NFI */ {
-            int index;
+                .takeWhile(new Predicate<>() /* NFI */ {
+                    int index;
 
-            @Override
-            public boolean test(String s) {
-                return index++ < 1;
-            }
-        });
+                    @Override
+                    public boolean test(String s) {
+                        return index++ < 1;
+                    }
+                });
         take.subscribe(observer);
 
         // wait for the Observable to complete

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -196,7 +196,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
         TestScheduler sch = new TestScheduler();
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimeoutWithSelectorTest.java
@@ -486,7 +486,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
+                var pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -530,7 +530,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
+                var pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -575,7 +575,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
+                var pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -620,7 +620,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
+                var pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 
@@ -663,7 +663,7 @@ public class ObservableTimeoutWithSelectorTest extends RxJavaTest {
 
                 final Observer<?>[] sub = { null, null };
 
-                final Observable<Integer> pp2 = new Observable<Integer>() /* NFI */ {
+                var pp2 = new Observable<Integer>() /* NFI */ {
 
                     int count;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTimerTest.java
@@ -233,7 +233,7 @@ public class ObservableTimerTest extends RxJavaTest {
     public void onceObserverThrows() {
         Observable<Long> source = Observable.timer(100, TimeUnit.MILLISECONDS, scheduler);
 
-        source.safeSubscribe(new DefaultObserver<Long>() /* NFI */ {
+        source.safeSubscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {
@@ -264,7 +264,7 @@ public class ObservableTimerTest extends RxJavaTest {
 
         InOrder inOrder = inOrder(observer);
 
-        source.safeSubscribe(new DefaultObserver<Long>() /* NFI */ {
+        source.safeSubscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onNext(Long t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToFutureTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToFutureTest.java
@@ -111,7 +111,7 @@ public class ObservableToFutureTest extends RxJavaTest {
 
     @Test
     public void cancellationDuringFutureGet() throws Exception {
-        Future<Object> future = new Future<Object>() /* NFI */ {
+        var future = new Future<>() /* NFI */ {
             private AtomicBoolean isCancelled = new AtomicBoolean(false);
             private AtomicBoolean isDone = new AtomicBoolean(false);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMapTest.java
@@ -135,7 +135,7 @@ public class ObservableToMapTest extends RxJavaTest {
     public void toMapWithFactoryObservable() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -3296811238780863394L;
@@ -275,7 +275,7 @@ public class ObservableToMapTest extends RxJavaTest {
     public void toMapWithFactory() {
         Observable<String> source = Observable.just("a", "bb", "ccc", "dddd");
 
-        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<Integer, String>() /* NFI */ {
+        Supplier<Map<Integer, String>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -3296811238780863394L;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableToMultimapTest.java
@@ -78,7 +78,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactoryObservable() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -2084477070717362859L;
@@ -270,7 +270,7 @@ public class ObservableToMultimapTest extends RxJavaTest {
     public void toMultimapWithMapFactory() {
         Observable<String> source = Observable.just("a", "b", "cc", "dd", "eee", "fff");
 
-        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<Integer, Collection<String>>() /* NFI */ {
+        Supplier<Map<Integer, Collection<String>>> mapFactory = () -> new LinkedHashMap<>() /* NFI */ {
 
             @Serial
             private static final long serialVersionUID = -2084477070717362859L;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -46,7 +46,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
+        var wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -103,7 +103,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
+        var wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -159,7 +159,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
+        var wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -209,7 +209,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
 
         final List<Observer<Object>> values = new ArrayList<>();
 
-        Observer<Observable<Integer>> wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
+        var wo = new DefaultObserver<Observable<Integer>>() /* NFI */ {
             @Override
             public void onNext(Observable<Integer> args) {
                 final Observer<Object> mo = TestHelper.mockObserver();
@@ -278,7 +278,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     public void reentrant() {
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -337,7 +337,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
             TestObserverEx<Observable<Object>> to = Observable.error(new TestException("main"))
-            .window(new Observable<Object>() /* NFI */ {
+            .window(new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -373,14 +373,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
                 final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
                 final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-                TestObserverEx<Observable<Object>> to = new Observable<Object>() /* NFI */ {
+                var to = new Observable<>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Observer<? super Object> observer) {
                         observer.onSubscribe(Disposable.empty());
                         refMain.set(observer);
                     }
                 }
-                .window(new Observable<Object>() /* NFI */ {
+                .window(new Observable<>() /* NFI */ {
                     @Override
                     protected void subscribeActual(Observer<? super Object> observer) {
                         observer.onSubscribe(Disposable.empty());
@@ -413,14 +413,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
+            var to = new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() /* NFI */ {
+            .window(new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
@@ -446,14 +446,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
         final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
         final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-        TestObserverEx<Observable<Object>> to = new Observable<Object>() /* NFI */ {
+        var to = new Observable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());
                 refMain.set(observer);
             }
         }
-        .window(new Observable<Object>() /* NFI */ {
+        .window(new Observable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Object> observer) {
                 observer.onSubscribe(Disposable.empty());
@@ -478,14 +478,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            final TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
+            var to = new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() /* NFI */ {
+            .window(new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     final AtomicInteger counter = new AtomicInteger();
@@ -529,14 +529,14 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
             final AtomicReference<Observer<? super Object>> refMain = new AtomicReference<>();
             final AtomicReference<Observer<? super Object>> ref = new AtomicReference<>();
 
-            final TestObserver<Observable<Object>> to = new Observable<Object>() /* NFI */ {
+            var to = new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     observer.onSubscribe(Disposable.empty());
                     refMain.set(observer);
                 }
             }
-            .window(new Observable<Object>() /* NFI */ {
+            .window(new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Object> observer) {
                     final AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -100,7 +100,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     }
 
     private Consumer<Observable<String>> observeWindow(final List<String> list, final List<List<String>> lists) {
-        return stringObservable -> stringObservable.subscribe(new DefaultObserver<String>() /* NFI */ {
+        return stringObservable -> stringObservable.subscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -264,7 +264,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
     public void reentrant() {
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -298,16 +298,16 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
         try {
             BehaviorSubject.createDefault(1)
             .window(BehaviorSubject.createDefault(1),
-                    (Function<Integer, Observable<Integer>>) _ -> new Observable<Integer>() /* NFI */ {
-                @Override
-                protected void subscribeActual(
-                        Observer<? super Integer> observer) {
-                    observer.onSubscribe(Disposable.empty());
-                    observer.onNext(1);
-                    observer.onNext(2);
-                    observer.onError(new TestException());
-                }
-            })
+                    (Function<Integer, Observable<Integer>>) _ -> new Observable<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(
+                                Observer<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
+                            observer.onNext(1);
+                            observer.onNext(2);
+                            observer.onError(new TestException());
+                        }
+                    })
             .doOnNext(w -> {
                 w.subscribe(Functions.emptyConsumer(), Functions.emptyConsumer()); // avoid abandonment
             })

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -121,7 +121,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     }
 
     private <T> Consumer<Observable<T>> observeWindow(final List<T> list, final List<List<T>> lists) {
-        return stringObservable -> stringObservable.subscribe(new DefaultObserver<T>() /* NFI */ {
+        return stringObservable -> stringObservable.subscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onComplete() {
                 lists.add(new ArrayList<>(list));
@@ -425,7 +425,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -453,7 +453,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -481,7 +481,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -509,7 +509,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
 
         final Subject<Integer> ps = PublishSubject.<Integer>create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -662,8 +662,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -703,8 +704,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -743,8 +745,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -784,8 +787,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(100, TimeUnit.MILLISECONDS, 10)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -824,8 +828,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());
@@ -865,8 +870,9 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
         final CountDownLatch secondWindowProcessing = new CountDownLatch(1);
 
         ps.window(90, 100, TimeUnit.MILLISECONDS)
-        .doOnNext(new Consumer<Observable<Integer>>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Observable<Integer> v) throws Exception {
                 System.out.println(Thread.currentThread());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipIterableTest.java
@@ -228,7 +228,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
-        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> r2 = () -> new Iterator<>() /* NFI */ {
             int count;
 
             @Override
@@ -271,7 +271,7 @@ public class ObservableZipIterableTest extends RxJavaTest {
         Observer<String> o = TestHelper.mockObserver();
         InOrder io = inOrder(o);
 
-        Iterable<String> r2 = () -> new Iterator<String>() /* NFI */ {
+        Iterable<String> r2 = () -> new Iterator<>() /* NFI */ {
             @Override
             public boolean hasNext() {
                 return true;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
@@ -677,7 +677,8 @@ public class ObservableZipTest extends RxJavaTest {
         final Observer<Integer> observer = TestHelper.mockObserver();
 
         Observable.zip(Observable.just(1),
-                Observable.just(1), Integer::sum).subscribe(new DefaultObserver<Integer>() /* NFI */ {
+                Observable.just(1), Integer::sum)
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -744,7 +745,7 @@ public class ObservableZipTest extends RxJavaTest {
                 .zipWith(ASYNC_OBSERVABLE_OF_INFINITE_INTEGERS(infiniteObservable), (a, b) -> a + "-" + b);
 
         final ArrayList<String> list = new ArrayList<>();
-        os.subscribe(new DefaultObserver<String>() /* NFI */ {
+        os.subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -881,7 +882,7 @@ public class ObservableZipTest extends RxJavaTest {
     }
 
     private Observable<Integer> createInfiniteObservable(final AtomicInteger generated) {
-        Observable<Integer> o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
+        var o = Observable.fromIterable(() -> new Iterator<Integer>() /* NFI */ {
 
             @Override
             public void remove() {
@@ -1141,7 +1142,7 @@ public class ObservableZipTest extends RxJavaTest {
         final PublishSubject<Integer> ps1 = PublishSubject.create();
         final PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCacheTest.java
@@ -62,7 +62,7 @@ public class SingleCacheTest extends RxJavaTest {
 
         final Single<Integer> cached = pp.single(-99).cache();
 
-        SingleObserver<Integer> doubleDisposer = new SingleObserver<Integer>() /* NFI */ {
+        var doubleDisposer = new SingleObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleCreateTest.java
@@ -136,7 +136,7 @@ public class SingleCreateTest extends RxJavaTest {
                 // expected
             }
         })
-        .subscribe(new SingleObserver<Object>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 
@@ -168,7 +168,7 @@ public class SingleCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
         })
-        .subscribe(new SingleObserver<Object>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 
@@ -196,7 +196,7 @@ public class SingleCreateTest extends RxJavaTest {
                 // expected
             }
         })
-        .subscribe(new SingleObserver<Object>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
             }
@@ -226,7 +226,7 @@ public class SingleCreateTest extends RxJavaTest {
 
             assertTrue(d.isDisposed());
         })
-        .subscribe(new SingleObserver<Object>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDetachTest.java
@@ -61,7 +61,7 @@ public class SingleDetachTest extends RxJavaTest {
         Disposable d = Disposable.empty();
         final WeakReference<Disposable> wr = new WeakReference<>(d);
 
-        TestObserver<Object> to = new Single<Object>() /* NFI */ {
+        var to = new Single<>() /* NFI */ {
             @Override
             protected void subscribeActual(SingleObserver<? super Object> observer) {
                 observer.onSubscribe(wr.get());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoAfterSuccessTest.java
@@ -34,7 +34,7 @@ public class SingleDoAfterSuccessTest extends RxJavaTest {
 
     final Consumer<Integer> afterSuccess = e -> values.add(-e);
 
-    final TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+    final TestObserver<Integer> to = new TestObserver<>() /* NFI */ {
         @Override
         public void onNext(Integer t) {
             super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableFlowableTest.java
@@ -215,12 +215,13 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
     public void fusedEmptyCheck() {
         Single.just(1)
         .flattenAsFlowable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
-        .subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        .subscribe(new FlowableSubscriber<>() /* NFI */ {
             QueueSubscription<Integer> qs;
+
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Subscription s) {
-                qs = (QueueSubscription<Integer>)s;
+                qs = (QueueSubscription<Integer>) s;
 
                 assertEquals(QueueFuseable.ASYNC, qs.requestFusion(QueueFuseable.ANY));
             }
@@ -348,8 +349,9 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<>() /* NFI */ {
             int count;
+
             @Override
             public boolean hasNext() {
                 if (count++ == 2) {
@@ -382,8 +384,9 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
         final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
         Single.just(1)
-        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<Integer>() /* NFI */ {
+        .flattenAsFlowable((Function<Integer, Iterable<Integer>>) _ -> (Iterable<Integer>) () -> new Iterator<>() /* NFI */ {
             int count;
+
             @Override
             public boolean hasNext() {
                 if (count++ == 2) {
@@ -445,7 +448,7 @@ public class SingleFlatMapIterableFlowableTest extends RxJavaTest {
 
     @Test
     public void slowPatchCancelAfterOnNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapIterableObservableTest.java
@@ -206,12 +206,13 @@ public class SingleFlatMapIterableObservableTest extends RxJavaTest {
     public void fusedEmptyCheck() {
         Single.just(1)
         .flattenAsObservable((Function<Object, Iterable<Integer>>) _ -> Arrays.asList(1, 2, 3))
-        .subscribe(new Observer<Integer>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             QueueDisposable<Integer> qd;
+
             @SuppressWarnings("unchecked")
             @Override
             public void onSubscribe(Disposable d) {
-                qd = (QueueDisposable<Integer>)d;
+                qd = (QueueDisposable<Integer>) d;
 
                 assertEquals(QueueFuseable.ASYNC, qd.requestFusion(QueueFuseable.ANY));
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleLiftTest.java
@@ -23,7 +23,8 @@ public class SingleLiftTest extends RxJavaTest {
     @Test
     public void normal() {
 
-        Single.just(1).lift((SingleOperator<Integer, Integer>) observer -> new SingleObserver<Integer>() /* NFI */ {
+        Single.just(1)
+        .lift((SingleOperator<Integer, Integer>) observer -> new SingleObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleMiscTest.java
@@ -120,8 +120,9 @@ public class SingleMiscTest extends RxJavaTest {
         final AtomicBoolean flag = new AtomicBoolean();
 
         Single.just(1)
-        .doOnSuccess(new Consumer<Integer>() /* NFI */ {
+        .doOnSuccess(new Consumer<>() /* NFI */ {
             int c;
+
             @Override
             public void accept(Integer v) throws Exception {
                 if (++c == 5) {
@@ -137,16 +138,17 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retry() {
-        Single.fromCallable(new Callable<Object>() /* NFI */ {
-            int c;
-            @Override
-            public Object call() throws Exception {
-                if (++c != 5) {
-                    throw new TestException();
-                }
-                return 1;
-            }
-        })
+        Single.fromCallable(new Callable<>() /* NFI */ {
+                    int c;
+
+                    @Override
+                    public Object call() throws Exception {
+                        if (++c != 5) {
+                            throw new TestException();
+                        }
+                        return 1;
+                    }
+                })
         .retry()
         .test()
         .assertResult(1);
@@ -154,16 +156,17 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retryBiPredicate() {
-        Single.fromCallable(new Callable<Object>() /* NFI */ {
-            int c;
-            @Override
-            public Object call() throws Exception {
-                if (++c != 5) {
-                    throw new TestException();
-                }
-                return 1;
-            }
-        })
+        Single.fromCallable(new Callable<>() /* NFI */ {
+                    int c;
+
+                    @Override
+                    public Object call() throws Exception {
+                        if (++c != 5) {
+                            throw new TestException();
+                        }
+                        return 1;
+                    }
+                })
         .retry((_, _) -> true)
         .test()
         .assertResult(1);
@@ -188,16 +191,17 @@ public class SingleMiscTest extends RxJavaTest {
 
     @Test
     public void retryPredicate() {
-        Single.fromCallable(new Callable<Object>() /* NFI */ {
-            int c;
-            @Override
-            public Object call() throws Exception {
-                if (++c != 5) {
-                    throw new TestException();
-                }
-                return 1;
-            }
-        })
+        Single.fromCallable(new Callable<>() /* NFI */ {
+                    int c;
+
+                    @Override
+                    public Object call() throws Exception {
+                        if (++c != 5) {
+                            throw new TestException();
+                        }
+                        return 1;
+                    }
+                })
         .retry(_ -> true)
         .test()
         .assertResult(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUnsubscribeOnTest.java
@@ -92,7 +92,7 @@ public class SingleUnsubscribeOnTest extends RxJavaTest {
 
             final Disposable[] ds = { null };
             pp.single(-99).unsubscribeOn(Schedulers.computation())
-            .subscribe(new SingleObserver<Integer>() /* NFI */ {
+            .subscribe(new SingleObserver<>() /* NFI */ {
                 @Override
                 public void onSubscribe(Disposable d) {
                     ds[0] = d;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleUsingTest.java
@@ -214,25 +214,25 @@ public class SingleUsingTest extends RxJavaTest {
         List<Throwable> errors = TestHelper.trackPluginErrors();
 
         try {
-            Single.using(Functions.justSupplier(1), (Function<Integer, SingleSource<Integer>>) _ -> new Single<Integer>() /* NFI */ {
-                @Override
-                protected void subscribeActual(SingleObserver<? super Integer> observer) {
-                    observer.onSubscribe(Disposable.empty());
+            Single.using(Functions.justSupplier(1), (Function<Integer, SingleSource<Integer>>) _ -> new Single<>() /* NFI */ {
+                        @Override
+                        protected void subscribeActual(SingleObserver<? super Integer> observer) {
+                            observer.onSubscribe(Disposable.empty());
 
-                    assertFalse(((Disposable)observer).isDisposed());
+                            assertFalse(((Disposable) observer).isDisposed());
 
-                    Disposable d = Disposable.empty();
-                    observer.onSubscribe(d);
+                            Disposable d = Disposable.empty();
+                            observer.onSubscribe(d);
 
-                    assertTrue(d.isDisposed());
+                            assertTrue(d.isDisposed());
 
-                    assertFalse(((Disposable)observer).isDisposed());
+                            assertFalse(((Disposable) observer).isDisposed());
 
-                    observer.onSuccess(1);
+                            observer.onSuccess(1);
 
-                    assertTrue(((Disposable)observer).isDisposed());
-                }
-            }, Functions.emptyConsumer())
+                            assertTrue(((Disposable) observer).isDisposed());
+                        }
+                    }, Functions.emptyConsumer())
             .test()
             .assertResult(1)
             ;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -34,7 +34,7 @@ public class StreamableTest extends StreamableBaseTest {
     public void empty() throws Throwable {
         TestHelper.withVirtual(exec -> {
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            var ts = new TestSubscriber<Integer>();
             ts.onSubscribe(EmptySubscription.INSTANCE);
 
             try (var comp = Streamable.empty().forEach(e -> ts.onError(new TestException("Element produced? " + e)), exec)) {
@@ -56,7 +56,7 @@ public class StreamableTest extends StreamableBaseTest {
     public void just() throws Throwable {
         TestHelper.withVirtual(exec -> {
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>();
+            var ts = new TestSubscriber<Integer>();
             ts.onSubscribe(EmptySubscription.INSTANCE);
 
             try (var comp = Streamable.just(1).forEach(ts::onNext, exec)) {

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/AbstractDirectTaskTest.java
@@ -44,7 +44,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
 
         assertTrue(task.isDisposed());
 
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -158,7 +158,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -188,7 +188,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
             private static final long serialVersionUID = 208585707945686116L;
         };
         final Boolean[] interrupted = { null };
-        FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
+        var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
             @Override
             public boolean cancel(boolean mayInterruptIfRunning) {
                 interrupted[0] = mayInterruptIfRunning;
@@ -224,7 +224,7 @@ public class AbstractDirectTaskTest extends RxJavaTest {
             };
 
             final Boolean[] interrupted = { null };
-            final FutureTask<Void> ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
+            var ft = new FutureTask<Void>(Functions.EMPTY_RUNNABLE, null) /* NFI */ {
                 @Override
                 public boolean cancel(boolean mayInterruptIfRunning) {
                     interrupted[0] = mayInterruptIfRunning;

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableConditionalSubscriberTest.java
@@ -220,7 +220,7 @@ public class BasicFuseableConditionalSubscriberTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         ConditionalSubscriber<Integer> ts = mock(ConditionalSubscriber.class);
 
-        BasicFuseableConditionalSubscriber<Integer, Integer> bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
+        var bfs = new BasicFuseableConditionalSubscriber<Integer, Integer>(ts) /* NFI */ {
 
             @Override
             protected boolean beforeDownstream() {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/BasicFuseableSubscriberTest.java
@@ -27,7 +27,7 @@ public class BasicFuseableSubscriberTest extends RxJavaTest {
 
     @Test
     public void offerThrows() {
-        BasicFuseableSubscriber<Integer, Integer> fcs = new BasicFuseableSubscriber<Integer, Integer>(new TestSubscriber<>(0L)) {
+        var fcs = new BasicFuseableSubscriber<Integer, Integer>(new TestSubscriber<>(0L)) {
 
             @Override
             public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/DeferredScalarSubscriberTest.java
@@ -173,7 +173,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeAfterNext() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -195,7 +195,7 @@ public class DeferredScalarSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeAfterNextViaRequest() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(0L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(0L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/InnerQueuedSubscriberTest.java
@@ -26,7 +26,7 @@ public class InnerQueuedSubscriberTest extends RxJavaTest {
 
     @Test
     public void requestInBatches() {
-        InnerQueuedSubscriberSupport<Integer> support = new InnerQueuedSubscriberSupport<Integer>() /* NFI */ {
+        var support = new InnerQueuedSubscriberSupport<Integer>() /* NFI */ {
             @Override
             public void innerNext(InnerQueuedSubscriber<Integer> inner, Integer value) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/QueueDrainSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/QueueDrainSubscriberTest.java
@@ -32,7 +32,7 @@ import io.reactivex.rxjava4.testsupport.TestHelper;
 public class QueueDrainSubscriberTest extends RxJavaTest {
 
     static QueueDrainSubscriber<Integer, Integer, Integer> createUnordered(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
+        return new QueueDrainSubscriber<>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmitMax(t, false, d);
@@ -60,7 +60,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static QueueDrainSubscriber<Integer, Integer, Integer> createOrdered(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
+        return new QueueDrainSubscriber<>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmitMax(t, false, d);
@@ -88,7 +88,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static QueueDrainSubscriber<Integer, Integer, Integer> createUnorderedReject(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
+        return new QueueDrainSubscriber<>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathEmitMax(t, false, d);
@@ -116,7 +116,7 @@ public class QueueDrainSubscriberTest extends RxJavaTest {
     }
 
     static QueueDrainSubscriber<Integer, Integer, Integer> createOrderedReject(TestSubscriber<Integer> ts, final Disposable d) {
-        return new QueueDrainSubscriber<Integer, Integer, Integer>(ts, new SpscArrayQueue<>(4)) {
+        return new QueueDrainSubscriber<>(ts, new SpscArrayQueue<>(4)) {
             @Override
             public void onNext(Integer t) {
                 fastPathOrderedEmitMax(t, false, d);

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/SinglePostCompleteSubscriberTest.java
@@ -29,7 +29,7 @@ public class SinglePostCompleteSubscriberTest extends RxJavaTest {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             final TestSubscriber<Integer> ts = new TestSubscriber<>(0L);
 
-            final SinglePostCompleteSubscriber<Integer, Integer> spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) /* NFI */ {
+            var spc = new SinglePostCompleteSubscriber<Integer, Integer>(ts) /* NFI */ {
                 @Serial
                 private static final long serialVersionUID = -2848918821531562637L;
 

--- a/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/subscribers/StrictSubscriberTest.java
@@ -30,7 +30,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void strictMode() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -53,7 +53,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() /* NFI */ {
+        new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 s.onSubscribe(new BooleanSubscription());
@@ -127,7 +127,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void deferredRequest() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -159,7 +159,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void requestZero() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -191,7 +191,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void requestNegative() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -223,9 +223,10 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void cancelAfterOnComplete() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             Subscription upstream;
+
             @Override
             public void onSubscribe(Subscription s) {
                 this.upstream = s;
@@ -249,7 +250,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() /* NFI */ {
+        new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 BooleanSubscription b = new BooleanSubscription();
@@ -265,7 +266,7 @@ public class StrictSubscriberTest extends RxJavaTest {
     @Test
     public void cancelAfterOnError() {
         final List<Object> list = new ArrayList<>();
-        Subscriber<Object> sub = new Subscriber<Object>() /* NFI */ {
+        var sub = new Subscriber<>() /* NFI */ {
 
             Subscription upstream;
             @Override
@@ -291,7 +292,7 @@ public class StrictSubscriberTest extends RxJavaTest {
             }
         };
 
-        new Flowable<Object>() /* NFI */ {
+        new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super Object> s) {
                 BooleanSubscription b = new BooleanSubscription();

--- a/src/test/java/io/reactivex/rxjava4/internal/util/AtomicThrowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/AtomicThrowableTest.java
@@ -250,7 +250,7 @@ public class AtomicThrowableTest extends RxJavaTest {
     }
 
     static <T> Emitter<T> wrapToEmitter(final Observer<T> observer) {
-        return new Emitter<T>() /* NFI */ {
+        return new Emitter<>() /* NFI */ {
             @Override
             public void onNext(T value) {
                 observer.onNext(value);

--- a/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/EndConsumerHelperTest.java
@@ -51,7 +51,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDefaultSubscriber() {
-        Subscriber<Integer> consumer = new DefaultSubscriber<Integer>() /* NFI */ {
+        var consumer = new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -125,7 +125,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableSubscriber() {
-        Subscriber<Integer> consumer = new DisposableSubscriber<Integer>() /* NFI */ {
+        var consumer = new DisposableSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -160,7 +160,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceSubscriber() {
-        Subscriber<Integer> consumer = new ResourceSubscriber<Integer>() /* NFI */ {
+        var consumer = new ResourceSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -195,7 +195,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDefaultObserver() {
-        Observer<Integer> consumer = new DefaultObserver<Integer>() /* NFI */ {
+        var consumer = new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -230,7 +230,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableObserver() {
-        Observer<Integer> consumer = new DisposableObserver<Integer>() /* NFI */ {
+        var consumer = new DisposableObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -265,7 +265,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceObserver() {
-        Observer<Integer> consumer = new ResourceObserver<Integer>() /* NFI */ {
+        var consumer = new ResourceObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }
@@ -300,7 +300,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableSingleObserver() {
-        SingleObserver<Integer> consumer = new DisposableSingleObserver<Integer>() /* NFI */ {
+        var consumer = new DisposableSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -331,7 +331,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceSingleObserver() {
-        SingleObserver<Integer> consumer = new ResourceSingleObserver<Integer>() /* NFI */ {
+        var consumer = new ResourceSingleObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -362,7 +362,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleDisposableMaybeObserver() {
-        MaybeObserver<Integer> consumer = new DisposableMaybeObserver<Integer>() /* NFI */ {
+        var consumer = new DisposableMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }
@@ -397,7 +397,7 @@ public class EndConsumerHelperTest extends RxJavaTest {
 
     @Test
     public void checkDoubleResourceMaybeObserver() {
-        MaybeObserver<Integer> consumer = new ResourceMaybeObserver<Integer>() /* NFI */ {
+        var consumer = new ResourceMaybeObserver<Integer>() /* NFI */ {
             @Override
             public void onSuccess(Integer t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/util/QueueDrainHelperTest.java
@@ -154,7 +154,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
 
     @Test
     public void postCompleteCancelledAfterOne() {
-        final TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -179,7 +179,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -234,7 +234,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -293,7 +293,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -348,7 +348,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -402,7 +402,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -456,7 +456,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -510,7 +510,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
 
-        QueueDrain<Integer, Integer> qd = new QueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new QueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -564,7 +564,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -607,7 +607,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -654,7 +654,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -697,7 +697,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -740,7 +740,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;
@@ -783,7 +783,7 @@ public class QueueDrainHelperTest extends RxJavaTest {
         TestObserver<Integer> to = new TestObserver<>();
         to.onSubscribe(Disposable.empty());
 
-        ObservableQueueDrain<Integer, Integer> qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
+        var qd = new ObservableQueueDrain<Integer, Integer>() /* NFI */ {
             @Override
             public boolean cancelled() {
                 return false;

--- a/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/maybe/MaybeTest.java
@@ -1926,7 +1926,7 @@ public class MaybeTest extends RxJavaTest {
 
     @Test
     public void subscribeWith() {
-        MaybeObserver<Integer> mo = new MaybeObserver<Integer>() /* NFI */ {
+        var mo = new MaybeObserver<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {
@@ -2570,7 +2570,7 @@ public class MaybeTest extends RxJavaTest {
 
         long middle = usedMemoryNow();
 
-        MaybeObserver<Object> observer = new MaybeObserver<Object>() /* NFI */ {
+        var observer = new MaybeObserver<>() /* NFI */ {
             @SuppressWarnings("unused")
             Disposable u;
 

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableErrorHandlingTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableErrorHandlingTests.java
@@ -34,8 +34,8 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
     public void onNextError() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
-        Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
-        Observer<Long> observer = new DefaultObserver<Long>() /* NFI */ {
+        var o = Observable.interval(50, TimeUnit.MILLISECONDS);
+        var observer = new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -70,8 +70,8 @@ public class ObservableErrorHandlingTests extends RxJavaTest {
     public void onNextErrorAcrossThread() throws InterruptedException {
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<Throwable> caughtError = new AtomicReference<>();
-        Observable<Long> o = Observable.interval(50, TimeUnit.MILLISECONDS);
-        Observer<Long> observer = new DefaultObserver<Long>() /* NFI */ {
+        var o = Observable.interval(50, TimeUnit.MILLISECONDS);
+        var observer = new DefaultObserver<Long>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableSubscriberTest.java
@@ -34,7 +34,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
     public void onStartCalledOnceViaSubscribe() {
         final AtomicInteger c = new AtomicInteger();
         Observable.just(1, 2, 3, 4).take(2)
-        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -64,7 +64,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
     public void onStartCalledOnceViaUnsafeSubscribe() {
         final AtomicInteger c = new AtomicInteger();
         Observable.just(1, 2, 3, 4).take(2)
-        .subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {
@@ -94,7 +94,7 @@ public class ObservableSubscriberTest extends RxJavaTest {
     public void onStartCalledOnceViaLift() {
         final AtomicInteger c = new AtomicInteger();
         Observable.just(1, 2, 3, 4)
-        .lift((ObservableOperator<Integer, Integer>) child -> new DefaultObserver<Integer>() /* NFI */ {
+        .lift((ObservableOperator<Integer, Integer>) child -> new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableTest.java
@@ -327,7 +327,7 @@ public class ObservableTest extends RxJavaTest {
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
         .subscribeOn(Schedulers.newThread())
-        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
+        .safeSubscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onComplete() {
                 System.out.println("completed");
@@ -374,7 +374,7 @@ public class ObservableTest extends RxJavaTest {
 
         // FIXME custom built???
         Observable.just("1", "2", "three", "4")
-        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
+        .safeSubscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -416,7 +416,7 @@ public class ObservableTest extends RxJavaTest {
         final AtomicReference<Throwable> error = new AtomicReference<>();
         // FIXME custom built???
         Observable.just("1", "2").concatWith(Observable.<String>error(NumberFormatException::new))
-        .subscribe(new DefaultObserver<String>() /* NFI */ {
+        .subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -584,7 +584,7 @@ public class ObservableTest extends RxJavaTest {
         final AtomicInteger count = new AtomicInteger();
         final AtomicReference<Throwable> error = new AtomicReference<>();
         Observable.just("1", "2", "three", "4").take(3)
-        .safeSubscribe(new DefaultObserver<String>() /* NFI */ {
+        .safeSubscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SafeObserverTest.java
@@ -93,7 +93,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() /* NFI */ {
+        return new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -114,7 +114,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
-        return new DefaultObserver<String>() /* NFI */ {
+        return new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -135,7 +135,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONERROR_FAIL() {
-        return new DefaultObserver<String>() /* NFI */ {
+        return new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -156,7 +156,7 @@ public class SafeObserverTest extends RxJavaTest {
     }
 
     private static Observer<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultObserver<String>() /* NFI */ {
+        return new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -185,7 +185,7 @@ public class SafeObserverTest extends RxJavaTest {
 
     @Test
     public void actual() {
-        Observer<Integer> actual = new DefaultObserver<Integer>() /* NFI */ {
+        var actual = new DefaultObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/SerializedObserverTest.java
@@ -277,7 +277,7 @@ public class SerializedObserverTest extends RxJavaTest {
                 final CountDownLatch latch = new CountDownLatch(1);
                 final CountDownLatch running = new CountDownLatch(2);
 
-                TestObserverEx<String> to = new TestObserverEx<>(new DefaultObserver<String>() /* NFI */ {
+                var to = new TestObserverEx<>(new DefaultObserver<String>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -358,7 +358,7 @@ public class SerializedObserverTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestObserver<String> to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
+        var to = new TestObserver<>(new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -386,7 +386,7 @@ public class SerializedObserverTest extends RxJavaTest {
         AtomicInteger p2 = new AtomicInteger();
 
         o.onSubscribe(Disposable.empty());
-        DisposableObserver<String> as1 = new DisposableObserver<String>() /* NFI */ {
+        var as1 = new DisposableObserver<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 o.onNext(t);
@@ -403,7 +403,7 @@ public class SerializedObserverTest extends RxJavaTest {
             }
         };
 
-        DisposableObserver<String> as2 = new DisposableObserver<String>() /* NFI */ {
+        var as2 = new DisposableObserver<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 o.onNext(t);
@@ -834,7 +834,7 @@ public class SerializedObserverTest extends RxJavaTest {
         try {
             final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
-            TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+            var to = new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer v) {
                     serial.get().onError(new TestException());
@@ -861,7 +861,7 @@ public class SerializedObserverTest extends RxJavaTest {
     public void completeReentry() {
         final AtomicReference<Observer<Integer>> serial = new AtomicReference<>();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer v) {
                 serial.get().onComplete();
@@ -1086,7 +1086,7 @@ public class SerializedObserverTest extends RxJavaTest {
     @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedObserver<Integer>> soRef = new AtomicReference<>();
-        TestObserverEx<Integer> to = new TestObserverEx<Integer>() /* NFI */ {
+        var to = new TestObserverEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
+++ b/src/test/java/io/reactivex/rxjava4/observers/TestObserverTest.java
@@ -791,7 +791,7 @@ public class TestObserverTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserver<Integer> to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
+        var to = new TestObserver<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelDoOnNextTryTest.java
@@ -127,8 +127,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Integer v) throws Exception {
                 if (count++ == 1) {
@@ -247,8 +248,9 @@ public class ParallelDoOnNextTryTest extends RxJavaTest implements Consumer<Obje
     public void doOnNextFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .doOnNext(new Consumer<Integer>() /* NFI */ {
+        .doOnNext(new Consumer<>() /* NFI */ {
             int count;
+
             @Override
             public void accept(Integer v) throws Exception {
                 if (count++ == 1) {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFilterTryTest.java
@@ -132,8 +132,9 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetry() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() /* NFI */ {
+        .filter(new Predicate<>() /* NFI */ {
             int count;
+
             @Override
             public boolean test(Integer v) throws Exception {
                 if (count++ == 1) {
@@ -230,8 +231,9 @@ public class ParallelFilterTryTest extends RxJavaTest implements Consumer<Object
     public void filterFailWithRetryConditional() {
         Flowable.range(0, 2)
         .parallel(1)
-        .filter(new Predicate<Integer>() /* NFI */ {
+        .filter(new Predicate<>() /* NFI */ {
             int count;
+
             @Override
             public boolean test(Integer v) throws Exception {
                 if (count++ == 1) {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelFromPublisherTest.java
@@ -216,7 +216,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void requestUnboundedRace() {
-        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() /* NFI */ {
+        var fs = new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Integer t) {
@@ -249,7 +249,7 @@ public class ParallelFromPublisherTest extends RxJavaTest {
     @SuppressWarnings("unchecked")
     @Test
     public void requestRace() {
-        FlowableSubscriber<Integer> fs = new FlowableSubscriber<Integer>() /* NFI */ {
+        var fs = new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onNext(@NonNull Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
@@ -56,7 +56,7 @@ public class ParallelJoinTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         final Subscriber<? super Integer>[] subs = new Subscriber[1];
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -119,7 +119,7 @@ public class ParallelJoinTest extends RxJavaTest {
         @SuppressWarnings("unchecked")
         final Subscriber<? super Integer>[] subs = new Subscriber[1];
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -241,7 +241,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void consumerCancelsAfterOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -260,7 +260,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void delayErrorConsumerCancelsAfterOne() {
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -375,7 +375,7 @@ public class ParallelJoinTest extends RxJavaTest {
     public void onNextWhileProcessingSlowPath() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -399,7 +399,7 @@ public class ParallelJoinTest extends RxJavaTest {
     public void delayErrorOnNextWhileProcessingSlowPath() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -435,14 +435,14 @@ public class ParallelJoinTest extends RxJavaTest {
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
                 AtomicReference<Subscriber<? super Integer>> ref2 = new AtomicReference<>();
 
-                Flowable<Integer> f1 = new Flowable<Integer>() /* NFI */ {
+                var f1 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
                         ref1.set(s);
                     }
                 };
-                Flowable<Integer> f2 = new Flowable<Integer>() /* NFI */ {
+                var f2 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
@@ -479,14 +479,14 @@ public class ParallelJoinTest extends RxJavaTest {
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
                 AtomicReference<Subscriber<? super Integer>> ref2 = new AtomicReference<>();
 
-                Flowable<Integer> f1 = new Flowable<Integer>() /* NFI */ {
+                var f1 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());
                         ref1.set(s);
                     }
                 };
-                Flowable<Integer> f2 = new Flowable<Integer>() /* NFI */ {
+                var f2 = new Flowable<Integer>() /* NFI */ {
                     @Override
                     public void subscribeActual(Subscriber<? super Integer> s) {
                         s.onSubscribe(new BooleanSubscription());

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelMapTest.java
@@ -176,7 +176,7 @@ public class ParallelMapTest extends RxJavaTest {
 
     @Test
     public void conditionalCancelIgnored() {
-        Flowable<Integer> f = new Flowable<Integer>() /* NFI */ {
+        var f = new Flowable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super @NonNull Integer> s) {
                 @SuppressWarnings("unchecked")

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelRunOnTest.java
@@ -238,7 +238,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @Test
     public void normalCancelAfterRequest1() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -259,7 +259,7 @@ public class ParallelRunOnTest extends RxJavaTest {
     @Test
     public void conditionalCancelAfterRequest1() {
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -566,30 +566,30 @@ public class RxJavaPluginsTest extends RxJavaTest {
         try {
             RxJavaPlugins.setOnParallelSubscribe((_, t) -> {
                     var result = new Subscriber<?>[] {
-                        new Subscriber<Object>() /* NFI */ {
+                            new Subscriber<>() /* NFI */ {
 
-                            @Override
-                            public void onSubscribe(Subscription s) {
-                                t[0].onSubscribe(s);
+                                @Override
+                                public void onSubscribe(Subscription s) {
+                                    t[0].onSubscribe(s);
+                                }
+
+                                @SuppressWarnings("unchecked")
+                                @Override
+                                public void onNext(Object value) {
+                                    ((Subscriber<Integer>) t[0]).onNext(((Integer) value - 9));
+                                }
+
+                                @Override
+                                public void onError(Throwable e) {
+                                    t[0].onError(e);
+                                }
+
+                                @Override
+                                public void onComplete() {
+                                    t[0].onComplete();
+                                }
+
                             }
-
-                            @SuppressWarnings("unchecked")
-                            @Override
-                            public void onNext(Object value) {
-                                ((Subscriber<Integer>)t[0]).onNext(((Integer)value - 9));
-                            }
-
-                            @Override
-                            public void onError(Throwable e) {
-                                t[0].onError(e);
-                            }
-
-                            @Override
-                            public void onComplete() {
-                                t[0].onComplete();
-                            }
-
-                        }
                     };
                     return result;
                 }
@@ -639,7 +639,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
     @Test
     public void singleStart() {
         try {
-            RxJavaPlugins.setOnSingleSubscribe((_, t) -> new SingleObserver<Object>() /* NFI */ {
+            RxJavaPlugins.setOnSingleSubscribe((_, t) -> new SingleObserver<>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/AsyncProcessorTest.java
@@ -433,8 +433,8 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onNextCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
+        var ts2 = new TestSubscriber<>();
+        var ts1 = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 ts2.cancel();
@@ -457,8 +457,8 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onErrorCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
+        var ts2 = new TestSubscriber<>();
+        var ts1 = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 ts2.cancel();
@@ -479,8 +479,8 @@ public class AsyncProcessorTest extends FlowableProcessorTest<Object> {
     public void onCompleteCrossCancel() {
         AsyncProcessor<Object> p = AsyncProcessor.create();
 
-        final TestSubscriber<Object> ts2 = new TestSubscriber<>();
-        TestSubscriber<Object> ts1 = new TestSubscriber<Object>() /* NFI */ {
+        var ts2 = new TestSubscriber<>();
+        var ts1 = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onComplete() {
                 ts2.cancel();

--- a/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/BehaviorProcessorTest.java
@@ -256,7 +256,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         subscriber.onNext(t);
@@ -383,7 +383,7 @@ public class BehaviorProcessorTest extends FlowableProcessorTest<Object> {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/MulticastProcessorTest.java
@@ -231,7 +231,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -259,7 +259,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -287,7 +287,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -316,7 +316,7 @@ public class MulticastProcessorTest extends RxJavaTest {
 
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>(1);
 
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>(1) /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -345,7 +345,7 @@ public class MulticastProcessorTest extends RxJavaTest {
         try {
             MulticastProcessor<Integer> mp = MulticastProcessor.create(false);
 
-            mp.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+            mp.subscribe(new FlowableSubscriber<>() /* NFI */ {
 
                 @Override
                 public void onNext(Integer t) {

--- a/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/PublishProcessorTest.java
@@ -296,7 +296,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         subscriber.onNext(t);
@@ -394,7 +394,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void crossCancel() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);
@@ -418,7 +418,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -441,7 +441,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
     @Test
     public void crossCancelOnComplete() {
         final TestSubscriber<Integer> ts1 = new TestSubscriber<>();
-        TestSubscriber<Integer> ts2 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts2 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -482,7 +482,7 @@ public class PublishProcessorTest extends FlowableProcessorTest<Object> {
 
         TestSubscriber<Integer> ts = pp.test();
 
-        pp.subscribe(new FlowableSubscriber<Integer>() /* NFI */ {
+        pp.subscribe(new FlowableSubscriber<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorBoundedConcurrencyTest.java
@@ -48,7 +48,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Subscriber<Long> slow = new DefaultSubscriber<Long>() /* NFI */ {
+            var slow = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -85,7 +85,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Subscriber<Long> fast = new DefaultSubscriber<Long>() /* NFI */ {
+            var fast = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -313,7 +313,7 @@ public class ReplayProcessorBoundedConcurrencyTest extends RxJavaTest {
                 .subscribeOn(s)
                 .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
-                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorConcurrencyTest.java
@@ -48,7 +48,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Subscriber<Long> slow = new DefaultSubscriber<Long>() /* NFI */ {
+            var slow = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -85,7 +85,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Subscriber<Long> fast = new DefaultSubscriber<Long>() /* NFI */ {
+            var fast = new DefaultSubscriber<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -305,7 +305,7 @@ public class ReplayProcessorConcurrencyTest extends RxJavaTest {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultSubscriber<Object>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/ReplayProcessorTest.java
@@ -264,7 +264,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
-        Subscriber<String> subscriber1 = new DefaultSubscriber<String>() /* NFI */ {
+        var subscriber1 = new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -288,7 +288,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Subscriber<String> subscriber2 = new DefaultSubscriber<String>() /* NFI */ {
+        var subscriber2 = new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -383,7 +383,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
             System.out.printf("Turn: %d%n", i);
             src.firstElement().toFlowable()
                 .flatMap((Function<String, Flowable<String>>) t1 -> Flowable.just(t1 + ", " + t1))
-                .subscribe(new DefaultSubscriber<String>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
@@ -415,7 +415,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final Subscriber<Integer> subscriber = TestHelper.mockSubscriber();
 
-        source.subscribe(new DefaultSubscriber<Integer>() /* NFI */ {
+        source.subscribe(new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -1173,7 +1173,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rp.onNext(2);
         rp.onNext(3);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        TestSubscriber<Integer> ts = new TestSubscriber<>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -1209,7 +1209,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
         rp.onNext(2);
         rp.onNext(3);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -1229,7 +1229,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1253,7 +1253,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
 
         final ReplayProcessor<Integer> rp = ReplayProcessor.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>(1L) /* NFI */ {
+        var ts = new TestSubscriber<Integer>(1L) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {
@@ -1431,7 +1431,7 @@ public class ReplayProcessorTest extends FlowableProcessorTest<Object> {
     }
 
     TestSubscriber<Integer> take1AndCancel() {
-        return new TestSubscriber<Integer>(1) /* NFI */ {
+        return new TestSubscriber<>(1) /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/processors/SerializedProcessorTest.java
@@ -590,7 +590,7 @@ public class SerializedProcessorTest extends RxJavaTest {
     public void onErrorQueued() {
         FlowableProcessor<Integer> sp = PublishProcessor.<Integer>create().toSerialized();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/AbstractSchedulerConcurrencyTests.java
@@ -52,7 +52,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
                 })
                 .subscribeOn(getScheduler())
                 .observeOn(getScheduler())
-                .subscribe(new DefaultSubscriber<Long>() /* NFI */ {
+                .subscribe(new DefaultSubscriber<>() /* NFI */ {
                     @Override
                     public void onComplete() {
                         System.out.println("--- completed");
@@ -265,7 +265,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final Worker inner = getScheduler().createWorker();
         try {
-            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<Integer>() /* NFI */ {
+            Flowable<Integer> obs = Flowable.unsafeCreate(new Publisher<>() /* NFI */ {
                 @Override
                 public void subscribe(final Subscriber<? super Integer> subscriber) {
                     inner.schedule(new Runnable() /* NFI */ {
@@ -299,7 +299,7 @@ public abstract class AbstractSchedulerConcurrencyTests extends AbstractSchedule
 
             final AtomicInteger count = new AtomicInteger();
             final AtomicBoolean completed = new AtomicBoolean(false);
-            ResourceSubscriber<Integer> s = new ResourceSubscriber<Integer>() /* NFI */ {
+            var s = new ResourceSubscriber<Integer>() /* NFI */ {
                 @Override
                 public void onComplete() {
                     System.out.println("Completed");

--- a/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/ExecutorSchedulerInterruptibleTest.java
@@ -879,7 +879,7 @@ public class ExecutorSchedulerInterruptibleTest extends AbstractSchedulerConcurr
 
         @Override
         public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-            return new TrackingScheduledFuture<V>(super.schedule(callable, delay, unit));
+            return new TrackingScheduledFuture<>(super.schedule(callable, delay, unit));
         }
 
         class TrackingScheduledFuture<V> implements ScheduledFuture<V> {

--- a/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/single/SingleTest.java
@@ -44,7 +44,7 @@ public class SingleTest extends RxJavaTest {
     public void helloWorld2() {
         final AtomicReference<String> v = new AtomicReference<>();
         Single.just("Hello World!")
-        .subscribe(new SingleObserver<String>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/AsyncSubjectTest.java
@@ -427,8 +427,8 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onNextCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
+        var to2 = new TestObserver<>();
+        var to1 = new TestObserver<>() /* NFI */ {
             @Override
             public void onNext(Object t) {
                 to2.dispose();
@@ -451,8 +451,8 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onErrorCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
+        var to2 = new TestObserver<>();
+        var to1 = new TestObserver<>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 to2.dispose();
@@ -473,8 +473,8 @@ public class AsyncSubjectTest extends SubjectTest<Integer> {
     public void onCompleteCrossCancel() {
         AsyncSubject<Object> p = AsyncSubject.create();
 
-        final TestObserver<Object> to2 = new TestObserver<>();
-        TestObserver<Object> to1 = new TestObserver<Object>() /* NFI */ {
+        var to2 = new TestObserver<>();
+        var to1 = new TestObserver<>() /* NFI */ {
             @Override
             public void onComplete() {
                 to2.dispose();

--- a/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/BehaviorSubjectTest.java
@@ -256,7 +256,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);
@@ -383,7 +383,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultObserver<Object>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {
@@ -613,7 +613,7 @@ public class BehaviorSubjectTest extends SubjectTest<Integer> {
     @Test
     public void innerDisposed() {
         BehaviorSubject.create()
-        .subscribe(new Observer<Object>() /* NFI */ {
+        .subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/MaybeSubjectTest.java
@@ -202,7 +202,7 @@ public class MaybeSubjectTest extends RxJavaTest {
     @Test
     public void disposeTwice() {
         MaybeSubject.create()
-        .subscribe(new MaybeObserver<Object>() /* NFI */ {
+        .subscribe(new MaybeObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subjects/PublishSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/PublishSubjectTest.java
@@ -296,7 +296,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         o.onNext(t);
@@ -398,7 +398,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @SuppressUndeliverable
     public void crossCancelOnError() {
         final TestObserver<Integer> to1 = new TestObserver<>();
-        TestObserver<Integer> to2 = new TestObserver<Integer>() /* NFI */ {
+        var to2 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable t) {
                 super.onError(t);
@@ -421,7 +421,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
     @Test
     public void crossCancelOnComplete() {
         final TestObserver<Integer> to1 = new TestObserver<>();
-        TestObserver<Integer> to2 = new TestObserver<Integer>() /* NFI */ {
+        var to2 = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 super.onComplete();
@@ -447,7 +447,7 @@ public class PublishSubjectTest extends SubjectTest<Integer> {
 
         TestObserver<Integer> to = ps.test();
 
-        ps.subscribe(new Observer<Integer>() /* NFI */ {
+        ps.subscribe(new Observer<>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectBoundedConcurrencyTest.java
@@ -24,7 +24,6 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.observers.DefaultObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestObserverEx;
@@ -51,7 +50,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Observer<Long> slow = new DefaultObserver<Long>() /* NFI */ {
+            var slow = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -88,7 +87,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Observer<Long> fast = new DefaultObserver<Long>() /* NFI */ {
+            var fast = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -317,7 +316,7 @@ public class ReplaySubjectBoundedConcurrencyTest extends RxJavaTest {
                 .subscribeOn(s)
                 .observeOn(Schedulers.cached())
 //                .doOnNext(e -> System.out.println(">>> " + j))
-                .subscribe(new DefaultObserver<Object>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     protected void onStart() {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectConcurrencyTest.java
@@ -24,7 +24,6 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
-import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.observers.DefaultObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestObserverEx;
@@ -51,7 +50,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
         // it's been played through once so now it will all be replays
         final CountDownLatch slowLatch = new CountDownLatch(1);
         Thread slowThread = new Thread(() -> {
-            Observer<Long> slow = new DefaultObserver<Long>() /* NFI */ {
+            var slow = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -88,7 +87,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
 
         Thread fastThread = new Thread(() -> {
             final CountDownLatch fastLatch = new CountDownLatch(1);
-            Observer<Long> fast = new DefaultObserver<Long>() /* NFI */ {
+            var fast = new DefaultObserver<Long>() /* NFI */ {
 
                 @Override
                 public void onComplete() {
@@ -309,7 +308,7 @@ public class ReplaySubjectConcurrencyTest extends RxJavaTest {
                 final AtomicReference<Object> o = new AtomicReference<>();
 
                 rs.subscribeOn(s).observeOn(Schedulers.cached())
-                .subscribe(new DefaultObserver<Object>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
 
                     @Override
                     public void onComplete() {

--- a/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/ReplaySubjectTest.java
@@ -261,7 +261,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
     public void newSubscriberDoesntBlockExisting() throws InterruptedException {
 
         final AtomicReference<String> lastValueForSubscriber1 = new AtomicReference<>();
-        Observer<String> observer1 = new DefaultObserver<String>() /* NFI */ {
+        var observer1 = new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -285,7 +285,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
         final CountDownLatch oneReceived = new CountDownLatch(1);
         final CountDownLatch makeSlow = new CountDownLatch(1);
         final CountDownLatch completed = new CountDownLatch(1);
-        Observer<String> observer2 = new DefaultObserver<String>() /* NFI */ {
+        var observer2 = new DefaultObserver<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -381,7 +381,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
             src.firstElement()
                 .toObservable()
                 .flatMap((Function<String, Observable<String>>) t1 -> Observable.just(t1 + ", " + t1))
-                .subscribe(new DefaultObserver<String>() /* NFI */ {
+                .subscribe(new DefaultObserver<>() /* NFI */ {
                     @Override
                     public void onNext(String t) {
                         System.out.println(t);
@@ -413,7 +413,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final Observer<Integer> o = TestHelper.mockObserver();
 
-        source.subscribe(new DefaultObserver<Integer>() /* NFI */ {
+        source.subscribe(new DefaultObserver<>() /* NFI */ {
 
             @Override
             public void onNext(Integer t) {
@@ -1082,7 +1082,7 @@ public class ReplaySubjectTest extends SubjectTest<Integer> {
 
         final ReplaySubject<Integer> rp = ReplaySubject.createWithTimeAndSize(1, TimeUnit.SECONDS, scheduler, 2);
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 if (t == 1) {

--- a/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SerializedSubjectTest.java
@@ -591,7 +591,7 @@ public class SerializedSubjectTest extends RxJavaTest {
     public void onErrorQueued() {
         Subject<Integer> sp = PublishSubject.<Integer>create().toSerialized();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);
@@ -615,7 +615,7 @@ public class SerializedSubjectTest extends RxJavaTest {
     public void onCompleteQueued() {
         Subject<Integer> sp = PublishSubject.<Integer>create().toSerialized();
 
-        TestObserver<Integer> to = new TestObserver<Integer>() /* NFI */ {
+        var to = new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(@NonNull Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subjects/SingleSubjectTest.java
@@ -182,7 +182,7 @@ public class SingleSubjectTest extends RxJavaTest {
     @Test
     public void disposeTwice() {
         SingleSubject.create()
-        .subscribe(new SingleObserver<Object>() /* NFI */ {
+        .subscribe(new SingleObserver<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 assertFalse(d.isDisposed());

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SafeSubscriberTest.java
@@ -237,7 +237,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     };
 
     private static Subscriber<String> OBSERVER_ONNEXT_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultSubscriber<String>() /* NFI */ {
+        return new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -258,7 +258,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> OBSERVER_ONNEXT_ONERROR_FAIL() {
-        return new DefaultSubscriber<String>() /* NFI */ {
+        return new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -279,7 +279,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> subscriberOnErrorFail() {
-        return new DefaultSubscriber<String>() /* NFI */ {
+        return new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -300,7 +300,7 @@ public class SafeSubscriberTest extends RxJavaTest {
     }
 
     private static Subscriber<String> OBSERVER_ONCOMPLETED_FAIL(final AtomicReference<Throwable> onError) {
-        return new DefaultSubscriber<String>() /* NFI */ {
+        return new DefaultSubscriber<>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -329,7 +329,7 @@ public class SafeSubscriberTest extends RxJavaTest {
 
     @Test
     public void actual() {
-        Subscriber<Integer> actual = new DefaultSubscriber<Integer>() /* NFI */ {
+        var actual = new DefaultSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
             }

--- a/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/SerializedSubscriberTest.java
@@ -359,7 +359,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @Test
     public void threadStarvation() throws InterruptedException {
 
-        TestSubscriber<String> ts = new TestSubscriber<>(new DefaultSubscriber<String>() /* NFI */ {
+        var ts = new TestSubscriber<>(new DefaultSubscriber<String>() /* NFI */ {
 
             @Override
             public void onComplete() {
@@ -387,7 +387,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         AtomicInteger p2 = new AtomicInteger();
 
         subscriber.onSubscribe(new BooleanSubscription());
-        ResourceSubscriber<String> as1 = new ResourceSubscriber<String>() /* NFI */ {
+        var as1 = new ResourceSubscriber<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 subscriber.onNext(t);
@@ -404,7 +404,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
             }
         };
 
-        ResourceSubscriber<String> as2 = new ResourceSubscriber<String>() /* NFI */ {
+        var as2 = new ResourceSubscriber<String>() /* NFI */ {
             @Override
             public void onNext(String t) {
                 subscriber.onNext(t);
@@ -835,7 +835,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
         try {
             final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
-            TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+            var ts = new TestSubscriber<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer v) {
                     serial.get().onError(new TestException());
@@ -862,7 +862,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     public void completeReentry() {
         final AtomicReference<Subscriber<Integer>> serial = new AtomicReference<>();
 
-        TestSubscriber<Integer> ts = new TestSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer v) {
                 serial.get().onComplete();
@@ -1078,7 +1078,7 @@ public class SerializedSubscriberTest extends RxJavaTest {
     @SuppressUndeliverable
     public void onErrorQueuedUp() {
         AtomicReference<SerializedSubscriber<Integer>> ssRef = new AtomicReference<>();
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
                 super.onNext(t);

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -648,7 +648,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void onErrorCrashCountsDownLatch() {
-        TestSubscriber<Integer> ts0 = new TestSubscriber<Integer>() /* NFI */ {
+        var ts0 = new TestSubscriber<Integer>() /* NFI */ {
             @Override
             public void onError(Throwable e) {
                 throw new TestException();
@@ -1260,7 +1260,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1296,7 +1296,7 @@ public class TestSubscriberTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() throws Exception {
-        TestSubscriber<Integer> ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriber<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {

--- a/src/test/java/io/reactivex/rxjava4/tck/RefCountProcessor.java
+++ b/src/test/java/io/reactivex/rxjava4/tck/RefCountProcessor.java
@@ -47,7 +47,7 @@ import io.reactivex.rxjava4.processors.FlowableProcessor;
     RefCountProcessor(FlowableProcessor<T> actual) {
         this.actual = actual;
         this.upstream = new AtomicReference<>();
-        this.subscribers = new AtomicReference<>(EMPTY);
+        this.subscribers = new AtomicReference<RefCountSubscriber<T>[]>(EMPTY);
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -357,7 +357,7 @@ public enum TestHelper {
         try {
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            var bad = new FlowableSubscriber<Object>() /* NFI */ {
+            var bad = new FlowableSubscriber<>() /* NFI */ {
 
                 @Override
                 public void onSubscribe(Subscription s) {
@@ -956,7 +956,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1010,7 +1010,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1064,7 +1064,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1118,7 +1118,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1172,7 +1172,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1226,7 +1226,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1280,7 +1280,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1333,7 +1333,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Maybe<T> source = new Maybe<T>() /* NFI */ {
+            var source = new Maybe<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super T> observer) {
                     try {
@@ -1387,7 +1387,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Single<T> source = new Single<T>() /* NFI */ {
+            var source = new Single<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super T> observer) {
                     try {
@@ -1441,7 +1441,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1495,7 +1495,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null, null, null };
             final CountDownLatch cdl = new CountDownLatch(2);
 
-            ParallelFlowable<T> source = new ParallelFlowable<T>() /* NFI */ {
+            var source = new ParallelFlowable<T>() /* NFI */ {
                 @Override
                 public void subscribe(Subscriber<? super T>[] subscribers) {
                     for (int i = 0; i < subscribers.length; i++) {
@@ -1558,7 +1558,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null, null, null };
             final CountDownLatch cdl = new CountDownLatch(2);
 
-            ParallelFlowable<T> source = new ParallelFlowable<T>() /* NFI */ {
+            var source = new ParallelFlowable<T>() /* NFI */ {
                 @Override
                 public void subscribe(Subscriber<? super T>[] subscribers) {
                     for (int i = 0; i < subscribers.length; i++) {
@@ -1623,7 +1623,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() /* NFI */ {
+            var source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1677,7 +1677,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() /* NFI */ {
+            var source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1731,7 +1731,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() /* NFI */ {
+            var source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1784,7 +1784,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Observable<T> source = new Observable<T>() /* NFI */ {
+            var source = new Observable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
                     try {
@@ -1838,7 +1838,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1892,7 +1892,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1946,7 +1946,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -1999,7 +1999,7 @@ public enum TestHelper {
             final Boolean[] b = { null, null };
             final CountDownLatch cdl = new CountDownLatch(1);
 
-            Flowable<T> source = new Flowable<T>() /* NFI */ {
+            var source = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     try {
@@ -2521,7 +2521,7 @@ public enum TestHelper {
 
         final Boolean[] state = { null, null, null, null };
 
-        source.subscribe(new Observer<T>() /* NFI */ {
+        source.subscribe(new Observer<>() /* NFI */ {
             @Override
             public void onSubscribe(Disposable d) {
                 try {
@@ -2587,7 +2587,7 @@ public enum TestHelper {
 
         final Boolean[] state = { null, null, null, null };
 
-        source.subscribe(new FlowableSubscriber<T>() /* NFI */ {
+        source.subscribe(new FlowableSubscriber<>() /* NFI */ {
             @Override
             public void onSubscribe(Subscription s) {
                 try {
@@ -2675,7 +2675,7 @@ public enum TestHelper {
             final boolean error, final T goodValue, final T badValue, final Object... expected) {
         List<Throwable> errors = trackPluginErrors();
         try {
-            Observable<T> bad = new Observable<T>() /* NFI */ {
+            var bad = new Observable<T>() /* NFI */ {
                 boolean once;
                 @Override
                 protected void subscribeActual(Observer<? super T> observer) {
@@ -2835,7 +2835,7 @@ public enum TestHelper {
             final boolean error, final T goodValue, final T badValue, final Object... expected) {
         List<Throwable> errors = trackPluginErrors();
         try {
-            Flowable<T> bad = new Flowable<T>() /* NFI */ {
+            var bad = new Flowable<T>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super T> subscriber) {
                     subscriber.onSubscribe(new BooleanSubscription());
@@ -2998,7 +2998,7 @@ public enum TestHelper {
      * @return the new Observable
      */
     public static <T> Observable<T> rejectObservableFusion() {
-        return new Observable<T>() /* NFI */ {
+        return new Observable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super T> observer) {
                 observer.onSubscribe(new QueueDisposable<T>() /* NFI */ {
@@ -3052,7 +3052,7 @@ public enum TestHelper {
      * @return the new Observable
      */
     public static <T> Flowable<T> rejectFlowableFusion() {
-        return new Flowable<T>() /* NFI */ {
+        return new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(Subscriber<? super T> subscriber) {
                 subscriber.onSubscribe(new QueueSubscription<T>() /* NFI */ {
@@ -3747,7 +3747,7 @@ public enum TestHelper {
      * @return the new FlowableTransformer instance
      */
     public static <T> FlowableTransformer<T, T> conditional() {
-        return f -> new Flowable<T>() /* NFI */ {
+        return f -> new Flowable<>() /* NFI */ {
             @Override
             protected void subscribeActual(@NonNull Subscriber<@NonNull ? super T> subscriber) {
                 f.subscribe(new ForwardingConditionalSubscriber<>(subscriber));

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestObserverExTest.java
@@ -1003,7 +1003,7 @@ public class TestObserverExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestObserverEx<Integer> to = new TestObserverEx<>(new Observer<Integer>() /* NFI */ {
+        var to = new TestObserverEx<>(new Observer<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Disposable d) {

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestSubscriberExTest.java
@@ -656,7 +656,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void onCompletedCrashCountsDownLatch() {
-        TestSubscriberEx<Integer> ts0 = new TestSubscriberEx<Integer>() /* NFI */ {
+        var ts0 = new TestSubscriberEx<Integer>() /* NFI */ {
             @Override
             public void onComplete() {
                 throw new TestException();
@@ -1427,7 +1427,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void completeDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {
@@ -1463,7 +1463,7 @@ public class TestSubscriberExTest extends RxJavaTest {
 
     @Test
     public void errorDelegateThrows() {
-        TestSubscriberEx<Integer> ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
+        var ts = new TestSubscriberEx<>(new FlowableSubscriber<Integer>() /* NFI */ {
 
             @Override
             public void onSubscribe(Subscription s) {


### PR DESCRIPTION
Over 700 cases, all remnants from the Java 6 version because it is generally not checked by Eclipse's compiler warnings.

Used IntelliJ 2026.1.3 with the Java migration helper inspections.