### PR TITLE
4.x: Cleanup API reduction - Observable.switchMap

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -11332,13 +11332,13 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #switchMapDelayError(Function)
+     * @see #switchMap(Function, ObservableSwitchConfig)
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
     public final <@NonNull R> Observable<R> switchMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return switchMap(mapper, bufferSize());
+        return switchMap(mapper, ObservableSwitchConfig.DEFAULT);
     }
 
     /**
@@ -11359,20 +11359,20 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
      *            {@code ObservableSource}
-     * @param bufferSize
-     *            the number of elements expected from the current active inner {@code ObservableSource} to be buffered
+     * @param config
+     *            the configuration record for this operator
      * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
+     * @throws NullPointerException if {@code mapper} or {@code config} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #switchMapDelayError(Function, int)
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> switchMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
+    public final <@NonNull R> Observable<R> switchMap(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper,
+            @NonNull ObservableSwitchConfig config) {
         Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
+        Objects.requireNonNull(config, "config is null");
         if (this instanceof ScalarSupplier) {
             @SuppressWarnings("unchecked")
             T v = ((ScalarSupplier<T>)this).get();
@@ -11381,7 +11381,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
             }
             return ObservableScalarXMap.scalarXMap(v, mapper);
         }
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<>(this, mapper, bufferSize, false));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<>(this, mapper, config.bufferSize(), config.delayError()));
     }
 
     /**
@@ -11401,7 +11401,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *  <dt><b>Error handling:</b></dt>
      *  <dd>If either the current {@code Observable} or the active {@code CompletableSource} signals an {@code onError},
      *  the resulting {@code Completable} is terminated immediately with that {@link Throwable}.
-     *  Use the {@link #switchMapCompletableDelayError(Function)} to delay such inner failures until
+     *  Use the {@link #switchMapCompletable(Function, boolean)} to delay such inner failures until
      *  every inner {@code CompletableSource}s and the main {@code Observable} terminates in some fashion.
      *  If they fail concurrently, the operator may combine the {@code Throwable}s into a
      *  {@link CompositeException}
@@ -11416,7 +11416,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *               (non blockingly) for its terminal event
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #switchMapCompletableDelayError(Function)
+     * @see #switchMapCompletable(Function, boolean)
      * @since 2.2
      */
     @CheckReturnValue
@@ -11441,7 +11441,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * {@code Observable}.
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMapCompletableDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapCompletable} does not operate by default on a particular {@link Scheduler}.</dd>
      *  <dt><b>Error handling:</b></dt>
      *  <dd>The errors of the current {@code Observable} and all the {@code CompletableSource}s, who had the chance
      *  to run to their completion, are delayed until
@@ -11458,17 +11458,18 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @param mapper the function called with each upstream item and should return a
      *               {@code CompletableSource} to be subscribed to and awaited for
      *               (non blockingly) for its terminal event
+     * @param delayError if {@code true}, errors from the outer and inner sources will be delayed
      * @return the new {@code Completable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see #switchMapCompletable(Function)
-     * @since 2.2
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final Completable switchMapCompletableDelayError(@NonNull Function<? super T, ? extends CompletableSource> mapper) {
+    public final Completable switchMapCompletable(@NonNull Function<? super T, ? extends CompletableSource> mapper, boolean delayError) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapCompletable<>(this, mapper, delayError));
     }
 
     /**
@@ -11498,7 +11499,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      *               and get subscribed to.
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see #switchMapMaybeDelayError(Function)
+     * @see #switchMapMaybe(Function, boolean)
      * @since 2.2
      */
     @CheckReturnValue
@@ -11517,24 +11518,25 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <img width="640" height="469" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapMaybeDelayError.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMapMaybeDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapMaybe} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.1.11 - experimental
      * @param <R> the output value type
      * @param mapper the function called with the current upstream event and should
      *               return a {@code MaybeSource} to replace the current active inner source
      *               and get subscribed to.
+     * @param delayError if {@code true}, errors from the outer and inner sources will be delayed
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see #switchMapMaybe(Function)
-     * @since 2.2
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> switchMapMaybeDelayError(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper) {
+    public final <@NonNull R> Observable<R> switchMapMaybe(@NonNull Function<? super T, ? extends MaybeSource<? extends R>> mapper, boolean delayError) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapMaybe<>(this, mapper, delayError));
     }
 
     /**
@@ -11558,7 +11560,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #switchMapSingleDelayError(Function)
+     * @see #switchMapSingle(Function, boolean)
      * @since 2.2
      */
     @CheckReturnValue
@@ -11581,102 +11583,26 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * <img width="640" height="467" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMapSingleDelayError.o.png" alt="">
      * <dl>
      *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMapSingleDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
