### PR TITLE
4.x: Cleanup API reduction: concat { Array, Eager, XYZ }

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/ErrorMode.java
+++ b/src/main/java/io/reactivex/rxjava4/core/ErrorMode.java
@@ -14,11 +14,15 @@
 package io.reactivex.rxjava4.core;
 
 /**
- * Indicates when an error from the main source should be reported.
+ * Indicates when an error from the any of the involved sources should be handled.
+ * <p>
+ * Usually appears with {@code concat} and {@code concatMap} operators where the outer and inner source(s)
+ * may error out in the middle of streaming and the user would like to finish the current source before
+ * cancelling the rest and signaling the error(s) to the consumers.
  * @since 4.0.0
  */
 public enum ErrorMode {
-    /** Report the error immediately, cancelling the active inner source. */
+    /** Report the error immediately, cancelling the active sources. */
     IMMEDIATE,
     /** Report error after an inner source terminated. */
     BOUNDARY,

--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -1084,11 +1084,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SafeVarargs
     public static <@NonNull T> Observable<T> concatArrayEager(@NonNull ObservableConcatEagerConfig config, @NonNull ObservableSource<? extends T>... sources) {
         Objects.requireNonNull(config, "config is null");
-        if (config.errorMode() == ErrorMode.IMMEDIATE) {
-            return fromArray(sources).concatMapEager((Function)Functions.identity(), config.maxConcurrency(), config.bufferSize());
-        }
-        return fromArray(sources).concatMapEagerDelayError((Function)Functions.identity(),
-                config.errorMode() == ErrorMode.END, config.maxConcurrency(), config.bufferSize());
+        return fromArray(sources).concatMapEager((Function)Functions.identity(), config);
     }
 
     /**
@@ -1143,11 +1139,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     public static <@NonNull T> Observable<T> concatEager(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources,
                                                          @NonNull ObservableConcatEagerConfig config) {
         Objects.requireNonNull(config, "config is null");
-        if (config.errorMode() == ErrorMode.IMMEDIATE) {
-            return fromIterable(sources).concatMapEager((Function)Functions.identity(), config.maxConcurrency(), config.bufferSize());
-        }
-        return fromIterable(sources).concatMapEagerDelayError((Function)Functions.identity(),
-                config.errorMode() == ErrorMode.END, config.maxConcurrency(), config.bufferSize());
+        return fromIterable(sources).concatMapEager((Function)Functions.identity(), config);
     }
 
     /**
@@ -1203,10 +1195,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     public static <@NonNull T> Observable<T> concatEager(@NonNull ObservableSource<? extends ObservableSource<? extends T>> sources,
                                                          @NonNull ObservableConcatEagerConfig config) {
         Objects.requireNonNull(config, "config is null");
-        if (config.errorMode() == ErrorMode.IMMEDIATE) {
-            return wrap(sources).concatMapEager((Function) Functions.identity(), config.maxConcurrency(), config.bufferSize());
-        }
-        return wrap(sources).concatMapEagerDelayError((Function) Functions.identity(), config.errorMode() == ErrorMode.END,  config.maxConcurrency(), config.bufferSize());
+        return wrap(sources).concatMapEager((Function) Functions.identity(), config);
     }
 
     /**
@@ -5542,7 +5531,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
      * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, int, Scheduler)} overload.
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, Scheduler, ObservableConcatMapConfig)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -5555,13 +5544,13 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #concatMap(Function, int, Scheduler)
+     * @see #concatMap(Function, Scheduler, ObservableConcatMapConfig)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return concatMap(mapper, 2);
+        return concatMap(mapper, ObservableConcatMapConfig.DEFAULT);
     }
 
     /**
@@ -5573,7 +5562,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
      * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, int, Scheduler)} overload.
+     * the {@code mapper} function is confined to a known thread, use the {@link #concatMap(Function, Scheduler, ObservableConcatMapConfig)} overload.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMap} does not operate by default on a particular {@link Scheduler}.</dd>
@@ -5583,20 +5572,22 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
      *            {@code ObservableSource}
-     * @param bufferSize
-     *            the number of elements expected from the current {@code Observable} to be buffered
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
      * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #concatMap(Function, int, Scheduler)
+     * @see #concatMap(Function, Scheduler, ObservableConcatMapConfig)
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
+    public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+            @NonNull ObservableConcatMapConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        Objects.requireNonNull(config, "config is null");
         if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarSupplier<T>)this).get();
@@ -5605,7 +5596,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableConcatMap<>(this, mapper, bufferSize, ErrorMode.IMMEDIATE));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMap<>(this, mapper, config.bufferSize(), config.errorMode()));
     }
 
     /**
@@ -5615,7 +5606,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.v3.png" alt="">
      * <p>
-     * The difference between {@link #concatMap(Function, int)} and this operator is that this operator guarantees the {@code mapper}
+     * The difference between {@link #concatMap(Function, ObservableConcatMapConfig)} and this operator is that this operator guarantees the {@code mapper}
      * function is executed on the specified scheduler.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
@@ -5626,138 +5617,25 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
      *            {@code ObservableSource}
-     * @param bufferSize
-     *            the number of elements expected from the current {@code Observable} to be buffered
      * @param scheduler
      *            the scheduler where the {@code mapper} function will be executed
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} or {@code scheduler} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @since 3.0.0
+     * @throws NullPointerException if {@code mapper} or {@code scheduler} or {@code config} is {@code null}
+     * @since 4.0.0
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final <@NonNull R> Observable<R> concatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            int bufferSize, @NonNull Scheduler scheduler) {
+            @NonNull Scheduler scheduler,
+            @NonNull ObservableConcatMapConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        Objects.requireNonNull(config, "config is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<>(this, mapper, bufferSize, ErrorMode.IMMEDIATE, scheduler));
-    }
-
-    /**
-     * Maps each of the items into an {@link ObservableSource}, subscribes to them one after the other,
-     * one at a time and emits their values in order
-     * while delaying any error from either this or any of the inner {@code ObservableSource}s
-     * till all of them terminate.
-     * <p>
-     * <img width="640" height="348" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapDelayError.o.png" alt="">
-     * <p>
-     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
-     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, boolean, int, Scheduler)} overload.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the result value type
-     * @param mapper the function that maps the items of the current {@code Observable} into the inner {@code ObservableSource}s.
-     * @return the new {@code Observable} instance with the concatenation behavior
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapDelayError(Function, boolean, int, Scheduler)
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return concatMapDelayError(mapper, true, bufferSize());
-    }
-
-    /**
-     * Maps each of the items into an {@link ObservableSource}, subscribes to them one after the other,
-     * one at a time and emits their values in order
-     * while delaying any error from either this or any of the inner {@code ObservableSource}s
-     * till all of them terminate.
-     * <p>
-     * <img width="640" height="348" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapDelayError.o.png" alt="">
-     * <p>
-     * Note that there is no guarantee where the given {@code mapper} function will be executed; it could be on the subscribing thread,
-     * on the upstream thread signaling the new item to be mapped or on the thread where the inner source terminates. To ensure
-     * the {@code mapper} function is confined to a known thread, use the {@link #concatMapDelayError(Function, boolean, int, Scheduler)} overload.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the result value type
-     * @param mapper the function that maps the items of the current {@code Observable} into the inner {@code ObservableSource}s.
-     * @param tillTheEnd
-     *            if {@code true}, all errors from the outer and inner {@code ObservableSource} sources are delayed until the end,
-     *            if {@code false}, an error from the main source is signaled when the current {@code Observable} source terminates
-     * @param bufferSize
-     *            the number of elements expected from the current {@code Observable} to be buffered
-     * @return the new {@code Observable} instance with the concatenation behavior
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see #concatMapDelayError(Function, boolean, int, Scheduler)
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean tillTheEnd, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarSupplier) {
-            @SuppressWarnings("unchecked")
-            T v = ((ScalarSupplier<T>)this).get();
-            if (v == null) {
-                return empty();
-            }
-            return ObservableScalarXMap.scalarXMap(v, mapper);
-        }
-        return RxJavaPlugins.onAssembly(new ObservableConcatMap<>(this, mapper, bufferSize, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY));
-    }
-
-    /**
-     * Maps each of the items into an {@link ObservableSource}, subscribes to them one after the other,
-     * one at a time and emits their values in order
-     * while delaying any error from either this or any of the inner {@code ObservableSource}s
-     * till all of them terminate.
-     * <p>
-     * <img width="640" height="348" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapDelayError.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the result value type
-     * @param mapper the function that maps the items of the current {@code Observable} into the inner {@code ObservableSource}s.
-     * @param tillTheEnd
-     *            if {@code true}, all errors from the outer and inner {@code ObservableSource} sources are delayed until the end,
-     *            if {@code false}, an error from the main source is signaled when the current {@code Observable} source terminates
-     * @param bufferSize
-     *            the number of elements expected from the current {@code Observable} to be buffered
-     * @param scheduler
-     *            the scheduler where the {@code mapper} function will be executed
-     * @return the new {@code Observable} instance with the concatenation behavior
-     * @throws NullPointerException if {@code mapper} or {@code scheduler} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see #concatMapDelayError(Function, boolean, int)
-     * @since 3.0.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean tillTheEnd, int bufferSize, @NonNull Scheduler scheduler) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        Objects.requireNonNull(scheduler, "scheduler is null");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<>(this, mapper, bufferSize, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, scheduler));
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapScheduler<>(this, mapper, config.bufferSize(), config.errorMode(), scheduler));
     }
 
     /**
@@ -5784,7 +5662,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> concatMapEager(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return concatMapEager(mapper, Integer.MAX_VALUE, bufferSize());
+        return concatMapEager(mapper, ObservableConcatEagerConfig.MAX_DEFAULT);
     }
 
     /**
@@ -5803,92 +5681,21 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param <R> the value type
      * @param mapper the function that maps a sequence of values into a sequence of {@code ObservableSource}s that will be
      *               eagerly concatenated
-     * @param maxConcurrency the maximum number of concurrent subscribed {@code ObservableSource}s
-     * @param bufferSize hints about the number of expected items from each inner {@code ObservableSource}, must be positive
+     * @param config
+     *               the configuration record for this operator
      * @return the new {@code Observable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @since 2.0
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> concatMapEager(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            int maxConcurrency, int bufferSize) {
+            @NonNull ObservableConcatEagerConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<>(this, mapper, ErrorMode.IMMEDIATE, maxConcurrency, bufferSize));
-    }
-
-    /**
-     * Maps a sequence of values into {@link ObservableSource}s and concatenates these {@code ObservableSource}s eagerly into a single
-     * {@code Observable} sequence.
-     * <p>
-     * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * current {@code Observable}s. The operator buffers the values emitted by these {@code ObservableSource}s and then drains them in
-     * order, each one after the previous one completes.
-     * <p>
-     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapEagerDelayError.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <R> the value type
-     * @param mapper the function that maps a sequence of values into a sequence of {@code ObservableSource}s that will be
-     *               eagerly concatenated
-     * @param tillTheEnd
-     *            if {@code true}, all errors from the outer and inner {@code ObservableSource} sources are delayed until the end,
-     *            if {@code false}, an error from the main source is signaled when the current {@code Observable} source terminates
-     * @return the new {@code Observable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean tillTheEnd) {
-        return concatMapEagerDelayError(mapper, tillTheEnd, Integer.MAX_VALUE, bufferSize());
-    }
-
-    /**
-     * Maps a sequence of values into {@link ObservableSource}s and concatenates these {@code ObservableSource}s eagerly into a single
-     * {@code Observable} sequence.
-     * <p>
-     * Eager concatenation means that once a subscriber subscribes, this operator subscribes to all of the
-     * current {@code Observable}s. The operator buffers the values emitted by these {@code ObservableSource}s and then drains them in
-     * order, each one after the previous one completes.
-     * <p>
-     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapEagerDelayError.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>This method does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * @param <R> the value type
-     * @param mapper the function that maps a sequence of values into a sequence of {@code ObservableSource}s that will be
-     *               eagerly concatenated
-     * @param tillTheEnd
-     *               if {@code true}, exceptions from the current {@code Observable} and all the inner {@code ObservableSource}s are delayed until
-     *               all of them terminate, if {@code false}, exception from the current {@code Observable} is delayed until the
-     *               currently running {@code ObservableSource} terminates
-     * @param maxConcurrency the maximum number of concurrent subscribed {@code ObservableSource}s
-     * @param bufferSize
-     *               the number of elements expected from the current {@code Observable} and each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance with the specified concatenation behavior
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapEagerDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean tillTheEnd, int maxConcurrency, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, maxConcurrency, bufferSize));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapEager<>(this, mapper,
+                config.errorMode(), config.maxConcurrency(), config.bufferSize()));
     }
 
     /**
@@ -5911,7 +5718,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
-        return concatMapCompletable(mapper, 2);
+        return concatMapCompletable(mapper, ObservableConcatMapConfig.DEFAULT);
     }
 
     /**
@@ -5926,117 +5733,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <p>History: 2.1.6 - experimental
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns a {@code CompletableSource}
-     *
-     * @param capacityHint
-     *            the number of upstream items expected to be buffered until the current {@code CompletableSource}, mapped from
-     *            the current item, completes.
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@link Completable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code capacityHint} is non-positive
-     * @since 2.2
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, int capacityHint) {
+    public final Completable concatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper,
+            @NonNull ObservableConcatMapConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(capacityHint, "capacityHint");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, ErrorMode.IMMEDIATE, capacityHint));
-    }
-
-    /**
-     * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
-     * other terminates, delaying all errors till both the current {@code Observable} and all
-     * inner {@code CompletableSource}s terminate.
-     * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code CompletableSource} to become the next source to
-     *               be subscribed to
-     * @return the new {@link Completable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapCompletable(Function, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
-        return concatMapCompletableDelayError(mapper, true, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
-     * other terminates, optionally delaying all errors till both the current {@code Observable} and all
-     * inner {@code CompletableSource}s terminate.
-     * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code CompletableSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code CompletableSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code CompletableSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @return the new {@link Completable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapCompletable(Function)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd) {
-        return concatMapCompletableDelayError(mapper, tillTheEnd, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link CompletableSource}s and subscribes to them one after the
-     * other terminates, optionally delaying all errors till both the current {@code Observable} and all
-     * inner {@code CompletableSource}s terminate.
-     * <p>
-     * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMap.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code CompletableSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code CompletableSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code CompletableSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @param bufferSize The number of upstream items expected to be buffered so that fresh items are
-     *                 ready to be mapped when a previous {@code CompletableSource} terminates.
-     * @return the new {@link Completable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see #concatMapCompletable(Function, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final Completable concatMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean tillTheEnd, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, bufferSize));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapCompletable<>(this, mapper, config.errorMode(), config.bufferSize()));
     }
 
     /**
@@ -6084,15 +5794,14 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *               be subscribed to
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapMaybeDelayError(Function)
-     * @see #concatMapMaybe(Function, int)
+     * @see #concatMapMaybe(Function, ObservableConcatMapConfig)
      * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
-        return concatMapMaybe(mapper, 2);
+        return concatMapMaybe(mapper, ObservableConcatMapConfig.DEFAULT);
     }
 
     /**
@@ -6105,128 +5814,24 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code MaybeSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code MaybeSource} to become the next source to
      *               be subscribed to
-     * @param bufferSize The number of upstream items expected to be buffered so that fresh items are
-     *                 ready to be mapped when a previous {@code MaybeSource} terminates.
+     * @param config the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
      * @see #concatMapMaybe(Function)
-     * @see #concatMapMaybeDelayError(Function, boolean, int)
-     * @since 2.2
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, int bufferSize) {
+    public final <@NonNull R> Observable<R> concatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper,
+            @NonNull ObservableConcatMapConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, ErrorMode.IMMEDIATE, bufferSize));
-    }
-
-    /**
-     * Maps the upstream items into {@link MaybeSource}s and subscribes to them one after the
-     * other terminates, emits their success value if available and delaying all errors
-     * till both the current {@code Observable} and all inner {@code MaybeSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapMaybeDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code MaybeSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code MaybeSource} to become the next source to
-     *               be subscribed to
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapMaybe(Function)
-     * @see #concatMapMaybeDelayError(Function, boolean)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
-        return concatMapMaybeDelayError(mapper, true, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link MaybeSource}s and subscribes to them one after the
-     * other terminates, emits their success value if available and optionally delaying all errors
-     * till both the current {@code Observable} and all inner {@code MaybeSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapMaybeDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code MaybeSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code MaybeSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code MaybeSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code MaybeSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapMaybe(Function, int)
-     * @see #concatMapMaybeDelayError(Function, boolean, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd) {
-        return concatMapMaybeDelayError(mapper, tillTheEnd, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link MaybeSource}s and subscribes to them one after the
-     * other terminates, emits their success value if available and optionally delaying all errors
-     * till both the current {@code Observable} and all inner {@code MaybeSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapMaybeDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code MaybeSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code MaybeSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code MaybeSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code MaybeSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @param bufferSize The number of upstream items expected to be buffered so that fresh items are
-     *                 ready to be mapped when a previous {@code MaybeSource} terminates.
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see #concatMapMaybe(Function, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapMaybeDelayError(
-            @NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, bufferSize));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapMaybe<>(this, mapper, config.errorMode(), config.bufferSize()));
     }
 
     /**
@@ -6246,15 +5851,14 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *               be subscribed to
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapSingleDelayError(Function)
-     * @see #concatMapSingle(Function, int)
+     * @see #concatMapSingle(Function, ObservableConcatMapConfig)
      * @since 2.2
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
-        return concatMapSingle(mapper, 2);
+        return concatMapSingle(mapper, ObservableConcatMapConfig.DEFAULT);
     }
 
     /**
@@ -6267,128 +5871,24 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code concatMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
-     * <p>History: 2.1.11 - experimental
      * @param <R> the result type of the inner {@code SingleSource}s
      * @param mapper the function called with the upstream item and should return
      *               a {@code SingleSource} to become the next source to
      *               be subscribed to
-     * @param bufferSize The number of upstream items expected to be buffered so that fresh items are
-     *                 ready to be mapped when a previous {@code SingleSource} terminates.
+     * @param config the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
      * @see #concatMapSingle(Function)
-     * @see #concatMapSingleDelayError(Function, boolean, int)
-     * @since 2.2
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, int bufferSize) {
+    public final <@NonNull R> Observable<R> concatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper,
+            @NonNull ObservableConcatMapConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, ErrorMode.IMMEDIATE, bufferSize));
-    }
-
-    /**
-     * Maps the upstream items into {@link SingleSource}s and subscribes to them one after the
-     * other succeeds or fails, emits their success values and delays all errors
-     * till both the current {@code Observable} and all inner {@code SingleSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapSingleDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code SingleSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code SingleSource} to become the next source to
-     *               be subscribed to
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapSingle(Function)
-     * @see #concatMapSingleDelayError(Function, boolean)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
-        return concatMapSingleDelayError(mapper, true, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link SingleSource}s and subscribes to them one after the
-     * other succeeds or fails, emits their success values and optionally delays all errors
-     * till both the current {@code Observable} and all inner {@code SingleSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapSingleDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code SingleSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code SingleSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code SingleSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code SingleSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #concatMapSingle(Function, int)
-     * @see #concatMapSingleDelayError(Function, boolean, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd) {
-        return concatMapSingleDelayError(mapper, tillTheEnd, 2);
-    }
-
-    /**
-     * Maps the upstream items into {@link SingleSource}s and subscribes to them one after the
-     * other succeeds or fails, emits their success values and optionally delays  errors
-     * till both the current {@code Observable} and all inner {@code SingleSource}s terminate.
-     * <p>
-     * <img width="640" height="310" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/concatMapSingleDelayError.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code concatMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     * <p>History: 2.1.11 - experimental
-     * @param <R> the result type of the inner {@code SingleSource}s
-     * @param mapper the function called with the upstream item and should return
-     *               a {@code SingleSource} to become the next source to
-     *               be subscribed to
-     * @param tillTheEnd If {@code true}, errors from the current {@code Observable} or any of the
-     *                   inner {@code SingleSource}s are delayed until all
-     *                   of them terminate. If {@code false}, an error from the current
-     *                   {@code Observable} is delayed until the current inner
-     *                   {@code SingleSource} terminates and only then is
-     *                   it emitted to the downstream.
-     * @param bufferSize The number of upstream items expected to be buffered so that fresh items are
-     *                 ready to be mapped when a previous {@code SingleSource} terminates.
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see #concatMapSingle(Function, int)
-     * @since 2.2
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> concatMapSingleDelayError(
-            @NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean tillTheEnd, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, tillTheEnd ? ErrorMode.END : ErrorMode.BOUNDARY, bufferSize));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableConcatMapSingle<>(this, mapper, config.errorMode(), config.bufferSize()));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableConcatEagerConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableConcatEagerConfig.java
@@ -29,24 +29,29 @@ public record ObservableConcatEagerConfig(@NonNull ErrorMode errorMode, int maxC
     /**
      * The default configuration with no error delays, maxConcurrency and bufferSize of {@link Observable#bufferSize()}.
      */
-    public static final ObservableConcatEagerConfig DEFAULT = new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, Observable.bufferSize());
+    public static final ObservableConcatEagerConfig DEFAULT = new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE);
 
     /**
      * The default configuration with error delays, maxConcurrency and bufferSize of {@link Observable#bufferSize()}.
      */
