### PR TITLE
4.x: Cleanup API: Observable flatMap*, groupBy, observeOn

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -2607,7 +2607,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public static <@NonNull T> Observable<T> merge(@NonNull Iterable<@NonNull ? extends ObservableSource<? extends T>> sources, @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(config, "config is null");
-        return fromIterable(sources).flatMap((Function)Functions.identity(), config.delayErrors(), config.maxConcurrency(), config.bufferSize());
+        return fromIterable(sources).flatMap((Function)Functions.identity(), config);
     }
 
     /**
@@ -2731,7 +2731,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     @SafeVarargs
     public static <@NonNull T> Observable<T> mergeArray(@NonNull ObservableSource<? extends T>... sources) {
-        return fromArray(sources).flatMap((Function)Functions.identity(), sources.length);
+        return fromArray(sources).flatMap((Function)Functions.identity(), ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -2775,7 +2775,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SafeVarargs
     public static <@NonNull T> Observable<T> mergeArray(@NonNull ObservableMergeConfig config, @NonNull ObservableSource<? extends T>... sources) {
         Objects.requireNonNull(config, "config is null");
-        return fromArray(sources).flatMap((Function) Functions.identity(), config.delayErrors(), config.maxConcurrency(), config.bufferSize());
+        return fromArray(sources).flatMap((Function) Functions.identity(), config);
     }
 
     /**
@@ -5576,7 +5576,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            the configuration record for this operator
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @see #concatMap(Function, Scheduler, ObservableConcatMapConfig)
      * @since 4.0.0
@@ -7310,36 +7309,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return flatMap(mapper, false);
-    }
-
-    /**
-     * Returns an {@code Observable} that emits items based on applying a function that you supply to each item emitted
-     * by the current {@code Observable}, where that function returns an {@link ObservableSource}, and then merging those returned
-     * {@code ObservableSource}s and emitting the results of this merger.
-     * <p>
-     * <img width="640" height="356" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flatMapDelayError.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the value type of the inner {@code ObservableSource}s and the output type
-     * @param mapper
-     *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
-     *            {@code ObservableSource}
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors) {
-        return flatMap(mapper, delayErrors, Integer.MAX_VALUE);
+        return flatMap(mapper, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7358,61 +7328,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
      *            {@code ObservableSource}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, boolean delayErrors, int maxConcurrency) {
-        return flatMap(mapper, delayErrors, maxConcurrency, bufferSize());
-    }
-
-    /**
-     * Returns an {@code Observable} that emits items based on applying a function that you supply to each item emitted
-     * by the current {@code Observable}, where that function returns an {@link ObservableSource}, and then merging those returned
-     * {@code ObservableSource}s and emitting the results of this merger, while limiting the maximum number of concurrent
-     * subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="442" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flatMapMaxConcurrency.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the value type of the inner {@code ObservableSource}s and the output type
-     * @param mapper
-     *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
-     *            {@code ObservableSource}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
-     * @param bufferSize
-     *            the number of elements expected from each inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
-            boolean delayErrors, int maxConcurrency, int bufferSize) {
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(maxConcurrency, "maxConcurrency");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        Objects.requireNonNull(config, "config is null");
         if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarSupplier<T>)this).get();
@@ -7421,7 +7350,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableFlatMap<>(this, mapper, delayErrors, maxConcurrency, bufferSize));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMap<>(this, mapper, config.delayErrors(), config.maxConcurrency(), config.bufferSize()));
     }
 
     /**
@@ -7455,10 +7384,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             @NonNull Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
             @NonNull Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
             @NonNull Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier) {
-        Objects.requireNonNull(onNextMapper, "onNextMapper is null");
-        Objects.requireNonNull(onErrorMapper, "onErrorMapper is null");
-        Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
-        return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier));
+        return flatMap(onNextMapper, onErrorMapper, onCompleteSupplier, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7494,7 +7420,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public final <@NonNull R> Observable<R> flatMap(
             @NonNull Function<? super T, ? extends ObservableSource<? extends R>> onNextMapper,
-            @NonNull Function<Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
+            @NonNull Function<? super Throwable, ? extends ObservableSource<? extends R>> onErrorMapper,
             @NonNull Supplier<? extends ObservableSource<? extends R>> onCompleteSupplier,
             @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(onNextMapper, "onNextMapper is null");
@@ -7502,37 +7428,6 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
         Objects.requireNonNull(onCompleteSupplier, "onCompleteSupplier is null");
         Objects.requireNonNull(config, "config is null");
         return merge(new ObservableMapNotification<>(this, onNextMapper, onErrorMapper, onCompleteSupplier), config);
-    }
-
-    /**
-     * Returns an {@code Observable} that emits items based on applying a function that you supply to each item emitted
-     * by the current {@code Observable}, where that function returns an {@link ObservableSource}, and then merging those returned
-     * {@code ObservableSource}s and emitting the results of this merger, while limiting the maximum number of concurrent
-     * subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="442" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flatMapMaxConcurrency.o.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the value type of the inner {@code ObservableSource}s and the output type
-     * @param mapper
-     *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
-     *            {@code ObservableSource}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int maxConcurrency) {
-        return flatMap(mapper, false, maxConcurrency, bufferSize());
     }
 
     /**
@@ -7563,41 +7458,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public final <@NonNull U, @NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
             @NonNull BiFunction<? super T, ? super U, ? extends R> combiner) {
-        return flatMap(mapper, combiner, false, bufferSize(), bufferSize());
-    }
-
-    /**
-     * Returns an {@code Observable} that emits the results of a specified function to the pair of values emitted by the
-     * current {@code Observable} and the mapped inner {@link ObservableSource}.
-     * <p>
-     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <U>
-     *            the type of items emitted by the collection {@code ObservableSource}
-     * @param <R>
-     *            the type of items emitted by the resulting {@code Observable}
-     * @param mapper
-     *            a function that returns an {@code ObservableSource} for each item emitted by the current {@code Observable}
-     * @param combiner
-     *            a function that combines one item emitted by each of the source and collection {@code ObservableSource}s and
-     *            returns an item to be emitted by the resulting {@code Observable}
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} or {@code combiner} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull U, @NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors) {
-        return flatMap(mapper, combiner, delayErrors, bufferSize(), bufferSize());
+        return flatMap(mapper, combiner, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7620,14 +7481,10 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param combiner
      *            a function that combines one item emitted by each of the source and collection {@code ObservableSource}s and
      *            returns an item to be emitted by the resulting {@code Observable}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} or {@code combiner} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
+     * @throws NullPointerException if {@code mapper} or {@code combiner} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @since 2.0
      */