+     *  <dd>{@code switchMapSingle} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * <p>History: 2.0.8 - experimental
      * @param <R> the element type of the inner {@code SingleSource}s and the output
      * @param mapper
      *            a function that, when applied to an item emitted by the current {@code Observable}, returns a
      *            {@code SingleSource}
+     * @param delayError if {@code true}, errors from the outer and inner sources will be delayed
      * @return the new {@code Observable} instance
      * @throws NullPointerException if {@code mapper} is {@code null}
      * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
      * @see #switchMapSingle(Function)
-     * @since 2.2
+     * @since 4.0.0
      */
     @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
     @NonNull
-    public final <@NonNull R> Observable<R> switchMapSingleDelayError(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper) {
+    public final <@NonNull R> Observable<R> switchMapSingle(@NonNull Function<? super T, ? extends SingleSource<? extends R>> mapper, boolean delayError) {
         Objects.requireNonNull(mapper, "mapper is null");
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<>(this, mapper, true));
-    }
-
-    /**
-     * Returns a new {@code Observable} by applying a function that you supply to each item emitted by the current
-     * {@code Observable} that returns an {@link ObservableSource}, and then emitting the items emitted by the most recently emitted
-     * of these {@code ObservableSource}s and delays any error until all {@code ObservableSource}s terminate.
-     * <p>
-     * The resulting {@code Observable} completes if both the current {@code Observable} and the last inner {@code ObservableSource}, if any, complete.
-     * If the current {@code Observable} signals an {@code onError}, the termination of the last inner {@code ObservableSource} will emit that error as is
-     * or wrapped into a {@link CompositeException} along with the other possible errors the former inner {@code ObservableSource}s signaled.
-     * <p>
-     * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the element type of the inner {@code ObservableSource}s and the output
-     * @param mapper
-     *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
-     *            {@code ObservableSource}
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #switchMap(Function)
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> switchMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper) {
-        return switchMapDelayError(mapper, bufferSize());
-    }
-
-    /**
-     * Returns a new {@code Observable} by applying a function that you supply to each item emitted by the current
-     * {@code Observable} that returns an {@link ObservableSource}, and then emitting the items emitted by the most recently emitted
-     * of these {@code ObservableSource}s and delays any error until all {@code ObservableSource}s terminate.
-     * <p>
-     * The resulting {@code Observable} completes if both the current {@code Observable} and the last inner {@code ObservableSource}, if any, complete.
-     * If the current {@code Observable} signals an {@code onError}, the termination of the last inner {@code ObservableSource} will emit that error as is
-     * or wrapped into a {@link CompositeException} along with the other possible errors the former inner {@code ObservableSource}s signaled.
-     * <p>
-     * <img width="640" height="350" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/switchMap.v3.png" alt="">
-     * <dl>
-     *  <dt><b>Scheduler:</b></dt>
-     *  <dd>{@code switchMapDelayError} does not operate by default on a particular {@link Scheduler}.</dd>
-     * </dl>
-     *
-     * @param <R> the element type of the inner {@code ObservableSource}s and the output
-     * @param mapper
-     *            a function that, when applied to an item emitted by the current {@code Observable}, returns an
-     *            {@code ObservableSource}
-     * @param bufferSize
-     *            the number of elements expected from the current active inner {@code ObservableSource} to be buffered
-     * @return the new {@code Observable} instance
-     * @throws NullPointerException if {@code mapper} is {@code null}
-     * @throws IllegalArgumentException if {@code bufferSize} is non-positive
-     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
-     * @see #switchMap(Function, int)
-     * @since 2.0
-     */
-    @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
-    @NonNull
-    public final <@NonNull R> Observable<R> switchMapDelayError(@NonNull Function<? super T, ? extends ObservableSource<? extends R>> mapper, int bufferSize) {
-        Objects.requireNonNull(mapper, "mapper is null");
-        ObjectHelper.verifyPositive(bufferSize, "bufferSize");
-        if (this instanceof ScalarSupplier) {
-            @SuppressWarnings("unchecked")
-            T v = ((ScalarSupplier<T>)this).get();
-            if (v == null) {
-                return empty();
-            }
-            return ObservableScalarXMap.scalarXMap(v, mapper);
-        }
-        return RxJavaPlugins.onAssembly(new ObservableSwitchMap<>(this, mapper, bufferSize, true));
+        return RxJavaPlugins.onAssembly(new ObservableSwitchMapSingle<>(this, mapper, delayError));
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapCompletableTest.java
@@ -269,7 +269,7 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Void> to = ps.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+        TestObserver<Void> to = ps.switchMapCompletable(Functions.justFunction(cs), true).test();
 
         ps.onNext(1);
 
@@ -289,7 +289,7 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Void> to = ps.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+        TestObserver<Void> to = ps.switchMapCompletable(Functions.justFunction(cs), true).test();
 
         ps.onNext(1);
         ps.onComplete();
@@ -306,7 +306,7 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final CompletableSubject cs = CompletableSubject.create();
 
-        TestObserver<Void> to = ps.switchMapCompletableDelayError(Functions.justFunction(cs)).test();
+        TestObserver<Void> to = ps.switchMapCompletable(Functions.justFunction(cs), true).test();
 
         ps.onNext(1);
 
@@ -370,6 +370,6 @@ public class ObservableSwitchMapCompletableTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Completable>) upstream ->
-            upstream.switchMapCompletableDelayError((Function<Integer, Completable>) _ -> Completable.complete().hide()));
+            upstream.switchMapCompletable((Function<Integer, Completable>) _ -> Completable.complete().hide(), true));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapMaybeTest.java
@@ -134,12 +134,12 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
         final MaybeSubject<Integer> ms1 = MaybeSubject.create();
         final MaybeSubject<Integer> ms2 = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+        TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
                     if (v == 1) {
                         return ms1;
                     }
                     return ms2;