-    public static final ObservableConcatEagerConfig DELAY_ERROR = new ObservableConcatEagerConfig(ErrorMode.END, Observable.bufferSize());
+    public static final ObservableConcatEagerConfig DELAY_ERROR = new ObservableConcatEagerConfig(ErrorMode.END);
 
     /**
      * The default configuration with error delays, maxConcurrency and bufferSize of {@link Observable#bufferSize()}.
      */
-    public static final ObservableConcatEagerConfig DELAY_ERROR_BOUNDARY = new ObservableConcatEagerConfig(ErrorMode.BOUNDARY, Observable.bufferSize());
+    public static final ObservableConcatEagerConfig DELAY_ERROR_BOUNDARY = new ObservableConcatEagerConfig(ErrorMode.BOUNDARY);
 
     /**
-     * Optionally delay error, {@link Flowable#bufferSize()} sizes
+     * The default configuration with no error delays, maxConcurrency of MAX_INT and bufferSize of {@link Observable#bufferSize()}.
+     */
+    public static final ObservableConcatEagerConfig MAX_DEFAULT = new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, Integer.MAX_VALUE);
+
+    /**
+     * Optionally delay error, {@link Observable#bufferSize()} sizes
      * @param errorMode how to handle when errors appear from the inner or outer sources
      */
     public ObservableConcatEagerConfig(ErrorMode errorMode) {
-        this(errorMode, Flowable.bufferSize(), Flowable.bufferSize());
+        this(errorMode, Observable.bufferSize(), Observable.bufferSize());
     }
 
     /**
@@ -54,7 +59,7 @@ public record ObservableConcatEagerConfig(@NonNull ErrorMode errorMode, int maxC
      * @param maxConcurrency the maximum number of concurrent flows
      */
     public ObservableConcatEagerConfig(int maxConcurrency) {
-        this(ErrorMode.IMMEDIATE, maxConcurrency, Flowable.bufferSize());
+        this(ErrorMode.IMMEDIATE, maxConcurrency, Observable.bufferSize());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfig.java
@@ -14,46 +14,45 @@
 package io.reactivex.rxjava4.core.config;
 
 import io.reactivex.rxjava4.annotations.NonNull;
-import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 import io.reactivex.rxjava4.core.ErrorMode;
 
 /**
- * Configuration record for Observable.concat() operators.
+ * Configuration record for Observable.concatMap() operators.
  * @param errorMode how to handle when errors appear from the inner or outer sources
  * @param bufferSize the expected number of outer sources to buffer while processing an inner source
  * @since 4.0.0
  */
-public record ObservableConcatConfig(@NonNull ErrorMode errorMode, int bufferSize) {
+public record ObservableConcatMapConfig(@NonNull ErrorMode errorMode, int bufferSize) {
 
     /**
-     * The default configuration with no error delays and bufferSize of {@link Observable#bufferSize()}.
+     * The default configuration with no error delays and bufferSize of 2.
      */
-    public static final ObservableConcatConfig DEFAULT = new ObservableConcatConfig(ErrorMode.IMMEDIATE);
+    public static final ObservableConcatMapConfig DEFAULT = new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 2);
 
     /**
-     * The default configuration with error delays till the end and bufferSize of {@link Observable#bufferSize()}.
+     * The default configuration with error delays till the end and bufferSize of 2.
      */
-    public static final ObservableConcatConfig DELAY_ERROR = new ObservableConcatConfig(ErrorMode.END);
+    public static final ObservableConcatMapConfig DELAY_ERROR = new ObservableConcatMapConfig(ErrorMode.END, 2);
 
     /**
-     * The default configuration with error delays till the boundary and bufferSize of {@link Observable#bufferSize()}.
+     * The default configuration with error delays till the boundary and bufferSize of 2.
      */
-    public static final ObservableConcatConfig DELAY_ERROR_BOUNDARY = new ObservableConcatConfig(ErrorMode.BOUNDARY);
+    public static final ObservableConcatMapConfig DELAY_ERROR_BOUNDARY = new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 2);
 
     /**
      * Constructs a configuration record.
      * @param errorMode how to handle when errors appear from the inner or outer sources
      */
-    public ObservableConcatConfig(@NonNull ErrorMode errorMode) {
-        this(errorMode, Observable.bufferSize());
+    public ObservableConcatMapConfig(@NonNull ErrorMode errorMode) {
+        this(errorMode, 2);
     }
 
     /**
      * Constructs a configuration record.
      * @param bufferSize the expected number of outer sources to buffer while processing an inner source
      */
-    public ObservableConcatConfig(int bufferSize) {
+    public ObservableConcatMapConfig(int bufferSize) {
         this(ErrorMode.IMMEDIATE, bufferSize);
     }
 
@@ -62,7 +61,7 @@ public record ObservableConcatConfig(@NonNull ErrorMode errorMode, int bufferSiz
      * @param errorMode how to handle when errors appear from the inner or outer sources
      * @param bufferSize the expected number of outer sources to buffer while processing an inner source
      */
-    public ObservableConcatConfig {
+    public ObservableConcatMapConfig {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatConfigTest.java
@@ -23,15 +23,15 @@ public class ObservableConcatConfigTest extends RxJavaTest {
 
     @Test
     public void validation() {
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - true");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - false");
-        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END).errorMode(), "errorMode - false");
-        assertEquals(5, new ObservableConcatConfig(5).bufferSize(), "bufferSize - 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - true, 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - false, 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - false, 5");
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - true, 5");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - false, 5");
-        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END, 5).errorMode(), "errorMode both - false, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
+        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END).errorMode(), "errorMode - END");
+        assertEquals(5, new ObservableConcatMapConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
+        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatConfigTest.java
@@ -23,15 +23,15 @@ public class ObservableConcatConfigTest extends RxJavaTest {
 
     @Test
     public void validation() {
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
-        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END).errorMode(), "errorMode - END");
-        assertEquals(5, new ObservableConcatMapConfig(5).bufferSize(), "bufferSize - 5");
-        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
-        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
-        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
-        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
+        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END).errorMode(), "errorMode - END");
+        assertEquals(5, new ObservableConcatConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
+        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfigTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.ErrorMode;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObservableConcatMapConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
+        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END).errorMode(), "errorMode - END");
+        assertEquals(5, new ObservableConcatConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
+        assertEquals(5, new ObservableConcatConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
+        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableConcatMapConfigTest.java
@@ -23,15 +23,15 @@ public class ObservableConcatMapConfigTest extends RxJavaTest {
 
     @Test
     public void validation() {
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
-        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END).errorMode(), "errorMode - END");
-        assertEquals(5, new ObservableConcatConfig(5).bufferSize(), "bufferSize - 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
-        assertEquals(5, new ObservableConcatConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
-        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
-        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
-        assertEquals(ErrorMode.END, new ObservableConcatConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE).errorMode(), "errorMode - IMMEDIATE");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY).errorMode(), "errorMode - BOUNDARY");
+        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END).errorMode(), "errorMode - END");
+        assertEquals(5, new ObservableConcatMapConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).bufferSize(), "bufferSize both - IMMEDIATE, 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).bufferSize(), "bufferSize both - BOUNDARY, 5");
+        assertEquals(5, new ObservableConcatMapConfig(ErrorMode.END, 5).bufferSize(), "bufferSize both - END, 5");
+        assertEquals(ErrorMode.IMMEDIATE, new ObservableConcatMapConfig(ErrorMode.IMMEDIATE, 5).errorMode(), "errorMode both - IMMEDIATE, 5");
+        assertEquals(ErrorMode.BOUNDARY, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 5).errorMode(), "errorMode both - BOUNDARY, 5");
+        assertEquals(ErrorMode.END, new ObservableConcatMapConfig(ErrorMode.END, 5).errorMode(), "errorMode both - END, 5");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapCompletableTest.java
@@ -21,8 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava4.observers.TestObserver;
@@ -54,7 +55,7 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void simpleLongPrefetch() {
         Observable.range(1, 1024)
-        .concatMapCompletable(Functions.justFunction(Completable.complete()), 32)
+        .concatMapCompletable(Functions.justFunction(Completable.complete()), new ObservableConcatMapConfig(32))
         .test()
         .assertResult();
     }