@@ -7635,87 +7492,11 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull U, @NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency) {
-        return flatMap(mapper, combiner, delayErrors, maxConcurrency, bufferSize());
-    }
-
-    /**
-     * Returns an {@code Observable} that emits the results of a specified function to the pair of values emitted by the
-     * current {@code Observable} and the mapped inner {@link ObservableSource}, while limiting the maximum number of concurrent
-     * subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <U>
-     *            the type of items emitted by the collection {@code ObservableSource}
-     * @param <R>
-     *            the type of items emitted by the resulting {@code Observable}
-     * @param mapper
-     *            a function that returns an {@code ObservableSource} for each item emitted by the current {@code Observable}
-     * @param combiner
-     *            a function that combines one item emitted by each of the source and collection {@code ObservableSource}s and
-     *            returns an item to be emitted by the resulting {@code Observable}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @param delayErrors
-     *            if {@code true}, exceptions from the current {@code Observable} and all inner {@code ObservableSource}s are delayed until all of them terminate
-     *            if {@code false}, the first one signaling an exception will terminate the whole sequence immediately
-     * @param bufferSize
-     *            the number of elements expected from the inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} or {@code combiner} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} or {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull U, @NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, boolean delayErrors, int maxConcurrency, int bufferSize) {
+            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner,
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return flatMap(ObservableInternalHelper.flatMapWithCombiner(mapper, combiner), delayErrors, maxConcurrency, bufferSize);
-    }
-
-    /**
-     * Returns an {@code Observable} that emits the results of a specified function to the pair of values emitted by the
-     * current {@code Observable} and the mapped inner {@link ObservableSource}, while limiting the maximum number of concurrent
-     * subscriptions to these {@code ObservableSource}s.
-     * <p>
-     * <img width="640" height="390" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/mergeMap.r.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code flatMap} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <U>
-     *            the type of items emitted by the collection {@code ObservableSource}
-     * @param <R>
-     *            the type of items emitted by the resulting {@code Observable}
-     * @param mapper
-     *            a function that returns an {@code ObservableSource} for each item emitted by the current {@code Observable}
-     * @param combiner
-     *            a function that combines one item emitted by each of the source and collection {@code ObservableSource}s and
-     *            returns an item to be emitted by the resulting {@code Observable}
-     * @param maxConcurrency
-     *         the maximum number of {@code ObservableSource}s that may be subscribed to concurrently
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} or {@code combiner} is {@code null}
-     * @throws IllegalArgumentException if {@code maxConcurrency} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull U, @NonNull R> Observable<R> flatMap(@NonNull Function<? super T, ? extends ObservableSource<? extends U>> mapper,
-            @NonNull BiFunction<? super T, ? super U, ? extends R> combiner, int maxConcurrency) {
-        return flatMap(mapper, combiner, false, maxConcurrency, bufferSize());
+        return flatMap(ObservableInternalHelper.flatMapWithCombiner(mapper, combiner), config);
     }
 
     /**
@@ -7735,7 +7516,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
-        return flatMapCompletable(mapper, false);
+        return flatMapCompletable(mapper, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7748,17 +7529,19 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dd>{@code flatMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @param mapper the function that received each source value and transforms them into {@code CompletableSource}s.
-     * @param delayErrors if {@code true}, errors from the upstream and inner {@code CompletableSource}s are delayed until all of them
-     * terminate.
+     * @param config the configuration record for this operator
      * @return the new {@link Completable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+    public final Completable flatMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper,
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletableCompletable<>(this, mapper, delayErrors));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapCompletableCompletable<>(this, mapper, config.delayErrors(), config.bufferSize()));
     }
 
     /**
@@ -7821,7 +7604,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             @NonNull BiFunction<? super T, ? super U, ? extends V> combiner) {
         Objects.requireNonNull(mapper, "mapper is null");
         Objects.requireNonNull(combiner, "combiner is null");
-        return flatMap(ObservableInternalHelper.flatMapIntoIterable(mapper), combiner, false, bufferSize(), bufferSize());
+        return flatMap(ObservableInternalHelper.flatMapIntoIterable(mapper), combiner, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7842,7 +7625,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
-        return flatMapMaybe(mapper, false);
+        return flatMapMaybe(mapper, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7857,17 +7640,18 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * </dl>
      * @param <R> the result value type
      * @param mapper the function that received each source value and transforms them into {@code MaybeSource}s.
-     * @param delayErrors if {@code true}, errors from the upstream and inner {@code MaybeSource}s are delayed until all of them
-     * terminate.
+     * @param config the configuration record for this operator
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors) {
+    public final <@NonNull R> Observable<R> flatMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper,
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapMaybe<>(this, mapper, delayErrors));
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapMaybe<>(this, mapper, config.delayErrors(), config.bufferSize()));
     }
 
     /**
@@ -7888,7 +7672,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
-        return flatMapSingle(mapper, false);
+        return flatMapSingle(mapper, ObservableMergeConfig.DEFAULT);
     }
 
     /**
@@ -7903,17 +7687,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * </dl>
      * @param <R> the result value type
      * @param mapper the function that received each source value and transforms them into {@code SingleSource}s.
-     * @param delayErrors if {@code true}, errors from the upstream and inner {@code SingleSource}s are delayed until each of them
      * terminates.
+     * @param config the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors) {
+    public final <@NonNull R> Observable<R> flatMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper,
+            @NonNull ObservableMergeConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableFlatMapSingle<>(this, mapper, delayErrors));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableFlatMapSingle<>(this, mapper, config.delayErrors(), /* config.maxConcurrency(), */ config.bufferSize()));
     }
 
     /**
@@ -8071,7 +7858,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull K> Observable<GroupedObservable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector) {
-        return groupBy(keySelector, (Function)Functions.identity(), false, bufferSize());
+        return groupBy(keySelector, (Function)Functions.identity(), ObservableGroupByConfig.DEFAULT);
     }
 
     /**
@@ -8104,19 +7891,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            a function that extracts the key for each item
      * @param <K>
      *            the key type
-     * @param delayError
-     *            if {@code true}, the exception from the current {@code Observable} is delayed in each group until that specific group emitted
-     *            the normal values; if {@code false}, the exception bypasses values in the groups and is reported immediately.
+     * @param config
+     *            the configuration record of this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code keySelector} is {@code null}
+     * @throws NullPointerException if {@code keySelector} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @since 4.0.0
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull K> Observable<GroupedObservable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector, boolean delayError) {
-        return groupBy(keySelector, (Function)Functions.identity(), delayError, bufferSize());
+    public final <@NonNull K> Observable<GroupedObservable<K, T>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+            @NonNull ObservableGroupByConfig config) {
+        return groupBy(keySelector, (Function)Functions.identity(), config);
     }
 
     /**
@@ -8162,7 +7950,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
     @NonNull
     public final <@NonNull K, @NonNull V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
             Function<? super T, ? extends V> valueSelector) {
-        return groupBy(keySelector, valueSelector, false, bufferSize());
+        return groupBy(keySelector, valueSelector, ObservableGroupByConfig.DEFAULT);
     }
 
     /**
@@ -8195,80 +7983,29 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *            a function that extracts the key for each item
      * @param valueSelector
      *            a function that extracts the return element for each item
-     * @param <K>
-     *            the key type
-     * @param <V>
-     *            the element type
-     * @param delayError
-     *            if {@code true}, the exception from the current {@code Observable} is delayed in each group until that specific group emitted
-     *            the normal values; if {@code false}, the exception bypasses values in the groups and is reported immediately.
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code keySelector} or {@code valueSelector} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull K, @NonNull V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
-            @NonNull Function<? super T, ? extends V> valueSelector, boolean delayError) {
-        return groupBy(keySelector, valueSelector, delayError, bufferSize());
-    }
-
-    /**
-     * Groups the items emitted by the current {@code Observable} according to a specified criterion, and emits these
-     * grouped items as {@link GroupedObservable}s.
-     * <p>
-     * <img width="640" height="360" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/groupBy.v3.png" alt="">
-     * <p>
-     * Each emitted {@code GroupedObservable} allows only a single {@link Observer} to subscribe to it during its
-     * lifetime and if this {@code Observer} calls {@code dispose()} before the
-     * source terminates, the next emission by the source having the same key will trigger a new
-     * {@code GroupedObservable} emission.
-     * <p>
-     * <em>Note:</em> A {@code GroupedObservable} will cache the items it is to emit until such time as it
-     * is subscribed to. For this reason, in order to avoid memory leaks, you should not simply ignore those
-     * {@code GroupedObservable}s that do not concern you. Instead, you can signal to them that they may
-     * discard their buffers by applying an operator like {@link #ignoreElements} to them.
-     * <p>
-     * Note also that ignoring groups or subscribing later (i.e., on another thread) will result in
-     * so-called group abandonment where a group will only contain one element and the group will be
-     * re-created over and over as new upstream items trigger a new group. The behavior is
-     * a trade-off between no-dataloss, upstream cancellation and excessive group creation.
-     *
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code groupBy} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param keySelector
-     *            a function that extracts the key for each item
-     * @param valueSelector
-     *            a function that extracts the return element for each item
-     * @param delayError
-     *            if {@code true}, the exception from the current {@code Observable} is delayed in each group until that specific group emitted
-     *            the normal values; if {@code false}, the exception bypasses values in the groups and is reported immediately.
-     * @param bufferSize
-     *            the hint for how many {@code GroupedObservable}s and element in each {@code GroupedObservable} should be buffered
+     * @param config
+     *            the configuration record of the operator
      * @param <K>
      *            the key type
      * @param <V>
      *            the element type
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code keySelector} or {@code valueSelector} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code keySelector} or {@code valueSelector} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/groupby.html">ReactiveX operators documentation: GroupBy</a>
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull K, @NonNull V> Observable<GroupedObservable<K, V>> groupBy(@NonNull Function<? super T, ? extends K> keySelector,
+    public final <@NonNull K, @NonNull V> Observable<GroupedObservable<K, V>> groupBy(
+            @NonNull Function<? super T, ? extends K> keySelector,
             @NonNull Function<? super T, ? extends V> valueSelector,
-            boolean delayError, int bufferSize) {
+            @NonNull ObservableGroupByConfig config) {
         Objects.requireNonNull(keySelector, "keySelector is null");
         Objects.requireNonNull(valueSelector, "valueSelector is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        Objects.requireNonNull(config, "config is null");
 
-        return RxJavaPlugins.onAssembly(new ObservableGroupBy<>(this, keySelector, valueSelector, bufferSize, delayError));
+        return RxJavaPlugins.onAssembly(new ObservableGroupBy<>(this, keySelector, valueSelector, config.bufferSize(), config.delayError()));
     }
 
     /**
@@ -8797,7 +8534,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * asynchronously with an unbounded buffer with {@link Flowable#bufferSize()} "island size".
      *
      * <p>Note that {@code onError} notifications will cut ahead of {@code onNext} notifications on the emission thread if {@code Scheduler} is truly
-     * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, boolean)} overload.
+     * asynchronous. If strict event ordering is required, consider using the {@link #observeOn(Scheduler, ObservableObserveOnConfig)} overload.
      * <p>
      * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.v3.png" alt="">
      * <p>
@@ -8819,54 +8556,14 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
-     * @see #observeOn(Scheduler, boolean)
-     * @see #observeOn(Scheduler, boolean, int)
+     * @see #observeOn(Scheduler, ObservableObserveOnConfig)
      * @see #delay(long, TimeUnit, Scheduler)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
     public final Observable<T> observeOn(@NonNull Scheduler scheduler) {
-        return observeOn(scheduler, false, bufferSize());
-    }
-
-    /**
-     * Returns an {@code Observable} to perform the current {@code Observable}'s emissions and notifications on a specified {@link Scheduler},
-     * asynchronously with an unbounded buffer with {@link Flowable#bufferSize()} "island size" and optionally delays {@code onError} notifications.
-     * <p>
-     * <img width="640" height="308" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/observeOn.v3.png" alt="">
-     * <p>
-     * This operator keeps emitting as many signals as it can on the given {@code Scheduler}'s worker thread,
-     * which may result in a longer than expected occupation of this thread. In other terms,
-     * it does not allow per-signal fairness in case the worker runs on a shared underlying thread.
-     * If such fairness and signal/work interleaving is preferred, use the delay operator with zero time instead.
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>You specify which {@code Scheduler} this operator will use.</dd>
-     * </dl>
-     * <p>"Island size" indicates how large chunks the unbounded buffer allocates to store the excess elements waiting to be consumed
-     * on the other side of the asynchronous boundary.
-     *
-     * @param scheduler
-     *            the {@code Scheduler} to notify {@link Observer}s on
-     * @param delayError
-     *            indicates if the {@code onError} notification may not cut ahead of {@code onNext} notification on the other side of the
-     *            scheduling boundary. If {@code true}, a sequence ending in {@code onError} will be replayed in the same order as was received
-     *            from the current {@code Observable}
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code scheduler} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
-     * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
-     * @see #subscribeOn
-     * @see #observeOn(Scheduler)
-     * @see #observeOn(Scheduler, boolean, int)
-     * @see #delay(long, TimeUnit, Scheduler, boolean)
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.CUSTOM)
-    @NonNull
-    public final Observable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError) {
-        return observeOn(scheduler, delayError, bufferSize());
+        return observeOn(scheduler, ObservableObserveOnConfig.DEFAULT);
     }
 
     /**
@@ -8888,28 +8585,24 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *
      * @param scheduler
      *            the {@code Scheduler} to notify {@link Observer}s on
-     * @param delayError
-     *            indicates if the {@code onError} notification may not cut ahead of {@code onNext} notification on the other side of the
-     *            scheduling boundary. If {@code true} a sequence ending in {@code onError} will be replayed in the same order as was received
-     *            from upstream
-     * @param bufferSize the size of the buffer.
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code scheduler} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code scheduler} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/observeon.html">ReactiveX operators documentation: ObserveOn</a>
      * @see <a href="http://www.grahamlea.com/2014/07/rxjava-threading-examples/">RxJava Threading Examples</a>
      * @see #subscribeOn
      * @see #observeOn(Scheduler)
-     * @see #observeOn(Scheduler, boolean)
      * @see #delay(long, TimeUnit, Scheduler, boolean)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.CUSTOM)
     @NonNull
-    public final Observable<T> observeOn(@NonNull Scheduler scheduler, boolean delayError, int bufferSize) {
+    public final Observable<T> observeOn(@NonNull Scheduler scheduler,
+            @NonNull ObservableObserveOnConfig config) {
         Objects.requireNonNull(scheduler, "scheduler is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        return RxJavaPlugins.onAssembly(new ObservableObserveOn<>(this, scheduler, delayError, bufferSize));
+        Objects.requireNonNull(config, "config is null");
+        return RxJavaPlugins.onAssembly(new ObservableObserveOn<>(this, scheduler, config.delayError(), config.bufferSize()));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/FlatMapConfig.java
@@ -28,14 +28,14 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 public record FlatMapConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
 
     /**
-     * The default config with no error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     * The default configuration with no error delay and Flowable#bufferSize() as the maximum concurrency setting.
      */