-                }).test();
+                }, true).test();
 
         to.assertEmpty();
 
@@ -171,7 +171,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
+        TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> ms, true).test();
 
         to.assertEmpty();
 
@@ -198,7 +198,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
+        TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> ms, true).test();
 
         to.assertEmpty();
 
@@ -265,7 +265,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
         final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
+        TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> ms, true).test();
 
         to.assertEmpty();
 
@@ -347,7 +347,7 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) _ -> ms).test();
+            final TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) _ -> ms, true).test();
 
             Runnable r1 = () -> ps.onNext(1);
 
@@ -372,12 +372,12 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestObserverEx<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                final TestObserverEx<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
                     if (v == 1) {
                         return ms;
                     }
                     return Maybe.never();
-                }).to(TestHelper.<Integer>testConsumer());
+                }, true).to(TestHelper.<Integer>testConsumer());
 
                 ps.onNext(1);
 
@@ -412,12 +412,12 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
                 final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-                final TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+                final TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
                     if (v == 1) {
                         return ms;
                     }
                     return Maybe.never();
-                }).test();
+                }, true).test();
 
                 ps.onNext(1);
 
@@ -446,12 +446,12 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
 
             final MaybeSubject<Integer> ms = MaybeSubject.create();
 
-            final TestObserver<Integer> to = ps.switchMapMaybeDelayError((Function<Integer, MaybeSource<Integer>>) v -> {
+            final TestObserver<Integer> to = ps.switchMapMaybe((Function<Integer, MaybeSource<Integer>>) v -> {
                 if (v == 1) {
                         return ms;
                 }
                 return Maybe.empty();
-            }).test();
+            }, true).test();
 
             ps.onNext(1);
 
@@ -545,6 +545,6 @@ public class ObservableSwitchMapMaybeTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.switchMapMaybeDelayError((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
+            upstream.switchMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide(), true));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/mixed/ObservableSwitchMapSingleTest.java
@@ -113,12 +113,12 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
         final SingleSubject<Integer> ss1 = SingleSubject.create();
         final SingleSubject<Integer> ss2 = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+        TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
                     if (v == 1) {
                         return ss1;
                     }
                     return ss2;
-                }).test();
+                }, true).test();
 
         to.assertEmpty();
 
@@ -150,7 +150,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
+        TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> ss, true).test();
 
         to.assertEmpty();
 
@@ -177,7 +177,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
+        TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> ss, true).test();
 
         to.assertEmpty();
 
@@ -244,7 +244,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
         final SingleSubject<Integer> ss = SingleSubject.create();
 
-        TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
+        TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> ss, true).test();
 
         to.assertEmpty();
 
@@ -325,7 +325,7 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
             final SingleSubject<Integer> ss = SingleSubject.create();
 
-            final TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) _ -> ss).test();
+            final TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) _ -> ss, true).test();
 
             Runnable r1 = () -> ps.onNext(1);
 
@@ -350,12 +350,12 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
                 final SingleSubject<Integer> ss = SingleSubject.create();
 
-                final TestObserverEx<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                final TestObserverEx<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
                     if (v == 1) {
                         return ss;
                     }
                     return Single.never();
-                }).to(TestHelper.<Integer>testConsumer());
+                }, true).to(TestHelper.<Integer>testConsumer());
 
                 ps.onNext(1);
 
@@ -390,12 +390,12 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
                 final SingleSubject<Integer> ss = SingleSubject.create();
 
-                final TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+                final TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
                     if (v == 1) {
                         return ss;
                     }
                     return Single.never();
-                }).test();
+                }, true).test();
 
                 ps.onNext(1);
 
@@ -424,12 +424,12 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
 
             final SingleSubject<Integer> ss = SingleSubject.create();
 