@@ -78,8 +79,9 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void innerErrorDelayed() {
         TestObserverEx<Void> to = Observable.range(1, 5)
-        .concatMapCompletableDelayError(
-                _ -> Completable.error(new TestException())
+        .concatMapCompletable(
+                _ -> Completable.error(new TestException()),
+                ObservableConcatMapConfig.DELAY_ERROR
         )
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class)
@@ -161,8 +163,9 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Void> to = ps.concatMapCompletableDelayError(
-                Functions.justFunction(cs), false).test();
+        TestObserver<Void> to = ps.concatMapCompletable(
+                Functions.justFunction(cs), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY)
+                .test();
 
         to.assertEmpty();
 
@@ -190,13 +193,13 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
         final CompletableSubject cs = CompletableSubject.create();
         final CompletableSubject cs2 = CompletableSubject.create();
 
-        TestObserver<Void> to = ps.concatMapCompletableDelayError(
+        TestObserver<Void> to = ps.concatMapCompletable(
                         v -> {
                             if (v == 1) {
                                 return cs;
                             }
                             return cs2;
-                        }, true, 32
+                        }, new ObservableConcatMapConfig(ErrorMode.END, 32)
         )
         .test();
 
@@ -391,13 +394,15 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
-            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), false, 2));
+            upstream.concatMapCompletable((Function<Integer, Completable>) _ ->
+            Completable.complete().hide(), new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 2)));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
-            upstream.concatMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide(), true, 2));
+            upstream.concatMapCompletable((Function<Integer, Completable>) _ ->
+                Completable.complete().hide(), new ObservableConcatMapConfig(ErrorMode.END, 2)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapMaybeTest.java
@@ -19,15 +19,15 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.operators.mixed.ObservableConcatMapMaybe.ConcatMapMaybeMainObserver;
-import io.reactivex.rxjava4.core.ErrorMode;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
@@ -47,7 +47,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void simpleLong() {
         Observable.range(1, 1024)
-        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, 32)
+        .concatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, new ObservableConcatMapConfig(32))
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -117,7 +117,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapMaybe(Functions.justFunction(ms), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY).test();
 
         to.assertEmpty();
 