-    public static final FlatMapConfig DEFAULT = new FlatMapConfig(false, Flowable.bufferSize());
+    public static final FlatMapConfig DEFAULT = new FlatMapConfig(false);
 
     /**
-     * The default config with error delay and Flowable#bufferSize() as the maximum concurrency setting.
+     * The default configuration with error delay and Flowable#bufferSize() as the maximum concurrency setting.
      */
-    public static final FlatMapConfig DELAY_ERRORS = new FlatMapConfig(true, Flowable.bufferSize());
+    public static final FlatMapConfig DELAY_ERRORS = new FlatMapConfig(true);
 
     /**
      * Optionally delay error, {@link Flowable#bufferSize()} sizes

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableGroupByConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableGroupByConfig.java
@@ -17,45 +17,45 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Configuration record for Observable.zip() operators.
+ * Configuration record for Observable.groupBy() operators.
  * @param delayError should the error propagation be delayed?
- * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
+ * @param bufferSize the expected number of items to buffer until it can be processed
  * @since 4.0.0
  */
-public record ObservableZipConfig(boolean delayError, int bufferSize) {
+public record ObservableGroupByConfig(boolean delayError, int bufferSize) {
 
     /**
      * The default configuration with no error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableZipConfig DEFAULT = new ObservableZipConfig(false);
+    public static final ObservableGroupByConfig DEFAULT = new ObservableGroupByConfig(false);
 
     /**
      * The default configuration with error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableZipConfig DELAY_ERROR = new ObservableZipConfig(true);
+    public static final ObservableGroupByConfig DELAY_ERROR = new ObservableGroupByConfig(true);
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
      */
-    public ObservableZipConfig(boolean delayError) {
+    public ObservableGroupByConfig(boolean delayError) {
         this(delayError, Observable.bufferSize());
     }
 
     /**
      * Constructs a configuration record.
-     * @param bufferSize the expected number of row combination items to be buffered internally
+     * @param bufferSize the expected number of items to buffer until it can be processed
      */
-    public ObservableZipConfig(int bufferSize) {
+    public ObservableGroupByConfig(int bufferSize) {
         this(false, bufferSize);
     }
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
-     * @param bufferSize the expected number of row combination items to be buffered internally
+     * @param bufferSize the expected number of items to buffer until it can be processed
      */
-    public ObservableZipConfig {
+    public ObservableGroupByConfig {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableMergeConfig.java
@@ -13,12 +13,11 @@
 
 package io.reactivex.rxjava4.core.config;
 
-import io.reactivex.rxjava4.core.Flowable;
-import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Configuration record for Observable.merge() operators.
+ * Configuration record for Observable.merge() and Observable.flatMap operators.
  * @param delayErrors should the error be delayed?
  * @param maxConcurrency the maximum number of concurrent flows?
  * @param bufferSize what would be the buffer size?
@@ -27,25 +26,25 @@ import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 public record ObservableMergeConfig(boolean delayErrors, int maxConcurrency, int bufferSize) {
 
     /**
-     * The default configuration with no error delays and bufferSize of {@link Observable#bufferSize()}.
+     * The default configuration with no error delays, MAX_VALUE concurrency and bufferSize of {@link Observable#bufferSize()}.
      */
-    public static final ObservableMergeConfig DEFAULT = new ObservableMergeConfig(false, Observable.bufferSize());
+    public static final ObservableMergeConfig DEFAULT = new ObservableMergeConfig(false);
 
     /**
-     * The default configuration with error delays and bufferSize of {@link Observable#bufferSize()}.
+     * The default configuration with error delays, MAX_VALUE concurrency and bufferSize of {@link Observable#bufferSize()}.
      */
-    public static final ObservableMergeConfig DELAY_ERROR = new ObservableMergeConfig(true, Observable.bufferSize());
+    public static final ObservableMergeConfig DELAY_ERROR = new ObservableMergeConfig(true);
 
     /**
-     * Optionally delay error, {@link Flowable#bufferSize()} sizes
+     * Optionally delay error, {@link Observable#bufferSize()} sizes
      * @param delayErrors should the error be delayed?
      */
     public ObservableMergeConfig(boolean delayErrors) {
-        this(delayErrors, Flowable.bufferSize(), Flowable.bufferSize());
+        this(delayErrors, Integer.MAX_VALUE, Observable.bufferSize());
     }
 
     /**
-     * Optionally set the buffer size, no delay errors.
+     * Optionally set the maximum concurrency levels, no errors and a buffer size of {@link Observable#bufferSize()}.
      * @param maxConcurrency the maximum number of concurrent flows
      */
     public ObservableMergeConfig(int maxConcurrency) {

--- a/src/main/java/io/reactivex/rxjava4/core/config/ObservableObserveOnConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/ObservableObserveOnConfig.java
@@ -17,45 +17,45 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 
 /**
- * Configuration record for Observable.zip() operators.
+ * Configuration record for Observable.observeOn() operators.
  * @param delayError should the error propagation be delayed?
- * @param bufferSize the expected number of items to cache from the inner {@code ObservableSource}s
+ * @param bufferSize the expected number of items to cache from the upstream
  * @since 4.0.0
  */
-public record ObservableZipConfig(boolean delayError, int bufferSize) {
+public record ObservableObserveOnConfig(boolean delayError, int bufferSize) {
 
     /**
      * The default configuration with no error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableZipConfig DEFAULT = new ObservableZipConfig(false);
+    public static final ObservableObserveOnConfig DEFAULT = new ObservableObserveOnConfig(false);
 
     /**
      * The default configuration with error delays and bufferSize of Observable.bufferSize().
      */
-    public static final ObservableZipConfig DELAY_ERROR = new ObservableZipConfig(true);
+    public static final ObservableObserveOnConfig DELAY_ERROR = new ObservableObserveOnConfig(true);
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
      */
-    public ObservableZipConfig(boolean delayError) {
+    public ObservableObserveOnConfig(boolean delayError) {
         this(delayError, Observable.bufferSize());
     }
 
     /**
      * Constructs a configuration record.
-     * @param bufferSize the expected number of row combination items to be buffered internally
+     * @param bufferSize the expected number of items to cache from the upstream
      */
-    public ObservableZipConfig(int bufferSize) {
+    public ObservableObserveOnConfig(int bufferSize) {
         this(false, bufferSize);
     }
 
     /**
      * Constructs a configuration record.
      * @param delayError should the error propagation be delayed?
-     * @param bufferSize the expected number of row combination items to be buffered internally
+     * @param bufferSize the expected number of items to cache from the upstream
      */
-    public ObservableZipConfig {
+    public ObservableObserveOnConfig {
         ObjectHelper.verifyPositive(bufferSize, "bufferSize");
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableCompletable.java
@@ -38,16 +38,19 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
     final boolean delayErrors;
 
+    final int bufferSize;
+
     public ObservableFlatMapCompletableCompletable(ObservableSource<T> source,
-            Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+            Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors, int bufferSize) {
         this.source = source;
         this.mapper = mapper;
         this.delayErrors = delayErrors;
+        this.bufferSize = bufferSize;
     }
 
     @Override
     protected void subscribeActual(CompletableObserver observer) {
-        source.subscribe(new FlatMapCompletableMainObserver<>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapCompletableMainObserver<>(observer, mapper, delayErrors, bufferSize));
     }
 
     @Override
@@ -67,16 +70,20 @@ public final class ObservableFlatMapCompletableCompletable<T> extends Completabl
 
         final boolean delayErrors;
 
+        final int bufferSize;
+
         final CompositeDisposable set;
 
         Disposable upstream;
 
         volatile boolean disposed;
 
-        FlatMapCompletableMainObserver(CompletableObserver observer, Function<? super T, ? extends CompletableSource> mapper, boolean delayErrors) {
+        FlatMapCompletableMainObserver(CompletableObserver observer, Function<? super T, ? extends CompletableSource> mapper,
+                boolean delayErrors, int bufferSize) {
             this.downstream = observer;
             this.mapper = mapper;
             this.delayErrors = delayErrors;
+            this.bufferSize = bufferSize;
             this.errors = new AtomicThrowable();
             this.set = new CompositeDisposable();
             this.lazySet(1);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybe.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybe.java
@@ -36,16 +36,20 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
 
     final boolean delayErrors;
 
+    final int bufferSize;
+
     public ObservableFlatMapMaybe(ObservableSource<T> source, Function<? super T, ? extends MaybeSource<? extends R>> mapper,
-            boolean delayError) {
+            boolean delayError,
+            int bufferSize) {
         super(source);
         this.mapper = mapper;
         this.delayErrors = delayError;
+        this.bufferSize = bufferSize;
     }
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapMaybeObserver<>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapMaybeObserver<>(observer, mapper, delayErrors, bufferSize));
     }
 
     static final class FlatMapMaybeObserver<T, R>
@@ -58,6 +62,8 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
         final Observer<? super R> downstream;
 
         final boolean delayErrors;
+
+        final int bufferSize;
 
         final CompositeDisposable set;
 
@@ -74,10 +80,11 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
         volatile boolean cancelled;
 
         FlatMapMaybeObserver(Observer<? super R> actual,
-                Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors) {
+                Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayErrors, int bufferSize) {
             this.downstream = actual;
             this.mapper = mapper;
             this.delayErrors = delayErrors;
+            this.bufferSize = bufferSize;
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
@@ -178,7 +185,7 @@ public final class ObservableFlatMapMaybe<T, R> extends AbstractObservableWithUp
             if (current != null) {
                 return current;
             }
-            current = new SpscLinkedArrayQueue<>(Observable.bufferSize());
+            current = new SpscLinkedArrayQueue<>(bufferSize);
             if (queue.compareAndSet(null, current)) {
                 return current;
             }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingle.java
@@ -36,16 +36,21 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
 
     final boolean delayErrors;
 
-    public ObservableFlatMapSingle(ObservableSource<T> source, Function<? super T, ? extends SingleSource<? extends R>> mapper,
-            boolean delayError) {
+    final int bufferSize;
+
+    public ObservableFlatMapSingle(ObservableSource<T> source,
+            Function<? super T, ? extends SingleSource<? extends R>> mapper,
+            boolean delayError,
+            int bufferSize) {
         super(source);
         this.mapper = mapper;
         this.delayErrors = delayError;
+        this.bufferSize = bufferSize;
     }
 
     @Override
     protected void subscribeActual(Observer<? super R> observer) {
-        source.subscribe(new FlatMapSingleObserver<>(observer, mapper, delayErrors));
+        source.subscribe(new FlatMapSingleObserver<>(observer, mapper, delayErrors, bufferSize));
     }
 
     static final class FlatMapSingleObserver<T, R>
@@ -58,6 +63,8 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
         final Observer<? super R> downstream;
 
         final boolean delayErrors;
+
+        final int bufferSize;
 
         final CompositeDisposable set;
 
@@ -74,10 +81,12 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
         volatile boolean cancelled;
 
         FlatMapSingleObserver(Observer<? super R> actual,
-                Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayErrors) {
+                Function<? super T, ? extends SingleSource<? extends R>> mapper,
+                boolean delayErrors, int bufferSize) {
             this.downstream = actual;
             this.mapper = mapper;
             this.delayErrors = delayErrors;
+            this.bufferSize = bufferSize;
             this.set = new CompositeDisposable();
             this.errors = new AtomicThrowable();
             this.active = new AtomicInteger(1);
@@ -178,7 +187,7 @@ public final class ObservableFlatMapSingle<T, R> extends AbstractObservableWithU
             if (current != null) {
                 return current;
             }
-            current = new SpscLinkedArrayQueue<>(Observable.bufferSize());
+            current = new SpscLinkedArrayQueue<>(bufferSize);
             if (queue.compareAndSet(null, current)) {
                 return current;
             }

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableGroupByConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableGroupByConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObservableGroupByConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new ObservableGroupByConfig(true).delayError(), "delayError - true");
+        assertFalse(new ObservableGroupByConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new ObservableGroupByConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableGroupByConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
+        assertEquals(5, new ObservableGroupByConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
+        assertTrue(new ObservableGroupByConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new ObservableGroupByConfig(false, 5).delayError(), "delayError both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/config/ObservableObbserveOnConfigTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/config/ObservableObbserveOnConfigTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core.config;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObservableObbserveOnConfigTest extends RxJavaTest {
+
+    @Test
+    public void validation() {
+        assertTrue(new ObservableObserveOnConfig(true).delayError(), "delayError - true");
+        assertFalse(new ObservableObserveOnConfig(false).delayError(), "delayError - false");
+        assertEquals(5, new ObservableObserveOnConfig(5).bufferSize(), "bufferSize - 5");
+        assertEquals(5, new ObservableObserveOnConfig(true, 5).bufferSize(), "bufferSize both - true, 5");
+        assertEquals(5, new ObservableObserveOnConfig(false, 5).bufferSize(), "bufferSize both - false, 5");
+        assertTrue(new ObservableObserveOnConfig(true, 5).delayError(), "delayError both - true, 5");
+        assertFalse(new ObservableObserveOnConfig(false, 5).delayError(), "delayError both - false, 5");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableTakeLastTimedTest.java
@@ -16,13 +16,14 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.concurrent.Flow.Subscriber;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.mockito.InOrder;
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableObserveOnConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.schedulers.*;
@@ -281,7 +282,7 @@ public class FlowableTakeLastTimedTest extends RxJavaTest {
         Observable.range(1, 1000)
         .takeLast(1, TimeUnit.DAYS)
         .take(500)
-        .observeOn(Schedulers.single(), true, 1)
+        .observeOn(Schedulers.single(), new ObservableObserveOnConfig(true, 1))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapCompletableTest.java
@@ -21,12 +21,12 @@ import java.util.concurrent.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.observers.TestObserver;
-import io.reactivex.rxjava4.operators.QueueDisposable;
-import io.reactivex.rxjava4.operators.QueueFuseable;
+import io.reactivex.rxjava4.operators.*;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.*;
@@ -80,7 +80,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorObservable() {
         Observable.range(1, 10)
-        .flatMapCompletable(_ -> Completable.complete(), true).toObservable()
+        .flatMapCompletable(_ -> Completable.complete(), new ObservableMergeConfig(true)).toObservable()
         .test()
         .assertResult();
     }
@@ -97,7 +97,8 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAllObservable() {
         TestObserverEx<Integer> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(_ -> Completable.error(new TestException()), true).<Integer>toObservable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), new ObservableMergeConfig(true))
+        .<Integer>toObservable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -111,7 +112,8 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAllObservable() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
-        .flatMapCompletable(_ -> Completable.error(new TestException()), true).<Integer>toObservable()
+        .flatMapCompletable(_ -> Completable.error(new TestException()), new ObservableMergeConfig(true))
+        .<Integer>toObservable()
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -125,7 +127,8 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuterObservable() {
         Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(_ -> Completable.complete(), false).toObservable()
+        .flatMapCompletable(_ -> Completable.complete(), new ObservableMergeConfig(false))
+        .toObservable()
         .test()
         .assertFailure(TestException.class);
     }
@@ -197,7 +200,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapCompletable(_ -> Completable.complete(), true)
+        .flatMapCompletable(_ -> Completable.complete(), new ObservableMergeConfig(true))
         .test()
         .assertResult();
     }
@@ -214,7 +217,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestObserverEx<Void> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(_ -> Completable.error(new TestException()), true)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), new ObservableMergeConfig(true))
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -228,7 +231,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalDelayInnerErrorAll() {
         TestObserverEx<Void> to = Observable.range(1, 10)
-        .flatMapCompletable(_ -> Completable.error(new TestException()), true)
+        .flatMapCompletable(_ -> Completable.error(new TestException()), new ObservableMergeConfig(true))
         .to(TestHelper.<Void>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -242,7 +245,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void normalNonDelayErrorOuter() {
         Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapCompletable(_ -> Completable.complete(), false)
+        .flatMapCompletable(_ -> Completable.complete(), new ObservableMergeConfig(false))
         .test()
         .assertFailure(TestException.class);
     }
@@ -356,7 +359,7 @@ public class ObservableFlatMapCompletableTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
-            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide(), true));
+            upstream.flatMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide(), new ObservableMergeConfig(true)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
@@ -52,7 +53,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, true)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) Maybe::just, new ObservableMergeConfig(true))
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -110,7 +111,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     public void normalDelayErrorAll() {
         TestObserverEx<Integer> to = Observable.range(1, 10)
                 .concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()), true)
+        .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> Maybe.error(new TestException()), new ObservableMergeConfig(true))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -188,7 +189,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
                 return ps.singleElement();
             }
             return Maybe.error(new TestException());
-        }, true)
+        }, new ObservableMergeConfig(true))
         .test();
 
         ps.onNext(1);
@@ -208,7 +209,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
                 return ps.singleElement();
             }
             return Maybe.error(new TestException());
-        }, true)
+        }, new ObservableMergeConfig(true))
         .test();
 
         ps.onComplete();
@@ -371,7 +372,7 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true));
+            upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), new ObservableMergeConfig(true)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.*;
 import org.junit.Test;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.Function;