-            final TestObserver<Integer> to = ps.switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+            final TestObserver<Integer> to = ps.switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
                 if (v == 1) {
                         return ss;
                 }
                 return Single.never();
-            }).test();
+            }, true).test();
 
             ps.onNext(1);
 
@@ -523,6 +523,6 @@ public class ObservableSwitchMapSingleTest extends RxJavaTest {
     @Test
     public void undeliverableUponCancelDelayError() {
         TestHelper.checkUndeliverableUponCancel((ObservableConverter<Integer, Observable<Integer>>) upstream ->
-            upstream.switchMapSingleDelayError((Function<Integer, Single<Integer>>) v -> Single.just(v).hide()));
+            upstream.switchMapSingle((Function<Integer, Single<Integer>>) v -> Single.just(v).hide(), true));
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -399,7 +399,8 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void delayErrors() {
         PublishSubject<ObservableSource<Integer>> source = PublishSubject.create();
 
-        TestObserverEx<Integer> to = source.switchMapDelayError(Functions.<ObservableSource<Integer>>identity())
+        TestObserverEx<Integer> to = source
+                .switchMap(Functions.<ObservableSource<Integer>>identity(), ObservableSwitchConfig.DELAY_ERROR)
                 .to(TestHelper.<Integer>testConsumer());
 
         to.assertNoValues()
@@ -472,13 +473,13 @@ public class ObservableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapDelayErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .switchMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16));
+                .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableSwitchConfig(16)));
     }
 
     @Test
     public void switchMapDelayErrorJustSource() {
         Observable.just(0)
-        .switchMapDelayError((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16)
+        .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableSwitchConfig(16))
         .test()
         .assertResult(1);
     }
@@ -486,13 +487,13 @@ public class ObservableSwitchTest extends RxJavaTest {
     @Test
     public void switchMapErrorEmptySource() {
         assertSame(Observable.empty(), Observable.<Object>empty()
-                .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16));
+                .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableSwitchConfig(16)));
     }
 
     @Test
     public void switchMapJustSource() {
         Observable.just(0)
-        .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), 16)
+        .switchMap((Function<Object, ObservableSource<Integer>>) _ -> Observable.just(1), new ObservableSwitchConfig(16))
         .test()
         .assertResult(1);
 
@@ -544,13 +545,13 @@ public class ObservableSwitchTest extends RxJavaTest {
     public void switchMapSingleDelayErrorJustSource() {
         final AtomicBoolean completed = new AtomicBoolean();
         Observable.just(0, 1)
-        .switchMapSingleDelayError((Function<Integer, SingleSource<Integer>>) v -> {
+        .switchMapSingle((Function<Integer, SingleSource<Integer>>) v -> {
             if (v == 0) {
                 return Single.error(new RuntimeException());
             } else {
                 return Single.just(1).doOnSuccess(_ -> completed.set(true));
             }
-        })
+        }, true)
         .test()
         .assertValue(1)
         .assertError(RuntimeException.class);
@@ -937,14 +938,14 @@ public class ObservableSwitchTest extends RxJavaTest {
         PublishSubject<Integer> ps = PublishSubject.create();
 
         TestObserver<Integer> to = ps
-        .switchMapDelayError(Functions.justFunction(
+        .switchMap(Functions.justFunction(
                 Observable.range(1, 5)
                 .observeOn(ImmediateThinScheduler.INSTANCE)
                 .map((Function<Integer, Integer>) _ -> {
                     throw new TestException();
                 })
                 .compose(TestHelper.<Integer>observableStripBoundary())
-        ))
+        ), ObservableSwitchConfig.DELAY_ERROR)
         .test();
 
         to.assertEmpty();
@@ -1129,7 +1130,7 @@ public class ObservableSwitchTest extends RxJavaTest {
         PublishSubject<Integer> ps1 = PublishSubject.create();
         PublishSubject<Integer> ps2 = PublishSubject.create();
 
-        TestObserver<Integer> to = ps1.switchMapDelayError(_ -> ps2)
+        TestObserver<Integer> to = ps1.switchMap(_ -> ps2, ObservableSwitchConfig.DELAY_ERROR)
         .test();
 
         ps1.onNext(1);


### PR DESCRIPTION
Reduce the API surface by turning overloads into record configurations.

# Observable

- `switchMap` to use `ObservableSwitchConfig`
- `switchMapCompletableDelayError` -> `switchMapCompletable(Function, boolean)` because there is nothing to buffer so `ObservableSwitchConfig` is an overkill.
- `switchMapMaybeDelayError` -> `switchMapMaybe(Function, boolean)` because there is only ever one thingto buffer so `ObservableSwitchConfig` is an overkill.
- `switchMapSingleDelayError` -> `switchMapSingle(Function, boolean)` because there is only ever one thingto buffer so `ObservableSwitchConfig` is an overkill.

Related: #8173