@@ -141,7 +141,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.concatMapMaybeDelayError(Functions.justFunction(ms), false).test();
+        TestObserver<Integer> to = ps.concatMapMaybe(Functions.justFunction(ms), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY).test();
 
         to.assertEmpty();
 
@@ -163,8 +163,8 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(
-                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapMaybeDelayError(
-                        Functions.justFunction(Maybe.empty()))
+                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapMaybe(
+                        Functions.justFunction(Maybe.empty()), ObservableConcatMapConfig.DELAY_ERROR)
         );
     }
 
@@ -201,7 +201,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
                 }
             }
             .concatMapMaybe(
-                    Functions.justFunction(Maybe.error(new TestException("inner"))), 1
+                    Functions.justFunction(Maybe.error(new TestException("inner"))), new ObservableConcatMapConfig(1)
             )
             .to(TestHelper.<Object>testConsumer())
             .assertFailureAndMessage(TestException.class, "inner");
@@ -247,7 +247,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestObserverEx<Object> to = Observable.range(1, 5)
-        .concatMapMaybeDelayError(_ -> Maybe.error(new TestException()))
+        .concatMapMaybe(_ -> Maybe.error(new TestException()), ObservableConcatMapConfig.DELAY_ERROR)
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -337,7 +337,7 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
 
         TestObserver<Integer> to = Observable
                 .fromArray(ms, Maybe.just(2), Maybe.just(3), Maybe.just(4))
-                .concatMapMaybe(Functions.<Maybe<Integer>>identity(), 2)
+                .concatMapMaybe(Functions.<Maybe<Integer>>identity(), new ObservableConcatMapConfig(2))
                 .test();
 
         to.assertEmpty();
@@ -376,13 +376,15 @@ public class ObservableConcatMapMaybeTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), false, 2));
+            upstream.concatMapMaybe((Function<Integer, Maybe<Integer>>) v ->
+                Maybe.just(v).hide(), new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 2)));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true, 2));
+            upstream.concatMapMaybe((Function<Integer, Maybe<Integer>>) v ->
+                Maybe.just(v).hide(), new ObservableConcatMapConfig(ErrorMode.END, 2)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableConcatMapSingleTest.java
@@ -18,15 +18,15 @@ import static org.junit.Assert.*;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.rxjava4.disposables.Disposable;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.operators.mixed.ObservableConcatMapSingle.ConcatMapSingleMainObserver;
-import io.reactivex.rxjava4.core.ErrorMode;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.subjects.*;
@@ -45,7 +45,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void simpleLong() {
         Observable.range(1, 1024)
-        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, 32)
+        .concatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, new ObservableConcatMapConfig(32))
         .test()
         .assertValueCount(1024)
         .assertNoErrors()
@@ -73,7 +73,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.concatMapSingleDelayError(Functions.justFunction(ss), false).test();
+        TestObserver<Integer> to = ps.concatMapSingle(Functions.justFunction(ss), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY).test();
 
         to.assertEmpty();
 
@@ -95,8 +95,8 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void doubleOnSubscribe() {
         TestHelper.checkDoubleOnSubscribeObservable(
-                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapSingleDelayError(
-                        Functions.justFunction(Single.never()))
+                (Function<Observable<Object>, Observable<Object>>) f -> f.concatMapSingle(
+                        Functions.justFunction(Single.never()), ObservableConcatMapConfig.DELAY_ERROR)
         );
     }
 