@@ -44,7 +45,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayError() {
         Observable.range(1, 10)
-        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, true)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) Single::just, new ObservableMergeConfig(true))
         .test()
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     }
@@ -101,7 +102,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void normalDelayErrorAll() {
         TestObserverEx<Integer> to = Observable.range(1, 10).concatWith(Observable.<Integer>error(new TestException()))
-        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()), true)
+        .flatMapSingle((Function<Integer, SingleSource<Integer>>) _ -> Single.error(new TestException()), new ObservableMergeConfig(true))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -169,7 +170,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
                 return ps.singleOrError();
             }
             return Single.error(new TestException());
-        }, true)
+        }, new ObservableMergeConfig(true))
         .test();
 
         ps.onNext(1);
@@ -305,7 +306,7 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true));
+            upstream.flatMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), new ObservableMergeConfig(true)));
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -270,7 +270,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Observable<Integer> source = Observable.range(1, 10)
         .flatMap((Function<Integer, Observable<Integer>>) t1 -> composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
-                .subscribeOn(Schedulers.computation()), m);
+                .subscribeOn(Schedulers.computation()), new ObservableMergeConfig(m));
 
         TestObserver<Integer> to = new TestObserver<>();
 
@@ -291,7 +291,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         final AtomicInteger subscriptionCount = new AtomicInteger();
         Observable<Integer> source = Observable.range(1, 10)
             .flatMap((Function<Integer, Observable<Integer>>) t1 -> composer(Observable.range(t1 * 10, 2), subscriptionCount, m)
-                    .subscribeOn(Schedulers.computation()), (t1, t2) -> t1 * 1000 + t2, m);
+                    .subscribeOn(Schedulers.computation()), (t1, t2) -> t1 * 1000 + t2, new ObservableMergeConfig(m));
 
         TestObserver<Integer> to = new TestObserver<>();
 
