### PR TITLE
4.x: API reductions: sequenceEqual, switchOnNext, zip

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -15,9 +15,8 @@ package io.reactivex.rxjava4.core;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.Flow.Publisher;
 import java.util.stream.*;
-
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.core.config.*;
@@ -270,7 +269,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            the configuration record for this operator
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources}, {@code combiner} or {@code config} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      * @since 4.0.0
      */
@@ -368,7 +366,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            the configuration record for this operator
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code sources}, {@code combiner} or {@code config} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
      * @since 4.0.0
      */
@@ -1078,7 +1075,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param config the configuration record of this operator
      * @return the new {@code Observable} instance with the specified concatenation behavior
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
      * @since 4.0.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -1198,7 +1194,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param config the configuration record for this operator
      * @return the new {@code Observable} instance with the specified concatenation behavior
      * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
      * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -2926,7 +2921,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Single<Boolean> sequenceEqual(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2) {
-        return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize());
+        return sequenceEqual(source1, source2, ObservableSequenceEqualConfig.DEFAULT);
     }
 
     /**
@@ -2944,91 +2939,25 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            the first {@code ObservableSource} to compare
      * @param source2
      *            the second {@code ObservableSource} to compare
-     * @param isEqual
-     *            a function used to compare items emitted by each {@code ObservableSource}
+     * @param config
+     *            the configuration record for this operator
      * @param <T>
      *            the type of items emitted by each {@code ObservableSource}
      * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code isEqual} is {@code null}
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Single<Boolean> sequenceEqual(
             @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull BiPredicate<? super T, ? super T> isEqual) {
-        return sequenceEqual(source1, source2, isEqual, bufferSize());
-    }
-
-    /**
-     * Returns a {@link Single} that emits a {@link Boolean} value that indicates whether two {@link ObservableSource} sequences are the
-     * same by comparing the items emitted by each {@code ObservableSource} pairwise based on the results of a specified
-     * equality function.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.2.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param source1
-     *            the first {@code ObservableSource} to compare
-     * @param source2
-     *            the second {@code ObservableSource} to compare
-     * @param isEqual
-     *            a function used to compare items emitted by each {@code ObservableSource}
-     * @param bufferSize
-     *            the number of items expected from the first and second source {@code ObservableSource} to be buffered
-     * @param <T>
-     *            the type of items emitted by each {@code ObservableSource}
-     * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code isEqual} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Single<Boolean> sequenceEqual(
-            @NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            @NonNull BiPredicate<? super T, ? super T> isEqual, int bufferSize) {
+            @NonNull ObservableSequenceEqualConfig<? super T> config) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(isEqual, "isEqual is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableSequenceEqualSingle<>(source1, source2, isEqual, bufferSize));
-    }
-
-    /**
-     * Returns a {@link Single} that emits a {@link Boolean} value that indicates whether two {@link ObservableSource} sequences are the
-     * same by comparing the items emitted by each {@code ObservableSource} pairwise.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/sequenceEqual.2.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code sequenceEqual} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param source1
-     *            the first {@code ObservableSource} to compare
-     * @param source2
-     *            the second {@code ObservableSource} to compare
-     * @param bufferSize
-     *            the number of items expected from the first and second source {@code ObservableSource} to be buffered
-     * @param <T>
-     *            the type of items emitted by each {@code ObservableSource}
-     * @return the new {@code Single} instance
-     * @throws NullPointerException if {@code source1} or {@code source2} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/sequenceequal.html">ReactiveX operators documentation: SequenceEqual</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Single<Boolean> sequenceEqual(@NonNull ObservableSource<? extends T> source1, @NonNull ObservableSource<? extends T> source2,
-            int bufferSize) {
-        return sequenceEqual(source1, source2, ObjectHelper.equalsPredicate(), bufferSize);
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableSequenceEqualSingle<>(source1, source2, config.isEqual(), config.bufferSize()));
     }
 
     /**
@@ -3052,21 +2981,21 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param <T> the item type
      * @param sources
      *            the {@code ObservableSource} that emits {@code ObservableSource}s
-     * @param bufferSize
-     *            the expected number of items to cache from the inner {@code ObservableSource}s
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code sources} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
+     * @since 4.0.0
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public static <@NonNull T> Observable<T> switchOnNext(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
+    public static <@NonNull T> Observable<T> switchOnNext(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, @NonNull ObservableSwitchConfig config) {
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), bufferSize, false));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), config.bufferSize(), config.delayError()));
     }
 
     /**
@@ -3098,81 +3027,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T> Observable<T> switchOnNext(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
-        return switchOnNext(sources, bufferSize());
-    }
-
-    /**
-     * Converts an {@link ObservableSource} that emits {@code ObservableSource}s into an {@code Observable} that emits the items emitted by the
-     * most recently emitted of those {@code ObservableSource}s and delays any exception until all {@code ObservableSource}s terminate.
-     * <p>
-     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchOnNextDelayError.v3.png" alt="">
-     * <p>
-     * {@code switchOnNext} subscribes to an {@code ObservableSource} that emits {@code ObservableSource}s. Each time it observes one of
-     * these emitted {@code ObservableSource}s, the {@code ObservableSource} returned by {@code switchOnNext} begins emitting the items
-     * emitted by that {@code ObservableSource}. When a new inner {@code ObservableSource} is emitted, {@code switchOnNext} stops emitting items
-     * from the earlier-emitted {@code ObservableSource} and begins emitting items from the new one.
-     * <p>
-     * The resulting {@code Observable} completes if both the main {@code ObservableSource} and the last inner {@code ObservableSource}, if any, complete.
-     * If the main {@code ObservableSource} signals an {@code onError}, the termination of the last inner {@code ObservableSource} will emit that error as is
-     * or wrapped into a {@link CompositeException} along with the other possible errors the former inner {@code ObservableSource}s signaled.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the item type
-     * @param sources
-     *            the {@code ObservableSource} that emits {@code ObservableSource}s
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> switchOnNextDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources) {
-        return switchOnNextDelayError(sources, bufferSize());
-    }
-
-    /**
-     * Converts an {@link ObservableSource} that emits {@code ObservableSource}s into an {@code Observable} that emits the items emitted by the
-     * most recently emitted of those {@code ObservableSource}s and delays any exception until all {@code ObservableSource}s terminate.
-     * <p>
-     * <img width="640" height="370" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchOnNextDelayError.v3.png" alt="">
-     * <p>
-     * {@code switchOnNext} subscribes to an {@code ObservableSource} that emits {@code ObservableSource}s. Each time it observes one of
-     * these emitted {@code ObservableSource}s, the {@code ObservableSource} returned by {@code switchOnNext} begins emitting the items
-     * emitted by that {@code ObservableSource}. When a new inner {@code ObservableSource} is emitted, {@code switchOnNext} stops emitting items
-     * from the earlier-emitted {@code ObservableSource} and begins emitting items from the new one.
-     * <p>
-     * The resulting {@code Observable} completes if both the main {@code ObservableSource} and the last inner {@code ObservableSource}, if any, complete.
-     * If the main {@code ObservableSource} signals an {@code onError}, the termination of the last inner {@code ObservableSource} will emit that error as is
-     * or wrapped into a {@link CompositeException} along with the other possible errors the former inner {@code ObservableSource}s signaled.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchOnNextDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T> the item type
-     * @param sources
-     *            the {@code ObservableSource} that emits {@code ObservableSource}s
-     * @param bufferSize
-     *            the expected number of items to cache from the inner {@code ObservableSource}s
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/switch.html">ReactiveX operators documentation: Switch</a>
-     * @since 2.0
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T> Observable<T> switchOnNextDelayError(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources, int bufferSize) {
-        Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap(sources, Functions.identity(), bufferSize, true));
+        return switchOnNext(sources, ObservableSwitchConfig.DEFAULT);
     }
 
     /**
@@ -3407,9 +3262,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public static <@NonNull T, @NonNull R> Observable<R> zip(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources,
             @NonNull Function<? super Object[], ? extends R> zipper) {
-        Objects.requireNonNull(zipper, "zipper is null");
-        Objects.requireNonNull(sources, "sources is null");
-        return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, bufferSize(), false));
+        return zip(sources, ObservableZipConfig.DEFAULT, zipper);
     }
 
     /**
@@ -3450,30 +3303,29 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *
      * @param sources
      *            an {@code Iterable} of source {@code ObservableSource}s
+     * @param config
+     *            the configuration record for this operator
      * @param zipper
      *            a function that, when applied to an item emitted by each of the {@code ObservableSource}s, results in
      *            an item that will be emitted by the resulting {@code Observable}
-     * @param delayError
-     *            delay errors signaled by any of the {@code ObservableSource} until all {@code ObservableSource}s terminate
-     * @param bufferSize
-     *            the number of elements expected from each source {@code ObservableSource} to be buffered
      * @param <T> the common source value type
      * @param <R> the zipped result type
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} or {@code zipper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code sources} or {@code zipper} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T, @NonNull R> Observable<R> zip(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources,
-            @NonNull Function<? super Object[], ? extends R> zipper, boolean delayError,
-            int bufferSize) {
+            @NonNull ObservableZipConfig config,
+            @NonNull Function<? super Object[], ? extends R> zipper
+    ) {
         Objects.requireNonNull(zipper, "zipper is null");
         Objects.requireNonNull(sources, "sources is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, bufferSize, delayError));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableZip<>(null, sources, zipper, config.bufferSize(), config.delayError()));
     }
 
     /**
@@ -3530,7 +3382,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2);
+        return zip(source1, source2, ObservableZipConfig.DEFAULT, zipper);
     }
 
     /**
@@ -3574,81 +3426,26 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param zipper
      *            a function that, when applied to an item emitted by each of the {@code ObservableSource}s, results
      *            in an item that will be emitted by the resulting {@code Observable}
-     * @param delayError delay errors from any of the {@code ObservableSource}s till the other terminates
+     * @param config the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code zipper} is {@code null}
+     * @throws NullPointerException if {@code source1}, {@code source2} or {@code zipper} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public static <@NonNull T1, @NonNull T2, @NonNull R> Observable<R> zip(
             @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
-            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError) {
+            @NonNull ObservableZipConfig config,
+            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper) {
         Objects.requireNonNull(source1, "source1 is null");
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), delayError, bufferSize(), source1, source2);
-    }
-
-    /**
-     * Returns an {@code Observable} that emits the results of a specified combiner function applied to combinations of
-     * two items emitted, in sequence, by two other {@link ObservableSource}s.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.v3.png" alt="">
-     * <p>
-     * {@code zip} applies this function in strict sequence, so the first item emitted by the resulting {@code Observable}
-     * will be the result of the function applied to the first item emitted by {@code o1} and the first item
-     * emitted by {@code o2}; the second item emitted by the resulting {@code Observable} will be the result of the function
-     * applied to the second item emitted by {@code o1} and the second item emitted by {@code o2}; and so forth.
-     * <p>
-     * The resulting {@code Observable<R>} returned from {@code zip} will invoke {@link Observer#onNext onNext}
-     * as many times as the number of {@code onNext} invocations of the {@code ObservableSource} that emits the fewest
-     * items.
-     * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
-     * is possible those other sources will never be able to run to completion (and thus not calling
-     * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
-     * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>zip(range(1, 5).doOnComplete(action1), range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
-     * {@code action1} will be called but {@code action2} won't.
-     * <br>To work around this termination property,
-     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
-     * or a dispose() call.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zip} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <T1> the value type of the first source
-     * @param <T2> the value type of the second source
-     * @param <R> the zipped result type
-     * @param source1
-     *            the first source {@code ObservableSource}
-     * @param source2
-     *            a second source {@code ObservableSource}
-     * @param zipper
-     *            a function that, when applied to an item emitted by each of the {@code ObservableSource}s, results
-     *            in an item that will be emitted by the resulting {@code Observable}
-     * @param delayError delay errors from any of the {@code ObservableSource}s till the other terminates
-     * @param bufferSize the number of elements expected from each source {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code source1}, {@code source2} or {@code zipper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public static <@NonNull T1, @NonNull T2, @NonNull R> Observable<R> zip(
-            @NonNull ObservableSource<? extends T1> source1, @NonNull ObservableSource<? extends T2> source2,
-            @NonNull BiFunction<? super T1, ? super T2, ? extends R> zipper, boolean delayError, int bufferSize) {
-        Objects.requireNonNull(source1, "source1 is null");
-        Objects.requireNonNull(source2, "source2 is null");
-        Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), delayError, bufferSize, source1, source2);
+        Objects.requireNonNull(config, "config is null");
+        return zipArray(new Observable<?>[] {
+                (Observable<?>) source1, (Observable<?>) source2 },
+                config, Functions.toFunction(zipper));
     }
 
     /**
@@ -3711,7 +3508,9 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source2, "source2 is null");
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3 },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -3779,7 +3578,11 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source3, "source3 is null");
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -3851,7 +3654,11 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source4, "source4 is null");
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4, (Observable<?>) source5
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -3926,7 +3733,11 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source5, "source5 is null");
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4, (Observable<?>) source5, (Observable<?>) source6
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -4007,7 +3818,12 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source6, "source6 is null");
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4, (Observable<?>) source5, (Observable<?>) source6,
+            (Observable<?>) source7
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -4092,7 +3908,12 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source7, "source7 is null");
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4, (Observable<?>) source5, (Observable<?>) source6,
+            (Observable<?>) source7, (Observable<?>) source8
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -4181,7 +4002,12 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(source8, "source8 is null");
         Objects.requireNonNull(source9, "source9 is null");
         Objects.requireNonNull(zipper, "zipper is null");
-        return zipArray(Functions.toFunction(zipper), false, bufferSize(), source1, source2, source3, source4, source5, source6, source7, source8, source9);
+        return zipArray(new Observable<?>[] {
+            (Observable<?>) source1, (Observable<?>) source2, (Observable<?>) source3,
+            (Observable<?>) source4, (Observable<?>) source5, (Observable<?>) source6,
+            (Observable<?>) source7, (Observable<?>) source8, (Observable<?>) source9
+            },
+            ObservableZipConfig.DEFAULT, Functions.toFunction(zipper));
     }
 
     /**
@@ -4224,33 +4050,30 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param <R> the result type
      * @param sources
      *            an array of source {@code ObservableSource}s
+     * @param config
+     *            the configuration record for this operator
      * @param zipper
      *            a function that, when applied to an item emitted by each of the {@code ObservableSource}s, results in
      *            an item that will be emitted by the resulting {@code Observable}
-     * @param delayError
-     *            delay errors signaled by any of the {@code ObservableSource} until all {@code ObservableSource}s terminate
-     * @param bufferSize
-     *            the number of elements expected from each source {@code ObservableSource} to be buffered
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code sources} or {@code zipper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code sources} or {@code zipper} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
-    @SafeVarargs
     @NonNull
     public static <@NonNull T, @NonNull R> Observable<R> zipArray(
-            @NonNull Function<? super Object[], ? extends R> zipper,
-            boolean delayError, int bufferSize,
-            @NonNull ObservableSource<? extends T>... sources) {
+            @NonNull ObservableSource<? extends T>[] sources,
+            @NonNull ObservableZipConfig config,
+            @NonNull Function<? super Object[], ? extends R> zipper
+    ) {
         Objects.requireNonNull(sources, "sources is null");
         if (sources.length == 0) {
             return empty();
         }
         Objects.requireNonNull(zipper, "zipper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableZip<>(sources, null, zipper, bufferSize, delayError));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableZip<>(sources, null, zipper, config.bufferSize(), config.delayError()));
     }
 
     // ***************************************************************************************************
@@ -15640,68 +15463,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param zipper
      *            a function that combines the pairs of items from the current {@code Observable} and the other {@code ObservableSource} to generate the items to
      *            be emitted by the resulting {@code Observable}
-     * @param delayError
-     *            if {@code true}, errors from the current {@code Observable} or the other {@code ObservableSource} is delayed until both terminate
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code other} or {@code zipper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
-     * @since 2.0
+     * @throws NullPointerException if {@code other} or {@code zipper} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull U, @NonNull R> Observable<R> zipWith(@NonNull ObservableSource<? extends U> other,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError) {
-        return zip(this, other, zipper, delayError);
-    }
-
-    /**
-     * Returns an {@code Observable} that emits items that are the result of applying a specified function to pairs of
-     * values, one each from the current {@code Observable} and another specified {@link ObservableSource}.
-     * <p>
-     * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/zip.v3.png" alt="">
-     * <p>
-     * The operator subscribes to its sources in order they are specified and completes eagerly if
-     * one of the sources is shorter than the rest while disposing the other sources. Therefore, it
-     * is possible those other sources will never be able to run to completion (and thus not calling
-     * {@code doOnComplete()}). This can also happen if the sources are exactly the same length; if
-     * source A completes and B has been consumed and is about to complete, the operator detects A won't
-     * be sending further values and it will dispose B immediately. For example:
-     * <pre><code>range(1, 5).doOnComplete(action1).zipWith(range(6, 5).doOnComplete(action2), (a, b) -&gt; a + b)</code></pre>
-     * {@code action1} will be called but {@code action2} won't.
-     * <br>To work around this termination property,
-     * use {@link #doOnDispose(Action)} as well or use {@code using()} to do cleanup in case of completion
-     * or a dispose() call.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code zipWith} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <U>
-     *            the type of items emitted by the {@code other} {@code ObservableSource}
-     * @param <R>
-     *            the type of items emitted by the resulting {@code Observable}
-     * @param other
-     *            the other {@code ObservableSource}
-     * @param zipper
-     *            a function that combines the pairs of items from the current {@code Observable} and the other {@code ObservableSource} to generate the items to
-     *            be emitted by the resulting {@code Observable}
-     * @param bufferSize
-     *            the capacity hint for the buffer in the inner windows
-     * @param delayError
-     *            if {@code true}, errors from the current {@code Observable} or the other {@code ObservableSource} is delayed until both terminate
-     * @return the new {@code Observable} instance
-     * @see <a href="http://reactivex.io/documentation/operators/zip.html">ReactiveX operators documentation: Zip</a>
-     * @throws NullPointerException if {@code other} or {@code zipper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull U, @NonNull R> Observable<R> zipWith(@NonNull ObservableSource<? extends U> other,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper, boolean delayError, int bufferSize) {
-        return zip(this, other, zipper, delayError, bufferSize);
+            @NonNull ObservableZipConfig config,
+            @NonNull BiFunction<? super T, ? super U, ? extends R> zipper) {
+        return zip(this, other, config, zipper);
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/CompletableMergeConfig.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.rxjava4.core.config;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
@@ -39,7 +39,7 @@ public record CompletableMergeConfig(boolean delayErrors, int maxConcurrency) {
      * @param delayErrors should the error propagation be delayed?
      */
     public CompletableMergeConfig(boolean delayErrors) {
-        this(delayErrors, 2);
+        this(delayErrors, Flowable.bufferSize());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/MaybeConcatEagerConfig.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.rxjava4.core.config;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
@@ -40,7 +40,7 @@ public record MaybeConcatEagerConfig(boolean delayError, int maxConcurrency, int
      * @param delayError should the error propagation be delayed?
      */
     public MaybeConcatEagerConfig(boolean delayError) {
-        this(delayError, 2, 2);
+        this(delayError, Flowable.bufferSize(), Flowable.bufferSize());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableCombineLatestConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableCombineLatestConfig.java
@@ -56,6 +56,6 @@ public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) 
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
     public ObservableCombineLatestConfig {
-        ObjectHelper.verifyPositive(bufferSize, "prefetch");
+        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import java.util.Objects;
+
+import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.functions.BiPredicate;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+/**
+ * Configuration record for Observable.sequenceEqual() operators.
+ * @param <T> the element type of the sequences being compared
+ * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
+ * @param isEqual the custom lambda to compare two elements
+ * @since 4.0.0
+ */
+public record ObservableSequenceEqualConfig<T>(int bufferSize, BiPredicate<? super T, ? super T> isEqual) {
+
+    /**
+     * The default configuration with bufferSize of Observable.bufferSize() and a default Objects.equals predicate.
+     */
+    public static final ObservableSequenceEqualConfig<Object> DEFAULT =
+            new ObservableSequenceEqualConfig<>(Observable.bufferSize(), ObjectHelper.equalsPredicate());
+
+    /**
+     * Constructs a configuration record.
+     * @param bufferSize the expected number of row combination items to be buffered internally
+     */
+    public ObservableSequenceEqualConfig(int bufferSize) {
+        this(bufferSize, ObjectHelper.equalsPredicate());
+    }
+
+    /**
+     * Constructs a configuration record.
+ * @param isEqual the custom lambda to compare two elements
+     */
+    public ObservableSequenceEqualConfig(BiPredicate<? super T, ? super T> isEqual) {
+        this(Observable.bufferSize(), isEqual);
+    }
+
+    /**
+     * Constructs a configuration record.
+     * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
+     * @param isEqual the custom lambda to compare two elements
+     */
+    public ObservableSequenceEqualConfig {
+        ObjectHelper.verifyPositive(bufferSize, "prefetch");
+        Objects.requireNonNull(isEqual, "isEqual is null");
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfig.java
@@ -56,7 +56,7 @@ public record ObservableSequenceEqualConfig<T>(int bufferSize, BiPredicate<? sup
      * @param isEqual the custom lambda to compare two elements
      */
     public ObservableSequenceEqualConfig {
-        ObjectHelper.verifyPositive(bufferSize, "prefetch");
+        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
         Objects.requireNonNull(isEqual, "isEqual is null");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfig.java
@@ -56,6 +56,6 @@ public record ObservableSwitchConfig(boolean delayError, int bufferSize) {
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
     public ObservableSwitchConfig {
-        ObjectHelper.verifyPositive(bufferSize, "prefetch");
+        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfig.java
@@ -17,36 +17,36 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Configuration record for Observable.combineLatest() operators.
+ * Configuration record for Observable.switchOnNext() operators.
  * @param delayError should the error propagation be delayed?
- * @param bufferSize the expected number of row combination items to be buffered internally
+ * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
  * @since 4.0.0
  */
-public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) {
+public record ObservableSwitchConfig(boolean delayError, int bufferSize) {
 
     /**
      * The default configuration with no error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableCombineLatestConfig DEFAULT = new ObservableCombineLatestConfig(false, Observable.bufferSize());
+    public static final ObservableSwitchConfig DEFAULT = new ObservableSwitchConfig(false, Observable.bufferSize());
 
     /**
-     * The default configuration with error delays and  bufferSize of Observable.bufferSize().
+     * The default configuration with error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableCombineLatestConfig DELAY_ERROR = new ObservableCombineLatestConfig(true, Observable.bufferSize());
+    public static final ObservableSwitchConfig DELAY_ERROR = new ObservableSwitchConfig(true, Observable.bufferSize());
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
      */
-    public ObservableCombineLatestConfig(boolean delayError) {
-        this(delayError, 2);
+    public ObservableSwitchConfig(boolean delayError) {
+        this(delayError, Observable.bufferSize());
     }
 
     /**
      * Constructs a configuration record.
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
-    public ObservableCombineLatestConfig(int bufferSize) {
+    public ObservableSwitchConfig(int bufferSize) {
         this(false, bufferSize);
     }
 
@@ -55,7 +55,7 @@ public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) 
      * @param delayError should the error propagation be delayed?
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
-    public ObservableCombineLatestConfig {
+    public ObservableSwitchConfig {
         ObjectHelper.verifyPositive(bufferSize, "prefetch");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableZipConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableZipConfig.java
@@ -56,6 +56,6 @@ public record ObservableZipConfig(boolean delayError, int bufferSize) {
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
     public ObservableZipConfig {
-        ObjectHelper.verifyPositive(bufferSize, "prefetch");
+        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableZipConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableZipConfig.java
@@ -17,36 +17,36 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Configuration record for Observable.combineLatest() operators.
+ * Configuration record for Observable.zip() operators.
  * @param delayError should the error propagation be delayed?
- * @param bufferSize the expected number of row combination items to be buffered internally
+ * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
  * @since 4.0.0
  */
-public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) {
+public record ObservableZipConfig(boolean delayError, int bufferSize) {
 
     /**
      * The default configuration with no error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableCombineLatestConfig DEFAULT = new ObservableCombineLatestConfig(false, Observable.bufferSize());
+    public static final ObservableZipConfig DEFAULT = new ObservableZipConfig(false, Observable.bufferSize());
 
     /**
-     * The default configuration with error delays and  bufferSize of Observable.bufferSize().
+     * The default configuration with error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableCombineLatestConfig DELAY_ERROR = new ObservableCombineLatestConfig(true, Observable.bufferSize());
+    public static final ObservableZipConfig DELAY_ERROR = new ObservableZipConfig(true, Observable.bufferSize());
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
      */
-    public ObservableCombineLatestConfig(boolean delayError) {
-        this(delayError, 2);
+    public ObservableZipConfig(boolean delayError) {
+        this(delayError, Observable.bufferSize());
     }
 
     /**
      * Constructs a configuration record.
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
-    public ObservableCombineLatestConfig(int bufferSize) {
+    public ObservableZipConfig(int bufferSize) {
         this(false, bufferSize);
     }
 
@@ -55,7 +55,7 @@ public record ObservableCombineLatestConfig(boolean delayError, int bufferSize) 
      * @param delayError should the error propagation be delayed?
      * @param bufferSize the expected number of row combination items to be buffered internally
      */
-    public ObservableCombineLatestConfig {
+    public ObservableZipConfig {
         ObjectHelper.verifyPositive(bufferSize, "prefetch");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/SingleConcatEagerConfig.java
@@ -13,7 +13,7 @@
 
 package io.reactivex.rxjava4.core.config;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
@@ -40,7 +40,7 @@ public record SingleConcatEagerConfig(boolean delayError, int maxConcurrency, in
      * @param delayError should the error propagation be delayed?
      */
     public SingleConcatEagerConfig(boolean delayError) {
-        this(delayError, 2, 2);
+        this(delayError, Flowable.bufferSize(), Flowable.bufferSize());
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableSequenceEqualConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.functions.BiPredicate;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
+
+public class ObservableSequenceEqualConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        BiPredicate<Object, Object> predicate = Objects::equals;
+
+        assertEquals(5, new ObservableSequenceEqualConfig<>(5).bufferSize(), "bufferSize - 5");
+        assertEquals(ObjectHelper.equalsPredicate(), new ObservableSequenceEqualConfig<>(5).isEqual(), "isEqual - std");
+        assertEquals(5, new ObservableSequenceEqualConfig<>(5, predicate).bufferSize(), "bufferSize - 5");
+        assertEquals(predicate, new ObservableSequenceEqualConfig<>(5, predicate).isEqual(), "isEqual - custom");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableSwitchConfigTest.java
@@ -18,16 +18,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ObservableCombineLatestConfigTest extends RxJavaTest {
+public class ObservableSwitchConfigTest extends RxJavaTest {
 
     @Test
     public void validation() {
-        assertTrue(new ObservableSwitchConfig(true).delayError(), "delayError - true");
-        assertFalse(new ObservableSwitchConfig(false).delayError(), "delayError - false");
-        assertEquals(5, new ObservableSwitchConfig(5).bufferSize(), "bufferSize - 5");
-        assertEquals(5, new ObservableSwitchConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
-        assertEquals(5, new ObservableSwitchConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
-        assertTrue(new ObservableSwitchConfig(true, 5).delayError(), "delayError both - true, 5");
-        assertFalse(new ObservableSwitchConfig(false, 5).delayError(), "delayError both - false, 5");
+        assertTrue(new ObservableCombineLatestConfig(true).delayError(), "delayError - true");
+        assertFalse(new ObservableCombineLatestConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new ObservableCombineLatestConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableCombineLatestConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
+        assertEquals(5, new ObservableCombineLatestConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
+        assertTrue(new ObservableCombineLatestConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new ObservableCombineLatestConfig(false, 5).delayError(), "delayError both - false, 5");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableZipConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableZipConfigTest.java
@@ -18,16 +18,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ObservableCombineLatestConfigTest extends RxJavaTest {
+public class ObservableZipConfigTest extends RxJavaTest {
 
     @Test
     public void validation() {
-        assertTrue(new ObservableSwitchConfig(true).delayError(), "delayError - true");
-        assertFalse(new ObservableSwitchConfig(false).delayError(), "delayError - false");
-        assertEquals(5, new ObservableSwitchConfig(5).bufferSize(), "bufferSize - 5");
-        assertEquals(5, new ObservableSwitchConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
-        assertEquals(5, new ObservableSwitchConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
-        assertTrue(new ObservableSwitchConfig(true, 5).delayError(), "delayError both - true, 5");
-        assertFalse(new ObservableSwitchConfig(false, 5).delayError(), "delayError both - false, 5");
+        assertTrue(new ObservableZipConfig(true).delayError(), "delayError - true");
+        assertFalse(new ObservableZipConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new ObservableZipConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableZipConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
+        assertEquals(5, new ObservableZipConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
+        assertTrue(new ObservableZipConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new ObservableZipConfig(false, 5).delayError(), "delayError both - false, 5");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqualTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSequenceEqualTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableSequenceEqualConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.PublishSubject;
@@ -106,9 +107,9 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
     public void withEqualityErrorObservable() {
         Observable<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one"), Observable.just("one"),
-                (_, _) -> {
+                new ObservableSequenceEqualConfig<>((_, _) -> {
                     throw new TestException();
-                }).toObservable();
+                })).toObservable();
         verifyError(o);
     }
 
@@ -142,7 +143,7 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void prefetchObservable() {
-        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
+        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), new ObservableSequenceEqualConfig<>(2))
         .toObservable()
         .test()
         .assertResult(true);
@@ -232,9 +233,9 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
     public void withEqualityError() {
         Single<Boolean> o = Observable.sequenceEqual(
                 Observable.just("one"), Observable.just("one"),
-                (_, _) -> {
+                new ObservableSequenceEqualConfig<>((_, _) -> {
                     throw new TestException();
-                });
+                }));
         verifyError(o);
     }
 
@@ -251,7 +252,7 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
 
     @Test
     public void prefetch() {
-        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), 2)
+        Observable.sequenceEqual(Observable.range(1, 20), Observable.range(1, 20), new ObservableSequenceEqualConfig<>(2))
         .test()
         .assertResult(true);
     }
@@ -343,14 +344,14 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
         PublishSubject<Integer> ps1 = PublishSubject.create();
         PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Boolean> to = Observable.sequenceEqual(ps1, ps2, (a, b) -> {
+        TestObserver<Boolean> to = Observable.sequenceEqual(ps1, ps2, new ObservableSequenceEqualConfig<>((a, b) -> {
             ps1.onNext(1);
             ps1.onComplete();
 
             ps2.onNext(1);
             ps2.onComplete();
             return a.equals(b);
-        })
+        }))
         .test()
         ;
 
@@ -365,14 +366,14 @@ public class ObservableSequenceEqualTest extends RxJavaTest {
         PublishSubject<Integer> ps1 = PublishSubject.create();
         PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Boolean> to = Observable.sequenceEqual(ps1, ps2, (a, b) -> {
+        TestObserver<Boolean> to = Observable.sequenceEqual(ps1, ps2, new ObservableSequenceEqualConfig<>((a, b) -> {
             ps1.onNext(1);
             ps1.onComplete();
 
             ps2.onNext(1);
             ps2.onComplete();
             return a.equals(b);
-        })
+        }))
         .toObservable()
         .test()
         ;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -28,6 +28,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
+import io.reactivex.rxjava4.core.config.ObservableSwitchConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -432,7 +433,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void switchOnNextDelayError() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps).test();
+        TestObserver<Integer> to = Observable.switchOnNext(ps, ObservableSwitchConfig.DELAY_ERROR).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.range(2, 4));
@@ -445,7 +446,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void switchOnNextDelayErrorWithError() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps).test();
+        TestObserver<Integer> to = Observable.switchOnNext(ps, ObservableSwitchConfig.DELAY_ERROR).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.<Integer>error(new TestException()));
@@ -459,7 +460,7 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void switchOnNextDelayErrorBufferSize() {
         PublishSubject<Observable<Integer>> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = Observable.switchOnNextDelayError(ps, 2).test();
+        TestObserver<Integer> to = Observable.switchOnNext(ps, new ObservableSwitchConfig(true, 2)).test();
 
         ps.onNext(Observable.just(1));
         ps.onNext(Observable.range(2, 4));
@@ -565,7 +566,7 @@ public class ObservableSwitchTest extends RxJavaTest {
 
     @Test
     public void scalarMapDelayError() {
-        Observable.switchOnNextDelayError(Observable.just(Observable.just(1)))
+        Observable.switchOnNext(Observable.just(Observable.just(1)), ObservableSwitchConfig.DELAY_ERROR)
         .test()
         .assertResult(1);
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableZipTest.java
@@ -27,7 +27,8 @@ import org.mockito.InOrder;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.core.config.ObservableZipConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
@@ -1068,7 +1069,8 @@ public class ObservableZipTest extends RxJavaTest {
     public void zip2DelayError() {
         Observable.zip(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())),
                 Observable.just(2),
-                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, true
+                ObservableZipConfig.DELAY_ERROR,
+                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b
         )
         .test()
         .assertFailure(TestException.class, "12");
@@ -1078,7 +1080,8 @@ public class ObservableZipTest extends RxJavaTest {
     public void zip2Prefetch() {
         Observable.zip(Observable.range(1, 9),
                 Observable.range(21, 9),
-                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, false, 2
+                new ObservableZipConfig(2),
+                (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b
         )
         .takeLast(1)
         .test()
@@ -1089,7 +1092,8 @@ public class ObservableZipTest extends RxJavaTest {
     public void zip2DelayErrorPrefetch() {
         Observable.zip(Observable.range(1, 9).concatWith(Observable.<Integer>error(new TestException())),
                 Observable.range(21, 9),
-                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b, true, 2
+                new ObservableZipConfig(true, 2),
+                        (BiFunction<Integer, Integer, Object>) (a, b) -> "" + a + b
         )
         .skip(8)
         .test()
@@ -1098,7 +1102,8 @@ public class ObservableZipTest extends RxJavaTest {
 
     @Test
     public void zipArrayEmpty() {
-        assertSame(Observable.empty(), Observable.zipArray(Functions.<Object[]>identity(), false, 16));
+        assertSame(Observable.empty(), Observable.zipArray(
+                new Observable<?>[0], new ObservableZipConfig(false, 16), Functions.<Object[]>identity()));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
+++ b/src/test/java/io/reactivex/rxjava4/observable/ObservableZipTests.java
@@ -21,6 +21,7 @@ import org.junit.*;
 
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.core.config.ObservableZipConfig;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observable.ObservableCovarianceTest.*;
 import io.reactivex.rxjava4.observable.ObservableEventStream.Event;
@@ -102,7 +103,7 @@ public class ObservableZipTests extends RxJavaTest {
     @Test
     public void zipWithDelayError() {
         Observable.just(1)
-        .zipWith(Observable.just(2), Integer::sum, true)
+        .zipWith(Observable.just(2), ObservableZipConfig.DELAY_ERROR, Integer::sum)
         .test()
         .assertResult(3);
     }
@@ -110,7 +111,7 @@ public class ObservableZipTests extends RxJavaTest {
     @Test
     public void zipWithDelayErrorBufferSize() {
         Observable.just(1)
-        .zipWith(Observable.just(2), Integer::sum, true, 16)
+        .zipWith(Observable.just(2), new ObservableZipConfig(true, 16), Integer::sum)
         .test()
         .assertResult(3);
     }

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -632,6 +632,9 @@ public class CheckParamValidationTest extends RxJavaTest {
         defaultValues.put(ObservableConcatConfig.class, ObservableConcatConfig.DEFAULT);
         defaultValues.put(ObservableMergeConfig.class, ObservableMergeConfig.DEFAULT);
         defaultValues.put(ObservableConcatEagerConfig.class, ObservableConcatEagerConfig.DEFAULT);
+        defaultValues.put(ObservableSwitchConfig.class, ObservableSwitchConfig.DEFAULT);
+        defaultValues.put(ObservableSequenceEqualConfig.class, ObservableSequenceEqualConfig.DEFAULT);
+        defaultValues.put(ObservableZipConfig.class, ObservableZipConfig.DEFAULT);
 
         // TODO insert new config record types here
 


### PR DESCRIPTION
Introduce

- `ObservableSwitchConfig`
- `ObservableSequenceEqualConfig`
- `ObservableZipConfig`

Remove

- `delayError` and/or `bufferSize` overloads of `switchOnNext`, `sequenceEqual` and `zip`
- `xxxDelayError` operators.

Correct

- Javadocs of configuration records
- Default values for certain operator configs.
-  Copy-paste errors.

Related: #8173