@@ -133,7 +133,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
                 }
             }
             .concatMapSingle(
-                    Functions.justFunction(Single.error(new TestException("inner"))), 1
+                    Functions.justFunction(Single.error(new TestException("inner"))), new ObservableConcatMapConfig(1)
             )
             .to(TestHelper.<Object>testConsumer())
             .assertFailureAndMessage(TestException.class, "inner");
@@ -179,7 +179,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void delayAllErrors() {
         TestObserverEx<Object> to = Observable.range(1, 5)
-        .concatMapSingleDelayError(_ -> Single.error(new TestException()))
+        .concatMapSingle(_ -> Single.error(new TestException()), ObservableConcatMapConfig.DELAY_ERROR)
         .to(TestHelper.<Object>testConsumer())
         .assertFailure(CompositeException.class)
         ;
@@ -232,7 +232,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
         SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.concatMapSingleDelayError(Functions.justFunction(ss), false).test();
+        TestObserver<Integer> to = ps.concatMapSingle(Functions.justFunction(ss), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY).test();
 
         to.assertEmpty();
 
@@ -291,7 +291,7 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
 
         TestObserver<Integer> to = Observable
                 .fromArray(ss, Single.just(2), Single.just(3), Single.just(4))
-                .concatMapSingle(Functions.<Single<Integer>>identity(), 2)
+                .concatMapSingle(Functions.<Single<Integer>>identity(), new ObservableConcatMapConfig(2))
                 .test();
 
         to.assertEmpty();
@@ -330,13 +330,13 @@ public class ObservableConcatMapSingleTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), false, 2));
+            upstream.concatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 2)));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true, 2));
+            upstream.concatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), new ObservableConcatMapConfig(ErrorMode.END, 2)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapCompletableTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.Function;
@@ -34,7 +35,8 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     public void asyncFused() throws Exception {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
-        TestObserver<Void> to = us.concatMapCompletable(completableComplete(), 2).test();
+        TestObserver<Void> to = us.concatMapCompletable(completableComplete(), new ObservableConcatMapConfig(2))
+                .test();
 
         us.onNext(1);
         us.onComplete();
@@ -46,7 +48,9 @@ public class ObservableConcatMapCompletableTest extends RxJavaTest {
     @Test
     public void notFused() throws Exception {
         UnicastSubject<Integer> us = UnicastSubject.create();
-        TestObserver<Void> to = us.hide().concatMapCompletable(completableComplete(), 2).test();
+        TestObserver<Void> to = us.hide()
+                .concatMapCompletable(completableComplete(), new ObservableConcatMapConfig(2))
+                .test();
 
         us.onNext(1);
         us.onNext(2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapEagerTest.java
@@ -20,13 +20,13 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava4.core.config.ObservableConcatEagerConfig;
 import org.junit.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.config.ObservableConcatEagerConfig;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -47,7 +47,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayBoundary() {
         Observable.range(1, 5)
-        .concatMapEagerDelayError((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), false)
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), ObservableConcatEagerConfig.DELAY_ERROR_BOUNDARY)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -55,7 +55,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void normalDelayEnd() {
         Observable.range(1, 5)
-        .concatMapEagerDelayError((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), true)
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) t -> Observable.range(t, 2), ObservableConcatEagerConfig.DELAY_ERROR)
         .test()
         .assertResult(1, 2, 2, 3, 3, 4, 4, 5, 5, 6);
     }
@@ -65,8 +65,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         PublishSubject<Integer> main = PublishSubject.create();
         final PublishSubject<Integer> inner = PublishSubject.create();
 
-        TestObserverEx<Integer> to = main.concatMapEagerDelayError(
-                (Function<Integer, ObservableSource<Integer>>) _ -> inner, false).to(TestHelper.<Integer>testConsumer());
+        TestObserverEx<Integer> to = main.concatMapEager(
+                (Function<Integer, ObservableSource<Integer>>) _ -> inner, ObservableConcatEagerConfig.DELAY_ERROR_BOUNDARY)
+                .to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
 
@@ -89,8 +90,9 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         PublishSubject<Integer> main = PublishSubject.create();
         final PublishSubject<Integer> inner = PublishSubject.create();
 
-        TestObserverEx<Integer> to = main.concatMapEagerDelayError(
-                (Function<Integer, ObservableSource<Integer>>) _ -> inner, true).to(TestHelper.<Integer>testConsumer());
+        TestObserverEx<Integer> to = main.concatMapEager(
+                (Function<Integer, ObservableSource<Integer>>) _ -> inner, ObservableConcatEagerConfig.DELAY_ERROR)
+                .to(TestHelper.<Integer>testConsumer());
 
         main.onNext(1);
         main.onNext(2);
@@ -333,12 +335,12 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidMaxConcurrent() {
-        assertNotNull(Observable.just(1).concatMapEager(toJust, 0, Observable.bufferSize()));
+        assertNotNull(Observable.just(1).concatMapEager(toJust, new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 0, Observable.bufferSize())));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void invalidCapacityHint() {
-        assertNotNull(Observable.just(1).concatMapEager(toJust, Observable.bufferSize(), 0));
+        assertNotNull(Observable.just(1).concatMapEager(toJust, new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, Observable.bufferSize(), 0)));
     }
 
     @Test
@@ -452,7 +454,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         Observable<Integer> source = Observable.just(1);
         try {
             assertNotNull(Observable.just(source, source, source)
-                    .concatMapEager((Function)Functions.identity(), 10, -99));
+                    .concatMapEager((Function)Functions.identity(), new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 10, -99)));
         } catch (IllegalArgumentException ex) {
             assertEquals("bufferSize > 0 required but it was -99", ex.getMessage());
         }
@@ -487,14 +489,18 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
 
     @Test
     public void innerErrorMaxConcurrency() {
-        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()), 1, 128)
+        Observable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ ->
+            Observable.error(new TestException()), new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 1, 128))
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void innerCallableThrows() {
-        Observable.<Integer>just(1).hide().concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> Observable.fromCallable((Callable<Integer>) () -> {
+        Observable.<Integer>just(1).hide()
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ ->
+            Observable.fromCallable((Callable<Integer>) () -> {
             throw new TestException();
         }))
         .test()
@@ -565,7 +571,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> {
             to.dispose();
             return Observable.never();
-        }, 1, 128)
+        }, new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 1, 128))
         .subscribe(to);
 
         to.assertEmpty();
@@ -594,7 +600,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         };
 
         Observable.<Integer>just(1).hide()
-        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> us, 1, 128)
+        .concatMapEager((Function<Integer, ObservableSource<Integer>>) _ -> us, new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 1, 128))
         .subscribe(to);
 
         to
@@ -649,7 +655,7 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
         .concatMapEager((Function<List<Integer>, ObservableSource<List<Integer>>>) v -> Observable.just(v)
                 .subscribeOn(Schedulers.cached())
                 .doOnNext(_ -> Thread.sleep(new Random().nextInt(20)))
-                , 2, 3)
+                , new ObservableConcatEagerConfig(ErrorMode.IMMEDIATE, 2, 3))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(list);
@@ -806,13 +812,13 @@ public class ObservableConcatMapEagerTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapEagerDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false));
+            upstream.concatMapEager((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), ObservableConcatEagerConfig.DELAY_ERROR_BOUNDARY));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapEagerDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true));
+            upstream.concatMapEager((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), ObservableConcatEagerConfig.DELAY_ERROR));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapSchedulerTest.java
@@ -26,6 +26,7 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -51,7 +52,7 @@ public class ObservableConcatMapSchedulerTest {
             }
             return name;
         })
-        .concatMap((Function<String, ObservableSource<? extends Object>>) Observable::just, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<String, ObservableSource<? extends Object>>) Observable::just, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -70,7 +71,7 @@ public class ObservableConcatMapSchedulerTest {
             }
             return name;
         })
-        .concatMapDelayError((Function<String, ObservableSource<? extends Object>>) Observable::just, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<String, ObservableSource<? extends Object>>) Observable::just, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .observeOn(Schedulers.computation())
         .distinct()
         .test()
@@ -85,7 +86,7 @@ public class ObservableConcatMapSchedulerTest {
             throw new TestException();
         })
         .compose(TestHelper.<Integer>observableStripBoundary())
-        .concatMap((Function<Integer, ObservableSource<Integer>>) Observable::just, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, ObservableSource<Integer>>) Observable::just, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertFailure(TestException.class);
     }