@@ -430,7 +430,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapper() {
         Observable.just(1)
-        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10), Integer::sum, true)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10),
+                Integer::sum, new ObservableMergeConfig(true))
         .test()
         .assertResult(11);
     }
@@ -438,7 +439,9 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperWithError() {
         Observable.just(1)
-        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10).concatWith(Observable.<Integer>error(new TestException())), Integer::sum, true)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v ->
+            Observable.just(v * 10).concatWith(Observable.<Integer>error(new TestException())), Integer::sum,
+            new ObservableMergeConfig(true))
         .test()
         .assertFailure(TestException.class, 11);
     }
@@ -446,7 +449,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void flatMapBiMapperMaxConcurrency() {
         Observable.just(1, 2)
-        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10), Integer::sum, true, 1)
+        .flatMap((Function<Integer, ObservableSource<Integer>>) v -> Observable.just(v * 10), Integer::sum,
+                new ObservableMergeConfig(true, 1))
         .test()
         .assertResult(11, 22);
     }
@@ -562,7 +566,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
         TestObserverEx<Integer> to = Observable.range(1, 2).hide()
         .flatMap((Function<Integer, ObservableSource<Integer>>) _ -> Observable.range(1, 2).map((Function<Integer, Integer>) _ -> {
             throw new TestException();
-        }), true)
+        }), new ObservableMergeConfig(true))
         .to(TestHelper.<Integer>testConsumer())
         .assertFailure(CompositeException.class);
 
