### PR TITLE
4.x: Remove Pioneer-RetryTest as it is itself flaky?!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ ext {
     guavaVersion = "33.6.0-jre"
     jupiterVersion = "6.1.1"
     jupiterLauncherVersion = "6.1.1"
-    junitPioneerVersion = "2.3.0"
 }
 
 def releaseTag = System.getenv("BUILD_TAG")
@@ -55,8 +54,6 @@ dependencies {
     testImplementation "org.junit.platform:junit-platform-launcher:$jupiterLauncherVersion"
 
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:$jupiterLauncherVersion"  // already have this
-
-    testImplementation "org.junit-pioneer:junit-pioneer:$junitPioneerVersion"
 }
 
 // === Experimental JDK handling for Outreach Program ===

--- a/src/test/java/io/reactivex/rxjava4/core/RxJavaSelfTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/RxJavaSelfTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public final class RxJavaSelfTest extends RxJavaTest {
+
+    @Test
+    public void withRetrySuccess() {
+        var counter = new AtomicInteger();
+        withRetry(3, () -> {
+            counter.incrementAndGet();
+        });
+
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void withRetryFailOnce() {
+        var counter = new AtomicInteger();
+        withRetry(3, () -> {
+            if (counter.getAndIncrement() == 0) {
+                throw new TestException("Failed index " + counter.get());
+            }
+        });
+
+        assertEquals(2, counter.get());
+    }
+
+    @Test
+    public void withRetryFailTwice() {
+        var counter = new AtomicInteger();
+        withRetry(3, () -> {
+            if (counter.getAndIncrement() < 2) {
+                throw new TestException("Failed index " + counter.get());
+            }
+        });
+
+        assertEquals(3, counter.get());
+    }
+
+    @Test
+    public void withRetryTruce() {
+        var counter = new AtomicInteger();
+
+        assertThrows(AssertionError.class, () -> {
+            withRetry(3, () -> {
+                counter.getAndIncrement();
+                throw new TestException("Failed index " + counter.get());
+            });
+        });
+
+        assertEquals(3, counter.get());
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
@@ -18,8 +18,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.*;
 
 import io.reactivex.rxjava4.exceptions.UndeliverableException;
+import io.reactivex.rxjava4.functions.Action;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
-import io.reactivex.rxjava4.testsupport.*;
+import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
 
 @Timeout(value = 5, unit = TimeUnit.MINUTES)
 public abstract class RxJavaTest {
@@ -53,4 +54,27 @@ public abstract class RxJavaTest {
         RxJavaPlugins.setErrorHandler(null);
     }
 
+    /**
+     * Wrap your test body into this retry lambda-based callback to retry flaky tests
+     * that usually depend on Thread.sleep consistency.
+     * @param count the number of times to retry
+     * @param code the code to run
+     */
+    public static void withRetry(int count, Action code) {
+        AssertionError error = null;
+        while (count-- > 0) {
+            try {
+                code.run();
+                return;
+            } catch (Throwable ex) {
+                if (error == null) {
+                    error = new AssertionError("withRetry failures");
+                }
+                error.addSuppressed(ex);
+            }
+        }
+        if (error != null) {
+            throw error;
+        }
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/XFlatMapTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Flow.Publisher;
 
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.RetryingTest;
 
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
@@ -66,919 +65,949 @@ public class XFlatMapTest extends RxJavaTest {
     }
 
     @Test
-    @RetryingTest(3)
     public void flowableFlowable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Publisher<Integer>>) _ -> {
-                sleep();
-                return Flowable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = Flowable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Publisher<Integer>>) _ -> {
+                    sleep();
+                    return Flowable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void flowableSingle() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapSingle(_ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = Flowable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapSingle(_ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void flowableMaybe() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Integer> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
-                sleep();
-                return Maybe.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = Flowable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void flowableCompletable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Flowable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Flowable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void flowableCompletable2() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Void> ts = Flowable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .<Void>toFlowable()
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Void> ts = Flowable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .<Void>toFlowable()
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void observableObservable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Observable<Integer>>) _ -> {
-                sleep();
-                return Observable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Observable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Observable<Integer>>) _ -> {
+                    sleep();
+                    return Observable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void observerSingle() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Observable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void observerMaybe() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Observable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
-                sleep();
-                return Maybe.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Observable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void observerCompletable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Observable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Observable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void observerCompletable2() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Observable.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .<Void>toObservable()
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Observable.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .<Void>toObservable()
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleSingle() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Single<Integer>>) _ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleMaybe() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
-                sleep();
-                return Maybe.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapMaybe((Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleCompletable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleCompletable2() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .toSingleDefault(0)
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .toSingleDefault(0)
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singlePublisher() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Integer> ts = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
-                sleep();
-                return Flowable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
+                    sleep();
+                    return Flowable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleCombiner() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Single<Integer>>) _ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            }, Integer::sum)
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                }, Integer::sum)
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleObservable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
-                sleep();
-                return Observable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
+                    sleep();
+                    return Observable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleNotificationSuccess() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap(
-                (Function<Integer, Single<Integer>>) _ -> {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                },
-                (Function<Throwable, Single<Integer>>) _ -> {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
-            )
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap(
+                    (Function<Integer, Single<Integer>>) _ -> {
+                        sleep();
+                        return Single.<Integer>error(new TestException());
+                    },
+                    (Function<Throwable, Single<Integer>>) _ -> {
+                        sleep();
+                        return Single.<Integer>error(new TestException());
+                    }
+                )
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void singleNotificationError() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Single.<Integer>error(new TestException())
-            .subscribeOn(Schedulers.cached())
-            .flatMap(
-                (Function<Integer, Single<Integer>>) _ -> {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                },
-                (Function<Throwable, Single<Integer>>) _ -> {
-                    sleep();
-                    return Single.<Integer>error(new TestException());
-                }
-            )
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Single.<Integer>error(new TestException())
+                .subscribeOn(Schedulers.cached())
+                .flatMap(
+                    (Function<Integer, Single<Integer>>) _ -> {
+                        sleep();
+                        return Single.<Integer>error(new TestException());
+                    },
+                    (Function<Throwable, Single<Integer>>) _ -> {
+                        sleep();
+                        return Single.<Integer>error(new TestException());
+                    }
+                )
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeSingle() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            })
-            .toSingle()
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                })
+                .toSingle()
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeSingle2() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
-                sleep();
-                return Single.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapSingle((Function<Integer, Single<Integer>>) _ -> {
+                    sleep();
+                    return Single.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeMaybe() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
-                sleep();
-                return Maybe.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybePublisher() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestSubscriber<Integer> ts = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
-                sleep();
-                return Flowable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestSubscriber<Integer> ts = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapPublisher((Function<Integer, Publisher<Integer>>) _ -> {
+                    sleep();
+                    return Flowable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(ts);
+                beforeCancelSleep(ts);
 
-            ts.cancel();
+                ts.cancel();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            ts.assertEmpty();
+                ts.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeObservable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
-                sleep();
-                return Observable.<Integer>error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapObservable((Function<Integer, Observable<Integer>>) _ -> {
+                    sleep();
+                    return Observable.<Integer>error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeNotificationSuccess() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap(
-                (Function<Integer, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Function<Throwable, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Supplier<Maybe<Integer>>) () -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
-            )
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap(
+                    (Function<Integer, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Function<Throwable, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Supplier<Maybe<Integer>>) () -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    }
+                )
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeNotificationError() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
-            .subscribeOn(Schedulers.cached())
-            .flatMap(
-                (Function<Integer, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Function<Throwable, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Supplier<Maybe<Integer>>) () -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
-            )
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.<Integer>error(new TestException())
+                .subscribeOn(Schedulers.cached())
+                .flatMap(
+                    (Function<Integer, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Function<Throwable, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Supplier<Maybe<Integer>>) () -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    }
+                )
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeNotificationEmpty() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.<Integer>empty()
-            .subscribeOn(Schedulers.cached())
-            .flatMap(
-                (Function<Integer, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Function<Throwable, Maybe<Integer>>) _ -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                },
-                (Supplier<Maybe<Integer>>) () -> {
-                    sleep();
-                    return Maybe.<Integer>error(new TestException());
-                }
-            )
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.<Integer>empty()
+                .subscribeOn(Schedulers.cached())
+                .flatMap(
+                    (Function<Integer, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Function<Throwable, Maybe<Integer>>) _ -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    },
+                    (Supplier<Maybe<Integer>>) () -> {
+                        sleep();
+                        return Maybe.<Integer>error(new TestException());
+                    }
+                )
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeCombiner() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Integer> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
-                sleep();
-                return Maybe.<Integer>error(new TestException());
-            }, Integer::sum)
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Integer> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMap((Function<Integer, Maybe<Integer>>) _ -> {
+                    sleep();
+                    return Maybe.<Integer>error(new TestException());
+                }, Integer::sum)
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeCompletable() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 
     @Test