@@ -97,7 +98,7 @@ public class ObservableConcatMapSchedulerTest {
             throw new TestException();
         })
         .compose(TestHelper.<Integer>observableStripBoundary())
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) Observable::just, true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, ObservableSource<Integer>>) Observable::just, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -107,7 +108,8 @@ public class ObservableConcatMapSchedulerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, 5)
-        .concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).doOnDispose(counter::getAndIncrement), 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Integer, Observable<Integer>>) v ->
+            Observable.just(v).doOnDispose(counter::getAndIncrement), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertResult(1, 2, 3, 4, 5);
 
@@ -117,12 +119,12 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void delayErrorCallableTillTheEnd() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
+        .concatMap((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
             if (integer >= 100) {
                 throw new NullPointerException("test null exp");
             }
             return integer;
-        }), true, 2, ImmediateThinScheduler.INSTANCE)
+        }), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(CompositeException.class, 1, 2, 3, 23, 32);
     }
@@ -130,12 +132,12 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void delayErrorCallableEager() {
         Observable.just(1, 2, 3, 101, 102, 23, 890, 120, 32)
-        .concatMapDelayError((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
+        .concatMap((Function<Integer, Observable<Integer>>) integer -> Observable.fromCallable(() -> {
             if (integer >= 100) {
                 throw new NullPointerException("test null exp");
             }
             return integer;
-        }), false, 2, ImmediateThinScheduler.INSTANCE)
+        }), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY)
         .test()
         .assertFailure(NullPointerException.class, 1, 2, 3);
     }