@@ -695,7 +699,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
         try {
             final PublishSubject<Integer> ps = PublishSubject.create();
 
-            TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1), 1)
+            TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1),
+                    new ObservableMergeConfig(1))
             .subscribeWith(new TestObserver<Integer>() /* NFI */ {
                 @Override
                 public void onNext(Integer t) {
@@ -725,7 +730,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
     public void scalarQueueNoOverflowHidden() {
         final PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(), 1)
+        TestObserver<Integer> to = ps.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v + 1).hide(),
+                new ObservableMergeConfig(1))
         .subscribeWith(new TestObserver<Integer>() /* NFI */ {
             @Override
             public void onNext(Integer t) {
@@ -785,7 +791,8 @@ public class ObservableFlatMapTest extends RxJavaTest {
         PublishSubject<Integer> ps4 = PublishSubject.create();
 
         TestObserver<Integer> to = Observable.just(ps1, ps2, ps3, ps4)
-        .flatMap((Function<PublishSubject<Integer>, ObservableSource<Integer>>) v -> v, 2)
+        .flatMap((Function<PublishSubject<Integer>, ObservableSource<Integer>>) v -> v,
+                new ObservableMergeConfig(2))
         .doOnNext(v -> {
             if (v == 1) {
                 // this will make sure the drain loop detects two completed
@@ -818,7 +825,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), true));
+            upstream.flatMap((Function<Integer, Observable<Integer>>) v -> Observable.just(v).hide(), new ObservableMergeConfig(true)));
     }
 
     @Test
@@ -935,7 +942,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
                 })
                 .compose(TestHelper.observableStripBoundary())
         )
