### PR TITLE
4.x: Fix SchedulerToExecutorService invokeAll and invokeAny impl

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
@@ -13,14 +13,15 @@
 
 package io.reactivex.rxjava4.internal.schedulers;
 
+import java.io.Serial;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.Scheduler;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
-import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.exceptions.*;
 
 /**
  * Represents the state for a Scheduler -&gt; ExecutorService interface.
@@ -149,28 +150,31 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
         var result = new ArrayList<Future<T>>();
+        var signal = new CompletableFuture<Void>();
+        var signaller = new CompletionSignaller(signal);
         for (var task : tasks) {
-            result.add(submit(task));
+            signaller.countUp();
+            result.add(submit(() -> {
+                try {
+                    return task.call();
+                } finally {
+                    signaller.countDown();
+                }
+            }));
         }
 
-        // FIXME how to wait in aggregate without spinning???
-        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
+        signaller.countDown();
 
-        while (!isTerminated() && totalTime > 0) {
-            totalTime--;
-
-            int done = 0;
+        try {
+            signal.get(timeout, unit);
+            // make sure we have tasks really finished
             for (var f : result) {
-                if (f.isDone()) {
-                    done++;
-                }
+                getException(f);
             }
-
-            if (done == result.size()) {
-                break;
+        } catch (TimeoutException | ExecutionException ex) {
+            for (var f : result) {
+                f.cancel(true);
             }
-
-            Thread.sleep(1);
         }
 
         return result;
@@ -182,27 +186,77 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
             throw new IllegalArgumentException("The tasks parameter should contain at least one callable!");
         }
 
+        var completionAll = new CompletableFuture<Void>();
+        var signaller = new CompletionSignaller(completionAll);
+        var completionPort = new CompletableFuture<CompletedIndexValue<T>>();
+
         var result = new ArrayList<Future<T>>();
+        var i = 0;
         for (var task : tasks) {
-            result.add(submit(task));
+            signaller.countUp();
+            var j = i;
+            result.add(submit(() -> {
+                try {
+                    var v = task.call();
+                    completionPort.complete(new CompletedIndexValue<>(j, v));
+                    return v;
+                } finally {
+                    signaller.countDown();
+                }
+            }));
+            i++;
         }
 
-        while (!isTerminated()) {
-            for (var f : result) {
-                if (f.state() == Future.State.SUCCESS) {
+        signaller.countDown();
 
-                    var v = f.resultNow();
+        var completionEither = new CompletableFuture<CompletableFuture<?>>();
 
-                    for (var g : result) {
-                        g.cancel(true);
-                    }
+        completionPort.whenComplete((_, _) -> completionEither.complete(completionPort));
+        completionAll.whenComplete((_, _) -> completionEither.complete(completionAll));
 
-                    return v;
+        var resultCompletable = completionEither.get();
+
+        if (resultCompletable == completionPort) {
+            var k = completionPort.getNow(null);
+            for (int j = 0; j < result.size(); j++) {
+                if (j != k.index()) {
+                    result.get(j).cancel(true);
                 }
             }
-            Thread.sleep(1);
+            return k.value();
         }
-        return null; // Practically unreachable
+
+        List<Throwable> errors = new ArrayList<>();
+        for (var f : result) {
+            errors.add(getException(f));
+        }
+        var composite = new CompositeException(errors);
+        throw new ExecutionException(composite);
+    }
+
+    record CompletedIndexValue<T>(int index, T value) {
+    }
+
+    static final class CompletionSignaller extends AtomicInteger {
+        @Serial
+        private static final long serialVersionUID = 4179219399191354619L;
+
+        final CompletableFuture<Void> signal;
+
+        CompletionSignaller(CompletableFuture<Void> signal) {
+            super(1);
+            this.signal = signal;
+        }
+
+        void countUp() {
+            incrementAndGet();
+        }
+
+        void countDown() {
+            if (decrementAndGet() == 0) {
+                signal.complete(null);
+            }
+        }
     }
 
     @Override
@@ -212,31 +266,60 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
             throw new IllegalArgumentException("The tasks parameter should contain at least one callable!");
         }
 
+        var completionAll = new CompletableFuture<Void>();
+        var signaller = new CompletionSignaller(completionAll);
+        var completionPort = new CompletableFuture<CompletedIndexValue<T>>();
+
         var result = new ArrayList<Future<T>>();
+        var i = 0;
         for (var task : tasks) {
-            result.add(submit(task));
+            signaller.countUp();
+            var j = i;
+            result.add(submit(() -> {
+                try {
+                    var v = task.call();
+                    completionPort.complete(new CompletedIndexValue<>(j, v));
+                    return v;
+                } finally {
+                    signaller.countDown();
+                }
+            }));
+            i++;
         }
 
-        // FIXME how to wait in aggregate without spinning???
-        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
+        signaller.countDown();
 
-        while (!isTerminated() && totalTime > 0) {
-            totalTime--;
+        var completionEither = new CompletableFuture<CompletableFuture<?>>();
 
-            for (var f : result) {
-                if (f.state() == Future.State.SUCCESS) {
+        completionPort.whenComplete((_, _) -> completionEither.complete(completionPort));
+        completionAll.whenComplete((_, _) -> completionEither.complete(completionAll));
 
-                    var v = f.resultNow();
+        var resultCompletable = completionEither.get(timeout, unit);
 
-                    for (var g : result) {
-                        g.cancel(true);
-                    }
-
-                    return v;
+        if (resultCompletable == completionPort) {
+            var k = completionPort.getNow(null);
+            for (int j = 0; j < result.size(); j++) {
+                if (j != k.index()) {
+                    result.get(j).cancel(true);
                 }
             }
+            return k.value();
         }
-        throw new TimeoutException("None of the tasks produced a clean result in the time allotted.");
+
+        List<Throwable> errors = new ArrayList<>();
+        for (var f : result) {
+            errors.add(getException(f));
+        }
+        var composite = new CompositeException(errors);
+        throw new ExecutionException(composite);
     }
 
+    static Throwable getException(Future<?> f) throws InterruptedException {
+        try {
+            f.get();
+        } catch (ExecutionException ex) {
+            return ex.getCause();
+        }
+        return null;
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
@@ -15,20 +15,21 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
-import java.util.concurrent.Callable;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava4.core.Scheduler;
+import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
 public class SchedulerToExecutorServiceTest {
 
     @Test
     public void invokeAnyShouldReturnResultOfCompletedTask() throws Exception {
-        Scheduler scheduler = Schedulers.trampoline();
+        Scheduler scheduler = Schedulers.computation();
         @SuppressWarnings("resource")
         SchedulerToExecutorService executor = new SchedulerToExecutorService(
                 scheduler, new AtomicReference<>(null));
@@ -44,7 +45,7 @@ public class SchedulerToExecutorServiceTest {
 
     @Test
     public void invokeAnyWithSingleTask() throws Exception {
-        Scheduler scheduler = Schedulers.trampoline();
+        Scheduler scheduler = Schedulers.computation();
         @SuppressWarnings("resource")
         SchedulerToExecutorService executor = new SchedulerToExecutorService(
                 scheduler, new AtomicReference<>(null));
@@ -64,10 +65,155 @@ public class SchedulerToExecutorServiceTest {
                 scheduler, new AtomicReference<>(null));
 
         try {
-            executor.invokeAny(Arrays.asList());
+            executor.invokeAny(List.of());
             fail("invokeAny with empty tasks should throw IllegalArgumentException");
         } catch (IllegalArgumentException expected) {
             // expected
+        }
+    }
+
+    @Test
+    public void invokeAnyTimeoutWithEmptyTasksShouldThrow() throws Exception {
+        Scheduler scheduler = Schedulers.trampoline();
+        @SuppressWarnings("resource")
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        try {
+            executor.invokeAny(List.of(), 5, TimeUnit.SECONDS);
+            fail("invokeAny with empty tasks should throw IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void invokeAnyAllThrow() {
+        var ex = assertThrows(ExecutionException.class, () -> {
+            Scheduler scheduler = Schedulers.computation();
+            @SuppressWarnings("resource")
+            SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                    scheduler, new AtomicReference<>(null));
+
+            Callable<Object> run = () -> { throw new TestException(); };
+
+            executor.invokeAny(List.of(run, run, run));
+        });
+
+        if (ex.getCause() instanceof CompositeException ce) {
+            assertEquals(3, ce.getExceptions().size());
+        } else {
+            throw new AssertionError("Wrong contents", ex);
+        }
+    }
+
+    @Test
+    public void invokeAnyTimeoutAllSucceed() throws Exception {
+        Scheduler scheduler = Schedulers.computation();
+        @SuppressWarnings("resource")
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<String> task1 = () -> "result1";
+        Callable<String> task2 = () -> "result2";
+
+        String result = executor.invokeAny(Arrays.asList(task1, task2), 5, TimeUnit.SECONDS);
+
+        assertNotNull("invokeAny should return a result", result);
+        assertTrue(result.equals("result1") || result.equals("result2"), "result should be one of the task results");
+    }
+
+    @Test
+    public void invokeAnyTimeoutAllThrow() {
+        var ex = assertThrows(ExecutionException.class, () -> {
+            Scheduler scheduler = Schedulers.computation();
+            @SuppressWarnings("resource")
+            SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                    scheduler, new AtomicReference<>(null));
+
+            Callable<Object> run = () -> { throw new TestException(); };
+
+            executor.invokeAny(List.of(run, run, run), 5, TimeUnit.SECONDS);
+        });
+
+        if (ex.getCause() instanceof CompositeException ce) {
+            assertEquals(3, ce.getExceptions().size());
+        } else {
+            throw new AssertionError("Wrong contents", ex);
+        }
+    }
+
+    @Test
+    public void invokeAnyTimeoutHappens() throws Exception {
+        assertThrows(TimeoutException.class, () -> {
+            Scheduler scheduler = Schedulers.computation();
+            @SuppressWarnings("resource")
+            SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                    scheduler, new AtomicReference<>(null));
+
+            Callable<String> task1 = () -> { Thread.sleep(1000); return "result1"; };
+            Callable<String> task2 = () -> { Thread.sleep(1000); return "result2"; };
+
+            String result = executor.invokeAny(Arrays.asList(task1, task2), 100, TimeUnit.MILLISECONDS);
+
+            assertNotNull("invokeAny should return a result", result);
+            assertTrue(result.equals("result1") || result.equals("result2"), "result should be one of the task results");
+        });
+    }
+
+    @Test
+    public void getExceptionNone() throws InterruptedException {
+        var cf = new CompletableFuture<Void>();
+        cf.complete(null);
+        assertNull(SchedulerToExecutorService.getException(cf));
+    }
+
+    @Test
+    public void invokeAll() throws Throwable{
+        Scheduler scheduler = Schedulers.computation();
+        @SuppressWarnings("resource")
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<String> task1 = () -> "result1";
+        Callable<String> task2 = () -> "result2";
+
+        var result = executor.invokeAll(List.of(task1, task2));
+
+        assertEquals("result1", result.get(0).resultNow());
+        assertEquals("result2", result.get(1).resultNow());
+    }
+
+    @Test
+    public void invokeAllTimeout() throws Throwable{
+        Scheduler scheduler = Schedulers.computation();
+        @SuppressWarnings("resource")
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<String> task1 = () -> "result1";
+        Callable<String> task2 = () -> "result2";
+
+        var result = executor.invokeAll(List.of(task1, task2), 5, TimeUnit.SECONDS);
+
+        assertEquals("result1", result.get(0).resultNow());
+        assertEquals("result2", result.get(1).resultNow());
+    }
+
+    @Test
+    public void invokeAllTimeoutDoesTimeout() throws Throwable {
+        Scheduler scheduler = Schedulers.computation();
+        @SuppressWarnings("resource")
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(null));
+
+        Callable<String> task1 = () -> { Thread.sleep(1000); return "result1"; };
+        Callable<String> task2 = () -> { Thread.sleep(1000); return "result2"; };
+
+        var result = executor.invokeAll(List.of(task1, task2), 100, TimeUnit.MILLISECONDS);
+
+        for (var f : result) {
+            assertTrue(f.isCancelled(), "Task was not cancelled: " + f);
         }
     }
 }


### PR DESCRIPTION
The previous implementation used busy sleep 1 milliseconds and was not well tested.

Now it uses a convoluted `CompletableFuture` dance because we don't have proper structured concurrency, and even if we had, the `ExecutorService` will most likely never get retrofitted.