@@ -143,7 +145,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperScheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), Schedulers.single(), ObservableConcatMapConfig.DEFAULT)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -156,7 +158,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ ->
+            Observable.just(Thread.currentThread().getName()).hide(), Schedulers.single(), ObservableConcatMapConfig.DEFAULT)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -169,7 +172,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayErrorScheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), false, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ ->
+            Observable.just(Thread.currentThread().getName()), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -182,7 +186,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayErrorScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), false, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ ->
+            Observable.just(Thread.currentThread().getName()).hide(), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -195,7 +200,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayError2Scheduled() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), true, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -208,7 +213,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void mapperDelayError2ScheduledHidden() {
         TestObserver<String> to = Observable.just(1)
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName()).hide(), true, 2, Schedulers.single())
+        .concatMap((Function<Integer, Observable<String>>) _ ->
+            Observable.just(Thread.currentThread().getName()).hide(), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertValueCount(1)
@@ -236,7 +242,7 @@ public class ObservableConcatMapSchedulerTest {
         final AtomicInteger counter = new AtomicInteger();
 
         Observable.range(1, n)
-        .concatMap(func, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(func, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .subscribe(new DefaultObserver<>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -286,7 +292,8 @@ public class ObservableConcatMapSchedulerTest {
             }
             TestObserverEx<Integer> to = new TestObserverEx<>();
             Observable.range(0, 1000)
-            .concatMap((Function<Integer, Observable<Integer>>) t -> Observable.fromIterable(Collections.singletonList(t)), 2, ImmediateThinScheduler.INSTANCE)
+            .concatMap((Function<Integer, Observable<Integer>>) t ->
+                Observable.fromIterable(Collections.singletonList(t)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
             .observeOn(Schedulers.computation()).subscribe(to);
 
             to.awaitDone(2500, TimeUnit.MILLISECONDS);
@@ -324,7 +331,7 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapJustJust() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.just(1)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.just(1)).concatMap((Function)Functions.identity(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT).subscribe(to);
 
         to.assertValue(1);
         to.assertNoErrors();
@@ -336,7 +343,7 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapJustRange() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.range(1, 5)).concatMap((Function)Functions.identity(), 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.range(1, 5)).concatMap((Function)Functions.identity(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT).subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5);
         to.assertNoErrors();
@@ -348,7 +355,8 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapDelayErrorJustJust() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.just(1)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.just(1)).concatMap((Function)Functions.identity(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
+        .subscribe(to);
 
         to.assertValue(1);
         to.assertNoErrors();
@@ -360,7 +368,8 @@ public class ObservableConcatMapSchedulerTest {
     public void concatMapDelayErrorJustRange() {
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.just(Observable.range(1, 5)).concatMapDelayError((Function)Functions.identity(), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.just(Observable.range(1, 5)).concatMap((Function)Functions.identity(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
+        .subscribe(to);
 
         to.assertValues(1, 2, 3, 4, 5);
         to.assertNoErrors();
@@ -416,7 +425,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapDelayError() {
         Observable.just(Observable.just(1), Observable.just(2))
-        .concatMapDelayError(Functions.<Observable<Integer>>identity(), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.<Observable<Integer>>identity(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertResult(1, 2);
     }
@@ -424,7 +433,8 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapDelayErrorJustSource() {
         Observable.just(0)
-        .concatMapDelayError((Function<Object, Observable<Integer>>) _ -> Observable.just(1), true, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Object, Observable<Integer>>) _ ->
+            Observable.just(1), ImmediateThinScheduler.INSTANCE, new ObservableConcatMapConfig(ErrorMode.END, 16))
         .test()
         .assertResult(1);
 
@@ -433,7 +443,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapJustSource() {
         Observable.just(0).hide()
-        .concatMap((Function<Object, Observable<Integer>>) _ -> Observable.just(1), 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Object, Observable<Integer>>) _ -> Observable.just(1), ImmediateThinScheduler.INSTANCE, new ObservableConcatMapConfig(16))
         .test()
         .assertResult(1);
     }
@@ -441,7 +451,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapJustSourceDelayError() {
         Observable.just(0).hide()
-        .concatMapDelayError((Function<Object, Observable<Integer>>) _ -> Observable.just(1), false, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap((Function<Object, Observable<Integer>>) _ -> Observable.just(1), ImmediateThinScheduler.INSTANCE, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 16))
         .test()
         .assertResult(1);
     }
@@ -449,7 +459,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapEmpty() {
         Observable.just(1).hide()
-        .concatMap(Functions.justFunction(Observable.empty()), 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.empty()), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertResult();
     }
@@ -457,15 +467,17 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapEmptyDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.empty()), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.empty()), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertResult();
     }
 
     @Test
     public void doubleOnSubscribe() {
-        TestHelper.checkDoubleOnSubscribeObservable(f -> f.concatMap(Functions.justFunction(Observable.just(2)), 2, ImmediateThinScheduler.INSTANCE));
-        TestHelper.checkDoubleOnSubscribeObservable(f -> f.concatMapDelayError(Functions.justFunction(Observable.just(2)), true, 2, ImmediateThinScheduler.INSTANCE));
+        TestHelper.checkDoubleOnSubscribeObservable(f ->
+        f.concatMap(Functions.justFunction(Observable.just(2)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT));
+        TestHelper.checkDoubleOnSubscribeObservable(f ->
+        f.concatMap(Functions.justFunction(Observable.just(2)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
@@ -482,7 +494,7 @@ public class ObservableConcatMapSchedulerTest {
             }
         };
 
-        ps.concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        ps.concatMap(Functions.justFunction(Observable.just(1)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .subscribe(to);
 
         ps.onNext(1);
@@ -506,7 +518,7 @@ public class ObservableConcatMapSchedulerTest {
             }
         };
 
-        ps.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE)
+        ps.concatMap(Functions.justFunction(Observable.just(1).hide()), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .subscribe(to);
 
         ps.onNext(1);
@@ -519,7 +531,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapInnerError() {
         Observable.just(1).hide()
-        .concatMap(Functions.justFunction(Observable.error(new TestException())), 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.error(new TestException())), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertFailure(TestException.class);
     }
@@ -527,14 +539,15 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void concatMapInnerErrorDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.error(new TestException())), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
 
     @Test
     public void badSource() {
-        TestHelper.checkBadSourceObservable(f -> f.concatMap(Functions.justFunction(Observable.just(1).hide()), 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(f ->
+        f.concatMap(Functions.justFunction(Observable.just(1).hide()), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT), true, 1, 1, 1);
     }
 
     @Test
@@ -549,7 +562,7 @@ public class ObservableConcatMapSchedulerTest {
                 o.onSubscribe(Disposable.empty());
                 o.onError(new TestException("First"));
             }
-        }), 2, ImmediateThinScheduler.INSTANCE)
+        }), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .to(TestHelper.<Integer>testConsumer());
 
         to.assertFailureAndMessage(TestException.class, "First");
@@ -569,14 +582,14 @@ public class ObservableConcatMapSchedulerTest {
         @SuppressWarnings("rawtypes")
         final Observer[] ts0 = { null };
         TestObserverEx<Integer> to = Observable.just(1).hide()
-                .concatMapDelayError(Functions.justFunction(new Observable<Integer>() /* NFI */ {
+                .concatMap(Functions.justFunction(new Observable<Integer>() /* NFI */ {
             @Override
             protected void subscribeActual(Observer<? super Integer> o) {
                 ts0[0] = o;
                 o.onSubscribe(Disposable.empty());
                 o.onError(new TestException("First"));
             }
-        }), true, 2, ImmediateThinScheduler.INSTANCE)
+        }), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .to(TestHelper.<Integer>testConsumer());
 
         to.assertFailureAndMessage(TestException.class, "First");
@@ -593,15 +606,15 @@ public class ObservableConcatMapSchedulerTest {
 
     @Test
     public void badSourceDelayError() {
-        TestHelper.checkBadSourceObservable(f -> f.concatMapDelayError(Functions.justFunction(Observable.just(1).hide()),
-                true, 2, ImmediateThinScheduler.INSTANCE), true, 1, 1, 1);
+        TestHelper.checkBadSourceObservable(f -> f.concatMap(Functions.justFunction(Observable.just(1).hide()),
+                ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR), true, 1, 1, 1);
     }
 
     @Test
     public void fusedCrash() {
         Observable.range(1, 2)
         .map(_ -> { throw new TestException(); })
-        .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.just(1)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertFailure(TestException.class);
     }
@@ -610,7 +623,7 @@ public class ObservableConcatMapSchedulerTest {
     public void fusedCrashDelayError() {
         Observable.range(1, 2)
         .map(_ -> { throw new TestException(); })
-        .concatMapDelayError(Functions.justFunction(Observable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.just(1)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -620,7 +633,7 @@ public class ObservableConcatMapSchedulerTest {
         Observable.just(1).hide()
         .concatMap(Functions.justFunction(Observable.fromCallable(() -> {
             throw new TestException();
-        })), 2, ImmediateThinScheduler.INSTANCE)
+        })), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertFailure(TestException.class);
     }
@@ -628,9 +641,9 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void callableCrashDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError(Functions.justFunction(Observable.fromCallable(() -> {
+        .concatMap(Functions.justFunction(Observable.fromCallable(() -> {
             throw new TestException();
-        })), true, 2, ImmediateThinScheduler.INSTANCE)
+        })), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -638,16 +651,16 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void dispose() {
         TestHelper.checkDisposed(Observable.range(1, 2)
-        .concatMap(Functions.justFunction(Observable.just(1)), 2, ImmediateThinScheduler.INSTANCE));
+        .concatMap(Functions.justFunction(Observable.just(1)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT));
 
         TestHelper.checkDisposed(Observable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Observable.just(1)), true, 2, ImmediateThinScheduler.INSTANCE));
+        .concatMap(Functions.justFunction(Observable.just(1)), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
     public void notVeryEnd() {
         Observable.range(1, 2)
-        .concatMapDelayError(Functions.justFunction(Observable.error(new TestException())), false, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.error(new TestException())), ImmediateThinScheduler.INSTANCE, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 16))
         .test()
         .assertFailure(TestException.class);
     }
@@ -655,7 +668,7 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void error() {
         Observable.error(new TestException())
-        .concatMapDelayError(Functions.justFunction(Observable.just(2)), false, 16, ImmediateThinScheduler.INSTANCE)
+        .concatMap(Functions.justFunction(Observable.just(2)), ImmediateThinScheduler.INSTANCE, new ObservableConcatMapConfig(ErrorMode.BOUNDARY, 16))
         .test()
         .assertFailure(TestException.class);
     }
@@ -665,7 +678,7 @@ public class ObservableConcatMapSchedulerTest {
         Observable.range(1, 2)
         .concatMap((Function<Integer, ObservableSource<Object>>) _ -> {
             throw new TestException();
-        }, 2, ImmediateThinScheduler.INSTANCE)
+        }, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertFailure(TestException.class);
     }
@@ -676,7 +689,8 @@ public class ObservableConcatMapSchedulerTest {
 
         TestObserver<Integer> to = TestObserver.create();
 
-        source.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.range(v, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        source.concatMap((Function<Integer, Observable<Integer>>) v ->
+            Observable.range(v, 2), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         source.onNext(1);
         source.onNext(2);
@@ -694,7 +708,8 @@ public class ObservableConcatMapSchedulerTest {
 
         TestObserver<Integer> to = TestObserver.create();
 
-        Observable.range(1, 3).concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        Observable.range(1, 3).concatMap((Function<Integer, Observable<Integer>>) _ ->
+            inner, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         to.assertValues(1, 2, 1, 2, 1, 2);
         to.assertError(CompositeException.class);
@@ -709,7 +724,7 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> inner, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMap((Function<Integer, Observable<Integer>>) _ -> inner, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         to.assertValues(1, 2);
         to.assertError(TestException.class);
@@ -722,7 +737,7 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> null, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMap((Function<Integer, Observable<Integer>>) _ -> null, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         to.assertNoValues();
         to.assertError(NullPointerException.class);
@@ -735,9 +750,9 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide() // prevent scalar optimization
-        .concatMapDelayError((Function<Integer, Observable<Integer>>) _ -> {
+        .concatMap((Function<Integer, Observable<Integer>>) _ -> {
             throw new TestException();
-        }, true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        }, ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         to.assertNoValues();
         to.assertError(TestException.class);
@@ -749,7 +764,7 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<Integer> to = TestObserver.create();
 
         Observable.range(1, 3)
-        .concatMapDelayError(v -> v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE).subscribe(to);
+        .concatMap(v -> v == 2 ? Observable.<Integer>empty() : Observable.range(1, 2), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR).subscribe(to);
 
         to.assertValues(1, 2, 1, 2);
         to.assertNoErrors();
@@ -761,7 +776,7 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<Integer> to = TestObserver.create();
 
         Observable.range(1, 3)
-        .concatMapDelayError(v -> v == 2 ? Observable.just(3) : Observable.range(1, 2), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(v -> v == 2 ? Observable.just(3) : Observable.range(1, 2), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .subscribe(to);
 
         to.assertValues(1, 2, 3, 1, 2);
@@ -776,7 +791,7 @@ public class ObservableConcatMapSchedulerTest {
         .observeOn(Schedulers.computation())
         .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
                 .repeat(1000)
-                .observeOn(Schedulers.cached()), 2, Schedulers.single())
+                .observeOn(Schedulers.cached()), Schedulers.single(), ObservableConcatMapConfig.DEFAULT)
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -792,9 +807,9 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<String> to = Observable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
                 .repeat(1000)
-                .observeOn(Schedulers.cached()), false, 2, Schedulers.single())
+                .observeOn(Schedulers.cached()), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY)
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -810,9 +825,9 @@ public class ObservableConcatMapSchedulerTest {
         TestObserver<String> to = Observable.range(1, 1000)
         .hide()
         .observeOn(Schedulers.computation())
-        .concatMapDelayError((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
+        .concatMap((Function<Integer, Observable<String>>) _ -> Observable.just(Thread.currentThread().getName())
                 .repeat(1000)
-                .observeOn(Schedulers.cached()), true, 2, Schedulers.single())
+                .observeOn(Schedulers.cached()), Schedulers.single(), ObservableConcatMapConfig.DELAY_ERROR)
         .distinct()
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -826,19 +841,21 @@ public class ObservableConcatMapSchedulerTest {
     @Test
     public void undeliverableUponCancel() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), 2, ImmediateThinScheduler.INSTANCE));
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT));
     }
 
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false, 2, ImmediateThinScheduler.INSTANCE));
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v ->
+                Observable.just(v).hide(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true, 2, ImmediateThinScheduler.INSTANCE));
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v ->
+                Observable.just(v).hide(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
@@ -846,7 +863,7 @@ public class ObservableConcatMapSchedulerTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
 
         TestHelper.rejectObservableFusion()
-        .concatMap(_ -> Observable.never(), 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(_ -> Observable.never(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DEFAULT)
         .subscribe(to);
     }
 
@@ -855,7 +872,7 @@ public class ObservableConcatMapSchedulerTest {
         TestObserverEx<Object> to = new TestObserverEx<>();
 
         TestHelper.rejectObservableFusion()
-        .concatMapDelayError(_ -> Observable.never(), true, 2, ImmediateThinScheduler.INSTANCE)
+        .concatMap(_ -> Observable.never(), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .subscribe(to);
     }
 
@@ -865,10 +882,10 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide()
-        .concatMapDelayError(_ -> Observable.fromCallable(() -> {
+        .concatMap(_ -> Observable.fromCallable(() -> {
             to.dispose();
             return 1;
-        }), true, 2, ImmediateThinScheduler.INSTANCE)
+        }), ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR)
         .subscribe(to);
 
         to.assertEmpty();
@@ -899,8 +916,8 @@ public class ObservableConcatMapSchedulerTest {
 
         Observable.just(1)
         .hide()
-        .concatMapDelayError(_ -> new EmptyDisposingObservable(to),
-                true, 2, ImmediateThinScheduler.INSTANCE
+        .concatMap(_ -> new EmptyDisposingObservable(to),
+                ImmediateThinScheduler.INSTANCE, ObservableConcatMapConfig.DELAY_ERROR
         )
         .subscribe(to);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatMapTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableConcatMapConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -56,7 +57,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void dispose2() {
         TestHelper.checkDisposed(Observable.<Integer>just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException())));
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()), ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
@@ -78,7 +79,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void mainErrorDelayed() {
         Observable.<Integer>error(new TestException())
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -86,7 +87,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void innerErrorDelayError() {
         Observable.<Integer>just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()))
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.error(new TestException()), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -94,9 +95,9 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void innerErrorDelayError2() {
         Observable.<Integer>just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> Observable.fromCallable((Callable<Integer>) () -> {
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.fromCallable((Callable<Integer>) () -> {
             throw new TestException();
-        }))
+        }), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -143,7 +144,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
                     observer.onComplete();
                 }
             }
-            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
+            .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), ObservableConcatMapConfig.DELAY_ERROR)
             .test()
             .assertResult(1, 2);
 
@@ -156,7 +157,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void normalDelayErrors() {
         Observable.just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertResult(1, 2);
     }
@@ -164,7 +165,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void normalDelayErrorsTillTheEnd() {
         Observable.just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), true, 16)
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), new ObservableConcatMapConfig(ErrorMode.END, 16))
         .test()
         .assertResult(1, 2);
     }
@@ -225,7 +226,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         .map((Function<Integer, Integer>) _ -> {
             throw new TestException();
         })
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2))
+        .concatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.range(v, 2), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -233,9 +234,9 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void mapperThrowsDelayError() {
         Observable.just(1).hide()
-        .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> {
+        .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> {
             throw new TestException();
-        })
+        }, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class);
     }
@@ -249,14 +250,14 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         try {
             Observable.just(1).hide()
-            .concatMapDelayError((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<>() /* NFI */ {
+            .concatMap((Function<Integer, ObservableSource<Integer>>) _ -> new Observable<>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
                     o[0] = observer;
                     observer.onSubscribe(Disposable.empty());
                     observer.onComplete();
                 }
-            })
+            }, ObservableConcatMapConfig.DELAY_ERROR)
             .test()
             .assertResult();
 
@@ -334,7 +335,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
+            TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), new ObservableConcatMapConfig(1))
             .subscribeWith(new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer t) {
@@ -364,7 +365,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void reentrantNoOverflowHidden() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
+        TestObserver<Integer> to = ps.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), new ObservableConcatMapConfig(1))
         .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -404,13 +405,13 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), false, 2));
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), ObservableConcatMapConfig.DELAY_ERROR_BOUNDARY));
     }
 
     @Test
     public void undeliverableUponCancelDelayErrorTillEnd() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.concatMapDelayError((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true, 2));