-    @RetryingTest(3)
     public void maybeCompletable2() throws Exception {
-        List<Throwable> errors = TestHelper.trackPluginErrors();
-        try {
-            TestObserver<Void> to = Maybe.just(1)
-            .subscribeOn(Schedulers.cached())
-            .flatMapCompletable((Function<Integer, Completable>) _ -> {
-                sleep();
-                return Completable.error(new TestException());
-            })
-            .<Void>toMaybe()
-            .test();
+        withRetry(3, () -> {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+                TestObserver<Void> to = Maybe.just(1)
+                .subscribeOn(Schedulers.cached())
+                .flatMapCompletable((Function<Integer, Completable>) _ -> {
+                    sleep();
+                    return Completable.error(new TestException());
+                })
+                .<Void>toMaybe()
+                .test();
 
-            cb.await();
+                cb.await();
 
-            beforeCancelSleep(to);
+                beforeCancelSleep(to);
 
-            to.dispose();
+                to.dispose();
 
-            Thread.sleep(SLEEP_AFTER_CANCEL);
+                Thread.sleep(SLEEP_AFTER_CANCEL);
 
-            to.assertEmpty();
+                to.assertEmpty();
 
-            assertTrue(errors.isEmpty(), errors.toString());
-        } finally {
-            RxJavaPlugins.reset();
-        }
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        });
     }
 }


### PR DESCRIPTION
LMAO the retry infrastructure is flaky itself.

2026-06-30T09:06:58.7103707Z XFlatMapTest > singlePublisher() FAILED
2026-06-30T09:06:58.7105028Z     org.junit.platform.commons.PreconditionViolationException: Illegal state: required test method is not present in the current ExtensionContext
2026-06-30T09:06:58.7106662Z         at app//org.junitpioneer.jupiter.RetryingTestExtension.retrierFor(RetryingTestExtension.java:68)
2026-06-30T09:06:58.7108579Z         at app//org.junitpioneer.jupiter.RetryingTestExtension.handleTestExecutionException(RetryingTestExtension.java:64)
2026-06-30T09:06:58.7109967Z         at java.base@27-beta/java.util.ArrayList.forEach(ArrayList.java:1612)
2026-06-30T09:06:58.7110913Z         at java.base@27-beta/java.util.ArrayList.forEach(ArrayList.java:1612)
2026-06-30T09:06:58.7111515Z 

https://github.com/ReactiveX/RxJava/actions/runs/28432952293/job/84251845327