-        .flatMap(v -> v, true)
+        .flatMap(v -> v, new ObservableMergeConfig(true))
         .doOnNext(v -> {
             if (v == 1) {
                 ps.onNext(2);
@@ -965,7 +972,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
                 .compose(TestHelper.observableStripBoundary())
                 , ps
         )
-        .flatMap(v -> v, true)
+        .flatMap(v -> v, new ObservableMergeConfig(true))
         .doOnNext(v -> {
             if (v == 1) {
                 ps.onNext(2);
@@ -996,8 +1003,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
                                 .just(-integer)
                                 .observeOn(Schedulers.computation());
                     },
-                    false,
-                    1
+                    new ObservableMergeConfig(false, 1)
             )
             .ignoreElements()
             .blockingAwait();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableGroupByTest.java
@@ -27,9 +27,10 @@ import org.mockito.Mockito;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
+import io.reactivex.rxjava4.core.config.ObservableGroupByConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observables.GroupedObservable;
 import io.reactivex.rxjava4.observers.*;
@@ -932,7 +933,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @SuppressUndeliverable
     public void keySelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
-        .groupBy(Functions.<Integer>identity(), true)
+        .groupBy(Functions.<Integer>identity(), new ObservableGroupByConfig(true))
         .flatMap((Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>) g -> g)
         .test()
         .assertFailure(TestException.class, 1);
@@ -942,7 +943,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @SuppressUndeliverable
     public void keyAndValueSelectorAndDelayError() {
         Observable.just(1).concatWith(Observable.<Integer>error(new TestException()))
-        .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), true)
+        .groupBy(Functions.<Integer>identity(), Functions.<Integer>identity(), new ObservableGroupByConfig(true))
         .flatMap((Function<GroupedObservable<Integer, Integer>, ObservableSource<Integer>>) g -> g)
         .test()
         .assertFailure(TestException.class, 1);
@@ -1006,7 +1007,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     @Test
     public void delayErrorSimpleComplete() {
         Observable.just(1)
-        .groupBy(Functions.justFunction(1), true)
+        .groupBy(Functions.justFunction(1), new ObservableGroupByConfig(true))
         .flatMap(Functions.<Observable<Integer>>identity())
         .test()
         .assertResult(1);
@@ -1142,7 +1143,7 @@ public class ObservableGroupByTest extends RxJavaTest {
     public void delayErrorCompleteMoreWorkInGroup() {
         PublishSubject<Integer> ps = PublishSubject.create();
 
-        TestObserver<Integer> to = ps.groupBy(_ -> 1, true)
+        TestObserver<Integer> to = ps.groupBy(_ -> 1,new ObservableGroupByConfig(true))
         .flatMap(g -> g.doOnNext(v -> {
             if (v == 1) {
                 ps.onNext(2);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableObserveOnTest.java
@@ -29,6 +29,7 @@ import io.reactivex.rxjava4.annotations.Nullable;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
+import io.reactivex.rxjava4.core.config.ObservableObserveOnConfig;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
@@ -398,7 +399,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
     @Test
     public void delayError() {
         Observable.range(1, 5).concatWith(Observable.<Integer>error(new TestException()))
-        .observeOn(Schedulers.computation(), true)
+        .observeOn(Schedulers.computation(), new ObservableObserveOnConfig(true))
         .doOnNext(v -> {
             if (v == 1) {
                 Thread.sleep(100);
@@ -494,7 +495,8 @@ public class ObservableObserveOnTest extends RxJavaTest {
     public void inputAsyncFusedErrorDelayed() {
         UnicastSubject<Integer> us = UnicastSubject.create();
 
-        TestObserver<Integer> to = us.observeOn(Schedulers.single(), true).test();
+        TestObserver<Integer> to = us.observeOn(Schedulers.single(),new ObservableObserveOnConfig(true))
+                .test();
 
         us.onError(new TestException());
 
@@ -555,7 +557,7 @@ public class ObservableObserveOnTest extends RxJavaTest {
 
         UnicastSubject<Integer> us = UnicastSubject.create();
 
-        us.observeOn(Schedulers.single(), true)
+        us.observeOn(Schedulers.single(), new ObservableObserveOnConfig(true))
         .subscribe(to);
 
         us.onError(new TestException());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableTakeLastTimedTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.ObservableObserveOnConfig;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.*;
@@ -244,7 +245,7 @@ public class ObservableTakeLastTimedTest extends RxJavaTest {
         Observable.range(1, 1000)
         .takeLast(1, TimeUnit.DAYS)
         .take(500)
-        .observeOn(Schedulers.single(), true, 1)
+        .observeOn(Schedulers.single(), new ObservableObserveOnConfig(true, 1))
         .to(TestHelper.<Integer>testConsumer())
         .awaitDone(5, TimeUnit.SECONDS)
         .assertSubscribed()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithObservableTest.java
@@ -26,9 +26,10 @@ import org.junit.Test;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
+import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -259,7 +260,7 @@ public class ObservableWindowWithObservableTest extends RxJavaTest {
     public void boundaryOnError() {
         TestObserverEx<Object> to = Observable.error(new TestException())
         .window(Observable.never())
-        .flatMap(Functions.<Observable<Object>>identity(), true)
+        .flatMap(Functions.<Observable<Object>>identity(), new ObservableMergeConfig(true))
         .to(TestHelper.testConsumer())
         .assertFailure(CompositeException.class);
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithTimeTest.java
@@ -24,6 +24,7 @@ import org.junit.*;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
+import io.reactivex.rxjava4.core.config.ObservableMergeConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
@@ -227,7 +228,7 @@ public class ObservableWindowWithTimeTest extends RxJavaTest {
     public void timespanDefaultSchedulerSizeRestart() {
         Observable.range(1, 10)
         .window(1, TimeUnit.MINUTES, 20, true)
-        .flatMap(Functions.<Observable<Integer>>identity(), true)
+        .flatMap(Functions.<Observable<Integer>>identity(), new ObservableMergeConfig(true))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -637,6 +637,9 @@ public class CheckParamValidationTest extends RxJavaTest {
         defaultValues.put(ObservableZipConfig.class, ObservableZipConfig.DEFAULT);
         defaultValues.put(ObservableConcatMapConfig.class, ObservableConcatMapConfig.DEFAULT);
 
+        defaultValues.put(ObservableGroupByConfig.class, ObservableGroupByConfig.DEFAULT);
+        defaultValues.put(ObservableObserveOnConfig.class, ObservableObserveOnConfig.DEFAULT);
+
         // TODO insert new config record types here
 
         @SuppressWarnings("rawtypes")


### PR DESCRIPTION
Reduce API surface by combining multiple overloads into one record-based configuration overload.

# Observable

- `flatMap*` to use `ObservableMergeConfig` since it should behave the same as `merge`
- `groupBy` to use `ObservableGroupByConfig`
- `observeOn` to use `ObservableObserveOnConfig`

## Notes

- Maybe later, the very similar records of `(delayError boolean, bufferSize int)` will be unified into one config record.

Related: #8173