+            upstream.concatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
@@ -420,7 +421,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribeDelayError() {
-        TestHelper.checkDoubleOnSubscribeObservable(o -> o.concatMapDelayError(_ -> Observable.never()));
+        TestHelper.checkDoubleOnSubscribeObservable(o -> o.concatMap(_ -> Observable.never(), ObservableConcatMapConfig.DELAY_ERROR));
     }
 
     @Test
@@ -441,7 +442,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     @Test
     public void rejectedFusionDelayError() {
         TestHelper.rejectObservableFusion()
-        .concatMapDelayError(_  -> Observable.never())
+        .concatMap(_  -> Observable.never(), ObservableConcatMapConfig.DELAY_ERROR)
         .test();
     }
 
@@ -449,7 +450,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void asyncFusedDelayError() {
         UnicastSubject<Integer> uc = UnicastSubject.create();
 
-        TestObserver<Integer> to = uc.concatMapDelayError(v -> Observable.just(v).hide())
+        TestObserver<Integer> to = uc.concatMap(v -> Observable.just(v).hide(), ObservableConcatMapConfig.DELAY_ERROR)
         .test();
 
         uc.onNext(1);
@@ -462,7 +463,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void scalarInnerJustDelayError() {
         Observable.just(1)
         .hide()
-        .concatMapDelayError(Observable::just)
+        .concatMap(Observable::just, ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertResult(1);
     }
@@ -471,7 +472,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
     public void scalarInnerEmptyDelayError() {
         Observable.just(1)
         .hide()
-        .concatMapDelayError(_ -> Observable.empty())
+        .concatMap(_ -> Observable.empty(), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertResult();
     }
@@ -482,10 +483,10 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         Observable.just(1)
         .hide()
-        .concatMapDelayError(_ -> Observable.fromCallable(() -> {
+        .concatMap(_ -> Observable.fromCallable(() -> {
             to.dispose();
             return 1;
-        }))
+        }), ObservableConcatMapConfig.DELAY_ERROR)
         .subscribe(to);
 
         to.assertEmpty();
@@ -497,7 +498,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         Observable.just(1)
         .hide()
-        .concatMapDelayError(_ -> new EmptyDisposingObservable(to))
+        .concatMap(_ -> new EmptyDisposingObservable(to), ObservableConcatMapConfig.DELAY_ERROR)
         .subscribe(to);
 
         to.assertEmpty();
@@ -509,7 +510,7 @@ public class ObservableConcatMapTest extends RxJavaTest {
 
         TestObserver<Integer> to = Observable.range(1, 5)
         .hide()
-        .concatMapDelayError(_ -> ps)
+        .concatMap(_ -> ps, ObservableConcatMapConfig.DELAY_ERROR)
         .test();
 
         ps.onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableConcatTest.java
@@ -21,16 +21,16 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 
-import io.reactivex.rxjava4.core.config.ObservableConcatConfig;
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.core.config.*;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.*;
 import io.reactivex.rxjava4.schedulers.*;
@@ -831,7 +831,7 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapDelayError() {
         Observable.just(Observable.just(1), Observable.just(2))
-        .concatMapDelayError(Functions.<Observable<Integer>>identity())
+        .concatMap(Functions.<Observable<Integer>>identity(), ObservableConcatMapConfig.DEFAULT)
         .test()
         .assertResult(1, 2);
     }
@@ -839,7 +839,7 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapDelayErrorWithError() {
         Observable.just(Observable.just(1).concatWith(Observable.<Integer>error(new TestException())), Observable.just(2))
-        .concatMapDelayError(Functions.<Observable<Integer>>identity())
+        .concatMap(Functions.<Observable<Integer>>identity(), ObservableConcatMapConfig.DELAY_ERROR)
         .test()
         .assertFailure(TestException.class, 1, 2);
     }
@@ -865,13 +865,13 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapDelayErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .concatMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), true, 16));
+                .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableConcatMapConfig(ErrorMode.END, 16)));
     }
 
     @Test
     public void concatMapDelayErrorJustSource() {
         Observable.just(0)
-        .concatMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), true, 16)
+        .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableConcatMapConfig(ErrorMode.END, 16))
         .test()
         .assertResult(1);
 
@@ -890,13 +890,13 @@ public class ObservableConcatTest extends RxJavaTest {
     @Test
     public void concatMapErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16));
+                .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableConcatMapConfig(16)));
     }
 
     @Test
     public void concatMapJustSource() {
         Observable.just(0)
-        .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16)
+        .concatMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableConcatMapConfig(16))
         .test()
         .assertResult(1);
 

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -635,6 +635,7 @@ public class CheckParamValidationTest extends RxJavaTest {
         defaultValues.put(ObservableSwitchConfig.class, ObservableSwitchConfig.DEFAULT);
         defaultValues.put(ObservableSequenceEqualConfig.class, ObservableSequenceEqualConfig.DEFAULT);
         defaultValues.put(ObservableZipConfig.class, ObservableZipConfig.DEFAULT);
+        defaultValues.put(ObservableConcatMapConfig.class, ObservableConcatMapConfig.DEFAULT);
 
         // TODO insert new config record types here
 


### PR DESCRIPTION
Reduce the API surface by introducing configuration records and removing `DelayError` overloads.

# Observable

- `concatMap` & `concatMapDelayError` -> `concatMap` + `ObservableConcatMapConfig`
- `concatMapEager` & `concatMapEagerDelayError` -> `concatMapEager` + `ObservableConcatEagerConfig`
- `concatMapCompletable` & `concatMapCompletableDelayError` -> `concatMapCompletable` + `ObservableConcatMapConfig`
- `concatMapSingle` & `concatMapSingleDelayError` -> `concatMapSingle` + `ObservableConcatMapConfig`
- `concatMapMaybe` & `concatMapMaybeDelayError` -> `concatMapMaybe` + `ObservableConcatMapConfig`


## Remarks

- No `ObservableConcatMapEagerConfig` was needed because the semantics and parameters are the same as the `ObservableConcatEagerConfig`.
- `ObservableConcatMapConfig` was needed because it defaults to `bufferSize` of 2 for the inner sources. We may later combine it with `ObservableConcatConfig` and different constants.

Related: #8173
