### PR TITLE
4.x: Streamable + range, fromArray, take, error, defer

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/CompletionStageDisposable.java
@@ -16,13 +16,14 @@ package io.reactivex.rxjava4.core;
 import java.io.Serial;
 import java.lang.ref.Cleaner;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.disposables.*;
-import io.reactivex.rxjava4.internal.util.AwaitCoordinatorStatic;
+import io.reactivex.rxjava4.exceptions.ThrowableWrapper;
+import io.reactivex.rxjava4.internal.util.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
 /**
@@ -84,19 +85,30 @@ public final class CompletionStageDisposable<T> implements AutoCloseable {
     }
     /**
      * Await the completion of the current stage.
+     * <p>
+     * Rethrows any original unchecked exceptions as is.
+     * @throws CancellationException if the computation was cancelled
+     * @throws ThrowableWrapper if the original exception was a checked exception
      */
     public void await() {
-        state.lazySet(true);
-        AwaitCoordinatorStatic.await(stage);
+        await(null);
     }
 
     /**
      * Await the completion of the current stage.
+     * <p>
+     * Rethrows any original unchecked exceptions as is.
      * @param canceller the canceller link
+     * @throws CancellationException if the computation was cancelled
+     * @throws ThrowableWrapper if the original exception was a checked exception
      */
     public void await(DisposableContainer canceller) {
         state.lazySet(true);
-        AwaitCoordinatorStatic.await(stage, canceller);
+        try {
+            AwaitCoordinatorStatic.await(stage, canceller);
+        } catch (CompletionException ce) {
+            throw ExceptionHelper.wrapOrThrow(ce.getCause());
+        }
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/Flowable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Flowable.java
@@ -18059,7 +18059,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
         Objects.requireNonNull(transformer, "transformer is null");
         Objects.requireNonNull(scheduler, "scheduler is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return new FlowableVirtualTransformExecutor<>(this, transformer, null, scheduler, prefetch);
+        return RxJavaPlugins.onAssembly(new FlowableVirtualTransformExecutor<>(this, transformer, null, scheduler, prefetch));
     }
 
     /**
@@ -18097,7 +18097,7 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
         Objects.requireNonNull(transformer, "transformer is null");
         Objects.requireNonNull(executor, "executor is null");
         ObjectHelper.verifyPositive(prefetch, "prefetch");
-        return new FlowableVirtualTransformExecutor<>(this, transformer, executor, null, prefetch);
+        return RxJavaPlugins.onAssembly(new FlowableVirtualTransformExecutor<>(this, transformer, executor, null, prefetch));
     }
 
     /**
@@ -18148,6 +18148,6 @@ public abstract class Flowable<@NonNull T> implements Publisher<T> {
     @NonNull
     public final Streamable<T> toStreamable(ExecutorService executor) {
         Objects.requireNonNull(executor, "executor is null");
-        return new StreamableFromPublisher<>(this, executor);
+        return RxJavaPlugins.onAssembly(new StreamableFromPublisher<>(this, executor));
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -23,7 +23,7 @@ import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
-import io.reactivex.rxjava4.internal.util.AwaitCoordinatorStatic;
+import io.reactivex.rxjava4.internal.util.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -453,9 +453,9 @@ public interface Streamable<@NonNull T> {
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
                 if (crash instanceof CompletionException ce) {
-                    throw Exceptions.propagate(ce.getCause());
+                    throw ExceptionHelper.wrapOrThrow(ce.getCause());
                 }
-                throw Exceptions.propagate(crash);
+                throw ExceptionHelper.wrapOrThrow(crash);
             }
             return null;
         }, executor);
@@ -497,9 +497,9 @@ public interface Streamable<@NonNull T> {
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
                 if (crash instanceof CompletionException ce) {
-                    throw Exceptions.propagate(ce.getCause());
+                    throw ExceptionHelper.wrapOrThrow(ce.getCause());
                 }
-                throw Exceptions.propagate(crash);
+                throw ExceptionHelper.wrapOrThrow(crash);
             }
             return null;
         });
@@ -515,12 +515,8 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
-            try {
-                me.forEach(emitter::emit, emitter.canceller().derive(), executor)
-                .await(emitter.canceller());
-            } catch (CompletionException ee) {
-                throw Exceptions.propagate(ee.getCause());
-            }
+            me.forEach(emitter::emit, emitter.canceller().derive(), executor)
+            .await(emitter.canceller());
         }, executor)
         .subscribe(subscriber);
     }
@@ -532,12 +528,7 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
-            try {
-                // System.out.println("Emitting " + v);
-                me.forEach(emitter::emit).await(emitter.canceller());
-            } catch (CompletionException ee) {
-                throw Exceptions.propagate(ee.getCause());
-            }
+            me.forEach(emitter::emit).await(emitter.canceller());
         })
         .subscribe(subscriber);
     }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -13,16 +13,18 @@
 
 package io.reactivex.rxjava4.core;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.Exceptions;
 import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.internal.functions.ObjectHelper;
 import io.reactivex.rxjava4.internal.operators.streamable.*;
 import io.reactivex.rxjava4.internal.util.AwaitCoordinatorStatic;
+import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
@@ -75,7 +77,7 @@ public interface Streamable<@NonNull T> {
     @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> empty() {
-        return new StreamableEmpty<>();
+        return RxJavaPlugins.onAssembly(new StreamableEmpty<>());
     }
 
     /**
@@ -88,7 +90,21 @@ public interface Streamable<@NonNull T> {
     @NonNull
     static <@NonNull T> Streamable<T> just(@NonNull T item) {
         Objects.requireNonNull(item, "item is null");
-        return new StreamableJust<>(item);
+        return RxJavaPlugins.onAssembly(new StreamableJust<>(item));
+    }
+
+    /**
+     * Streams all elements of the given items array.
+     * @param <T> the element type of the items
+     * @param items the array of items to stream
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code items} is {@code null}
+     */
+    @SafeVarargs
+    @NonNull
+    static <@NonNull T> Streamable<T> fromArray(T... items) {
+        Objects.requireNonNull(items, "items is null");
+        return RxJavaPlugins.onAssembly(new StreamableFromArray<>(items));
     }
 
     /**
@@ -115,7 +131,7 @@ public interface Streamable<@NonNull T> {
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
         Objects.requireNonNull(source, "source is null");
-        return new StreamableFromPublisher<>(source, executor);
+        return RxJavaPlugins.onAssembly(new StreamableFromPublisher<>(source, executor));
     }
 
     /**
@@ -194,6 +210,32 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
+     * Defers the creation of the actual {@code Streamable}, allowing a per streamer
+     * state to be created along with it.
+     * @param <T> the element type of the {@code Streamable}
+     * @param supplier the callback that returns the actual {@code Streamable} to be streamed
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code supplier} is {@code null}
+     */
+    static <@NonNull T> Streamable<T> defer(Supplier<? extends Streamable<? extends T>> supplier) {
+        Objects.requireNonNull(supplier, "supplier is null");
+        return RxJavaPlugins.onAssembly(new StreamableDefer<>(supplier));
+    }
+
+    /**
+     * Creates a {@code Streamable} that signals the given {@link Throwable} immediately when it begins streaming,
+     * ending the sequence.
+     * @param <T> the element type of the sequence
+     * @param throwable the {@code Throwable} to signal immediately upon streaming
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code throwable} is {@code null}
+     */
+    static <@NonNull T> Streamable<T> error(Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable is null");
+        return RxJavaPlugins.onAssembly(new StreamableError<>(throwable));
+    }
+
+    /**
      * Emits the elements of each inner sequence produced by the outher sequence.
      * @param <T> the common element type
      * @param sources a streamable of inner streamables
@@ -210,6 +252,54 @@ public interface Streamable<@NonNull T> {
                 mainSource.await(emitter.canceller());
             }
         }, exec);
+    }
+
+    /**
+     * Emits elements from start up to start + count exclusive.
+     * @param start the start element
+     * @param count the number of elements to emit
+     * @return the new {@code Streamable} instance
+     */
+    static Streamable<Integer> range(int start, int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count >= 0 required but it was " + count);
+        } else
+        if (count == 0) {
+            return empty();
+        } else
+        if (count == 1) {
+            return just(start);
+        } else
+        if ((long)start + (count - 1) > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Integer overflow");
+        }
+        return RxJavaPlugins.onAssembly(new StreamableRange(start, count));
+    }
+
+    /**
+     * Emits elements from start up to start + count exclusive.
+     * @param start the start element
+     * @param count the number of elements to emit
+     * @return the new {@code Streamable} instance
+     */
+    static Streamable<Long> rangeLong(long start, long count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count >= 0 required but it was " + count);
+        }
+
+        if (count == 0) {
+            return empty();
+        }
+
+        if (count == 1) {
+            return just(start);
+        }
+
+        long end = start + (count - 1);
+        if (start > 0 && end < 0) {
+            throw new IllegalArgumentException("Overflow! start + count is bigger than Long.MAX_VALUE");
+        }
+        return RxJavaPlugins.onAssembly(new StreamableRangeLong(start, count));
     }
 
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
@@ -274,6 +364,25 @@ public interface Streamable<@NonNull T> {
         .await(emitter.canceller()), executor);
     }
 
+    /**
+     * Takes at most the given number of items from the upstream and relays it to the downstream,
+     * then cancels the rest of the sequence.
+     * @param n the maximum number of items to relay
+     * @return the new {@code Streamable} instance
+     */
+    default Streamable<T> take(long n) {
+        ObjectHelper.verifyPositive(n, "n");
+        return defer(() -> {
+            var countdown = new AtomicLong(n);
+            return transform((item, emitter, stopper) -> {
+                emitter.emit(item);
+                if (countdown.decrementAndGet() <= 0) {
+                    stopper.dispose();
+                }
+            });
+        });
+    }
+
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     // Consumption methods and outgoing converters
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
@@ -324,13 +433,12 @@ public interface Streamable<@NonNull T> {
      */
     @CheckReturnValue
     @NonNull
-    @SuppressWarnings("unchecked")
     default CompletionStageDisposable<Void> forEach(@NonNull Consumer<? super T> consumer, @NonNull DisposableContainer canceller, @NonNull ExecutorService executor) {
         Objects.requireNonNull(consumer, "consumer is null");
         Objects.requireNonNull(canceller, "canceller is null");
         Objects.requireNonNull(executor, "executor is null");
         final Streamable<T> me = this;
-        var future = executor.submit(() -> {
+        var future = CompletableFuture.<Void>supplyAsync(() -> {
             try (var str = me.stream(canceller)) {
                 while (!canceller.isDisposed()) {
                     if (str.awaitNext(canceller)) {
@@ -344,20 +452,15 @@ public interface Streamable<@NonNull T> {
                 // System.out.println("Canceller status after loop: " + canceller.isDisposed());
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
-                // System.out.println("Canceller status in error: " + canceller.isDisposed());
-                crash.printStackTrace();
-                if (crash instanceof RuntimeException ex) {
-                    throw ex;
+                if (crash instanceof CompletionException ce) {
+                    throw Exceptions.propagate(ce.getCause());
                 }
-                if (crash instanceof Exception ex) {
-                    throw ex;
-                }
-                throw new InvocationTargetException(crash);
+                throw Exceptions.propagate(crash);
             }
             return null;
-        });
+        }, executor);
         canceller.add(Disposable.fromFuture(future));
-        return new CompletionStageDisposable<>(StreamableHelper.toCompletionStage((Future<Void>) (Future<?>) future), canceller);
+        return new CompletionStageDisposable<>(future, canceller);
     }
 
     /**
@@ -369,7 +472,6 @@ public interface Streamable<@NonNull T> {
      */
     @CheckReturnValue
     @NonNull
-    @SuppressWarnings("unchecked")
     default CompletionStageDisposable<Void> forEach(
             @NonNull BiConsumer<? super T, ? super Disposable> consumer,
             @NonNull DisposableContainer canceller,
@@ -378,7 +480,7 @@ public interface Streamable<@NonNull T> {
         Objects.requireNonNull(canceller, "canceller is null");
         Objects.requireNonNull(executor, "executor is null");
         final Streamable<T> me = this;
-        var future = executor.submit(() -> {
+        var future = CompletableFuture.<Void>supplyAsync(() -> {
             try (var str = me.stream(canceller)) {
                 var stopper = Disposable.empty();
                 while (!canceller.isDisposed() && !stopper.isDisposed()) {
@@ -394,21 +496,15 @@ public interface Streamable<@NonNull T> {
                 // System.out.println("Canceller status after loop: " + canceller.isDisposed());
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
-                // System.out.println("Canceller status in error: " + canceller.isDisposed());
-                // crash.printStackTrace();
-                if (crash instanceof RuntimeException ex) {
-                    throw ex;
+                if (crash instanceof CompletionException ce) {
+                    throw Exceptions.propagate(ce.getCause());
                 }
-                if (crash instanceof Exception ex) {
-                    throw ex;
-                }
-                throw new InvocationTargetException(crash);
+                throw Exceptions.propagate(crash);
             }
             return null;
         });
         canceller.add(Disposable.fromFuture(future));
-        return new CompletionStageDisposable<>(
-                StreamableHelper.toCompletionStage((Future<Void>) (Future<?>) future), canceller);
+        return new CompletionStageDisposable<>(future, canceller);
     }
 
     /**
@@ -419,9 +515,12 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
-            // System.out.println("subscribe::virtualCreate");
-                    // System.out.println("subscribe::virtualCreate::forEach::emit");
-                    me.forEach(emitter::emit).await(emitter.canceller());
+            try {
+                me.forEach(emitter::emit, emitter.canceller().derive(), executor)
+                .await(emitter.canceller());
+            } catch (CompletionException ee) {
+                throw Exceptions.propagate(ee.getCause());
+            }
         }, executor)
         .subscribe(subscriber);
     }
@@ -433,8 +532,12 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
-                    // System.out.println("Emitting " + v);
-                    me.forEach(emitter::emit).await(emitter.canceller());
+            try {
+                // System.out.println("Emitting " + v);
+                me.forEach(emitter::emit).await(emitter.canceller());
+            } catch (CompletionException ee) {
+                throw Exceptions.propagate(ee.getCause());
+            }
         })
         .subscribe(subscriber);
     }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -14,7 +14,7 @@
 package io.reactivex.rxjava4.core;
 
 import java.util.*;
-import java.util.concurrent.CompletionStage;
+import java.util.concurrent.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.disposables.*;
@@ -197,4 +197,22 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
     default void awaitFinish(@NonNull DisposableContainer cancellation) {
         await(finish(cancellation), cancellation);
     }
+
+    /**
+     * Use this constant in {@link #next(DisposableContainer)} to indicate
+     * the next value is available, synchronously.
+     */
+    CompletionStage<Boolean> NEXT_TRUE = CompletableFuture.completedStage(true);
+
+    /**
+     * Use this constant in {@link #next(DisposableContainer)} to indicate
+     * no more values will be available, synchronously.
+     */
+    CompletionStage<Boolean> NEXT_FALSE = CompletableFuture.completedStage(false);
+
+    /**
+     * Use this constant in {@link #finish(DisposableContainer)} to indicate
+     * the cleanupp was done synchronously.
+     */
+    CompletionStage<Void> FINISHED = CompletableFuture.completedStage(null);
 }

--- a/src/main/java/io/reactivex/rxjava4/exceptions/Exceptions.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/Exceptions.java
@@ -28,7 +28,7 @@ public final class Exceptions {
     }
     /**
      * Convenience method to throw a {@code RuntimeException} and {@code Error} directly
-     * or wrap any other exception type into a {@code RuntimeException}.
+     * or wrap any other exception type into a {@link ThrowableWrapper}.
      * @param t the exception to throw directly or wrapped
      * @return because {@code propagate} itself throws an exception or error, this is a sort of phantom return
      *         value; {@code propagate} does not actually return anything

--- a/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
@@ -32,6 +32,6 @@ public final class ThrowableWrapper extends RuntimeException {
      * @param original the original Throwable
      */
     public ThrowableWrapper(Throwable original) {
-        super(original != null ? original : new NullPointerException("original is null"));
+        super("You forgot to unwrap me!", original != null ? original : new NullPointerException("original is null"));
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.exceptions;
+
+import java.io.Serial;
+
+/**
+ * A runtime exception to sneak around checked exceptions.
+ * <p>
+ * If you encounter me, it means some operator forgot to unwrap the inner throwable
+ * at the right place.
+ * @since 4.0.0
+ */
+public final class ThrowableWrapper extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = -5280780582536857320L;
+
+    /**
+     * Constructs an instance with the given non-null original Throwable.
+     * @param original the original Throwable
+     */
+    public ThrowableWrapper(Throwable original) {
+        super(original != null ? original : new NullPointerException("original is null"));
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
+++ b/src/main/java/io/reactivex/rxjava4/exceptions/ThrowableWrapper.java
@@ -34,4 +34,14 @@ public final class ThrowableWrapper extends RuntimeException {
     public ThrowableWrapper(Throwable original) {
         super("You forgot to unwrap me!", original != null ? original : new NullPointerException("original is null"));
     }
+
+    /**
+     * Checks if the given {@link Throwable} is of type {@code ThrowableWrapper} and
+     * unwraps it, or returns the provided throwable as is.
+     * @param t the throwable to unwrap
+     * @return the possibly unwrapped throwable
+     */
+    public static Throwable unwrap(Throwable t) {
+        return t instanceof ThrowableWrapper ? t.getCause() : t;
+    }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDefer.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDefer.java
@@ -13,22 +13,22 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
-import java.util.concurrent.*;
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.functions.Supplier;
 
-public enum StreamableHelper {
-    INSTANCE;
+public record StreamableDefer<T>(Supplier<? extends Streamable<? extends T>> supplier) implements Streamable<T> {
 
     @SuppressWarnings("unchecked")
-    public static <T> CompletionStage<T> toCompletionStage(Future<T> future) {
-        if (future instanceof CompletionStage) {
-            return (CompletionStage<T>) future;
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        try {
+            return (Streamer<T>)(supplier.get().stream(cancellation));
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            return StreamableError.createFailed(ex);
         }
-        return CompletableFuture.supplyAsync(() -> {
-            try {
-                return future.get();
-            } catch (Exception e) {
-                throw new CompletionException(e);
-            }
-        });
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableError.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableError.java
@@ -13,34 +13,43 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
-import java.util.NoSuchElementException;
 import java.util.concurrent.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 
-public final class StreamableEmpty<T> implements Streamable<T> {
+public record StreamableError<T>(@NonNull Throwable throwable) implements Streamable<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new EmptyStreamer<>();
+        return createFailed(throwable);
     }
 
-    static final class EmptyStreamer<T> implements Streamer<T> {
+    public static <@NonNull T> Streamer<@NonNull T> createFailed(@NonNull Throwable throwable) {
+        return new ErrorStreamer<>(throwable);
+    }
+
+    static final class ErrorStreamer<T> implements Streamer<T> {
+
+        final CompletionStage<Boolean> throwable;
+
+        ErrorStreamer(Throwable throwable) {
+            this.throwable = CompletableFuture.failedFuture(throwable);
+        }
 
         @Override
-        public @NonNull CompletionStage<Boolean> next(DisposableContainer cancellation) {
-            return NEXT_FALSE;
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            return throwable;
         }
 
         @Override
         public @NonNull T current() {
-            throw new NoSuchElementException("This Streamable/Streamer never has elements");
+            throw new IllegalStateException("current cannot be called if next() did not result in a true CompletionStage");
         }
 
         @Override
-        public @NonNull CompletionStage<Void> finish(DisposableContainer canceller) {
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
             return FINISHED;
         }
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromArray.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromArray.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.Objects;
+import java.util.concurrent.*;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+
+public record StreamableFromArray<T>(@NonNull T[] items) implements Streamable<T> {
+
+    public StreamableFromArray {
+        Objects.requireNonNull(items, "items is null");
+    }
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        return new FromArrayStreamer<>(items);
+    }
+
+    static final class FromArrayStreamer<T> implements Streamer<T> {
+
+        final T[] items;
+
+        volatile int index;
+
+        volatile T current;
+
+        public FromArrayStreamer(T[] items) {
+            this.items = items;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            var i = index;
+            if (i >= items.length) {
+                return NEXT_FALSE;
+            }
+            var nextItem = items[i];
+            if (nextItem == null) {
+                index = items.length;
+                current = null;
+                return CompletableFuture.failedStage(new NullPointerException("Item at index " + i + " is null."));
+            }
+            current = nextItem;
+            index = i + 1;
+            return NEXT_TRUE;
+        }
+
+        @Override
+        public @NonNull T current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            index = items.length;
+            current = null;
+            return FINISHED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -22,8 +22,8 @@ import io.reactivex.rxjava4.disposables.*;
 
 public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
-    public StreamableJust(T item) {
-        this.item = Objects.requireNonNull(item, "item is null");
+    public StreamableJust {
+        Objects.requireNonNull(item, "item is null");
     }
 
     @Override
@@ -49,12 +49,12 @@ public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
         public @NonNull CompletionStage<Boolean> next(DisposableContainer cancellation) {
             if (stage == 0) {
                 stage = 1;
-                return CompletableFuture.completedStage(true);
+                return NEXT_TRUE;
             }
             item = null;
             cancellation = null;
             stage = 2;
-            return CompletableFuture.completedStage(false); // TODO would constant stages work here or is that contention?
+            return NEXT_FALSE;
         }
 
         @Override
@@ -74,7 +74,7 @@ public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
             item = null;
             cancellation = null;
             stage = 2;
-            return CompletableFuture.completedStage(null); // TODO would constant stages work here or is that contention?
+            return FINISHED;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRange.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRange.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.CompletionStage;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+
+public record StreamableRange(int start, int count) implements Streamable<Integer> {
+
+    @Override
+    public @NonNull Streamer<@NonNull Integer> stream(@NonNull DisposableContainer cancellation) {
+        return new RangeStreamer<>(start, start + count);
+    }
+
+    static final class RangeStreamer<T> implements Streamer<Integer> {
+
+        final int end;
+
+        volatile int current;
+
+        volatile int index;
+
+        RangeStreamer(int start, int end) {
+            index = start;
+            this.end = end;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            int i = index;
+            if (i >= end) {
+                return NEXT_FALSE;
+            }
+            current = i;
+            index = i + 1;
+            return NEXT_TRUE;
+        }
+
+        @Override
+        public @NonNull Integer current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            index = end;
+            current = end;
+            return FINISHED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeLong.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeLong.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.CompletionStage;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+
+public record StreamableRangeLong(long start, long count) implements Streamable<Long> {
+
+    @Override
+    public @NonNull Streamer<@NonNull Long> stream(@NonNull DisposableContainer cancellation) {
+        return new RangeLongStreamer<>(start, start + count);
+    }
+
+    static final class RangeLongStreamer<T> implements Streamer<Long> {
+
+        final long end;
+
+        volatile long current;
+
+        volatile long index;
+
+        RangeLongStreamer(long start, long end) {
+            index = start;
+            this.end = end;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
+            long i = index;
+            if (i >= end) {
+                return NEXT_FALSE;
+            }
+            current = i;
+            index = i + 1;
+            return NEXT_TRUE;
+        }
+
+        @Override
+        public @NonNull Long current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
+            index = end;
+            current = end;
+            return FINISHED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/AwaitCoordinatorStatic.java
@@ -29,22 +29,14 @@ import io.reactivex.rxjava4.exceptions.Exceptions;
 public interface AwaitCoordinatorStatic {
 
     /**
-     * The {@code await} keyword for async/await.
-     * @param <T> the type of the returned value if any.
-     * @param stage the stage to await virtual-blockingly
-     * @return the awaited value
-     */
-    @Nullable
-    static <T> T await(@NonNull CompletionStage<T> stage) {
-        return await(stage, null);
-    }
-
-    /**
      * The cancellable {@code await} keyword for async/await.
      * @param <T> the type of the returned value if any.
      * @param stage the stage to await virtual-blockingly
      * @param canceller the container that can trigger a cancellation on demand
      * @return the awaited value
+     * @throws CancellationException if the computation was cancelled
+     * @throws CompletionException if this future completed
+     * exceptionally or a completion computation threw an exception
      */
     @Nullable
     static <T> T await(@NonNull CompletionStage<T> stage, @Nullable DisposableContainer canceller) {

--- a/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
@@ -18,7 +18,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.reactivex.rxjava4.exceptions.CompositeException;
+import io.reactivex.rxjava4.exceptions.*;
 
 /**
  * Terminal atomics for Throwable containers.
@@ -44,7 +44,7 @@ public final class ExceptionHelper {
         if (error instanceof RuntimeException) {
             return (RuntimeException)error;
         }
-        return new RuntimeException(error);
+        return new ThrowableWrapper(error);
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
@@ -38,11 +38,11 @@ public final class ExceptionHelper {
      * @return the (wrapped) error
      */
     public static RuntimeException wrapOrThrow(Throwable error) {
-        if (error instanceof Error) {
-            throw (Error)error;
+        if (error instanceof Error err) {
+            throw err;
         }
-        if (error instanceof RuntimeException) {
-            return (RuntimeException)error;
+        if (error instanceof RuntimeException rte) {
+            return rte;
         }
         return new ThrowableWrapper(error);
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
-import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 
 /**
@@ -105,7 +105,11 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     if (ex != STOP && !cancelled) {
-                        downstream.onError(ex);
+                        if (ex instanceof ThrowableWrapper) {
+                            downstream.onError(ex.getCause());
+                        } else {
+                            downstream.onError(ex);
+                        }
                     }
                     return null;
                 }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualCreateExecutor.java
@@ -105,11 +105,7 @@ public final class FlowableVirtualCreateExecutor<T> extends Flowable<T> {
                 } catch (Throwable ex) {
                     Exceptions.throwIfFatal(ex);
                     if (ex != STOP && !cancelled) {
-                        if (ex instanceof ThrowableWrapper) {
-                            downstream.onError(ex.getCause());
-                        } else {
-                            downstream.onError(ex);
-                        }
+                        downstream.onError(ThrowableWrapper.unwrap(ex));
                     }
                     return null;
                 }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.*;
-import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.internal.util.BackpressureHelper;
 import io.reactivex.rxjava4.operators.SpscArrayQueue;
 
@@ -206,7 +206,11 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                         if (d && empty) {
                             var ex = error;
                             if (ex != null) {
-                                downstream.onError(ex);
+                                if (ex instanceof ThrowableWrapper) {
+                                    downstream.onError(ex.getCause());
+                                } else {
+                                    downstream.onError(ex);
+                                }
                             } else {
                                 downstream.onComplete();
                             }
@@ -234,7 +238,11 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                     Exceptions.throwIfFatal(ex);
                     if (ex != STOP && !cancelled) {
                         upstream.cancel();
-                        downstream.onError(ex);
+                        if (ex instanceof ThrowableWrapper) {
+                            downstream.onError(ex.getCause());
+                        } else {
+                            downstream.onError(ex);
+                        }
                     }
                     return null;
                 }

--- a/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/virtual/FlowableVirtualTransformExecutor.java
@@ -206,11 +206,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                         if (d && empty) {
                             var ex = error;
                             if (ex != null) {
-                                if (ex instanceof ThrowableWrapper) {
-                                    downstream.onError(ex.getCause());
-                                } else {
-                                    downstream.onError(ex);
-                                }
+                                downstream.onError(ThrowableWrapper.unwrap(ex));
                             } else {
                                 downstream.onComplete();
                             }
@@ -238,11 +234,7 @@ public final class FlowableVirtualTransformExecutor<T, R> extends Flowable<R> {
                     Exceptions.throwIfFatal(ex);
                     if (ex != STOP && !cancelled) {
                         upstream.cancel();
-                        if (ex instanceof ThrowableWrapper) {
-                            downstream.onError(ex.getCause());
-                        } else {
-                            downstream.onError(ex);
-                        }
+                        downstream.onError(ThrowableWrapper.unwrap(ex));
                     }
                     return null;
                 }

--- a/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
@@ -595,6 +595,8 @@ public final class RxJavaPlugins {
         setOnParallelAssembly(null);
         setOnParallelSubscribe(null);
 
+        setOnStreamableAssembly(null);
+
         setFailOnNonBlockingScheduler(false);
         setOnBeforeBlocking(null);
     }

--- a/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
+++ b/src/main/java/io/reactivex/rxjava4/plugins/RxJavaPlugins.java
@@ -101,6 +101,10 @@ public final class RxJavaPlugins {
 
     @SuppressWarnings("rawtypes")
     @Nullable
+    static volatile Function<? super Streamable, ? extends Streamable> onStreamableAssembly;
+
+    @SuppressWarnings("rawtypes")
+    @Nullable
     static volatile BiFunction<? super Flowable, @NonNull ? super Subscriber, @NonNull ? extends Subscriber> onFlowableSubscribe;
 
     @SuppressWarnings("rawtypes")
@@ -808,6 +812,16 @@ public final class RxJavaPlugins {
      */
     @Nullable
     @SuppressWarnings("rawtypes")
+    public static Function<? super Streamable, ? extends Streamable> getOnStreamableAssembly() {
+        return onStreamableAssembly;
+    }
+
+    /**
+     * Returns the current hook function.
+     * @return the hook function, may be null
+     */
+    @Nullable
+    @SuppressWarnings("rawtypes")
     public static Function<? super Single, ? extends Single> getOnSingleAssembly() {
         return onSingleAssembly;
     }
@@ -897,6 +911,18 @@ public final class RxJavaPlugins {
             throw new IllegalStateException("Plugins can't be changed anymore");
         }
         RxJavaPlugins.onMaybeAssembly = onMaybeAssembly;
+    }
+
+    /**
+     * Sets the specific hook function.
+     * @param onStreamableAssembly the hook function to set, null allowed
+     */
+    @SuppressWarnings("rawtypes")
+    public static void setOnStreamableAssembly(@Nullable Function<? super Streamable, ? extends Streamable> onStreamableAssembly) {
+        if (lockdown) {
+            throw new IllegalStateException("Plugins can't be changed anymore");
+        }
+        RxJavaPlugins.onStreamableAssembly = onStreamableAssembly;
     }
 
     /**
@@ -1122,6 +1148,22 @@ public final class RxJavaPlugins {
     @NonNull
     public static <@NonNull T> Flowable<T> onAssembly(@NonNull Flowable<T> source) {
         Function<? super Flowable, ? extends Flowable> f = onFlowableAssembly;
+        if (f != null) {
+            return apply(f, source);
+        }
+        return source;
+    }
+
+    /**
+     * Calls the associated hook function.
+     * @param <T> the value type
+     * @param source the hook's input value
+     * @return the value returned by the hook
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @NonNull
+    public static <@NonNull T> Streamable<T> onAssembly(@NonNull Streamable<T> source) {
+        Function<? super Streamable, ? extends Streamable> f = onStreamableAssembly;
         if (f != null) {
             return apply(f, source);
         }

--- a/src/test/java/io/reactivex/rxjava4/core/DisposeTaskTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/DisposeTaskTest.java
@@ -26,7 +26,7 @@ public class DisposeTaskTest extends RxJavaTest {
 
     @Test
     public void runnableThrows() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
 
             Scheduler.Worker worker = Schedulers.single().createWorker();
 

--- a/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
@@ -13,14 +13,15 @@
 
 package io.reactivex.rxjava4.core;
 
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 
 import org.junit.jupiter.api.*;
 
-import io.reactivex.rxjava4.exceptions.UndeliverableException;
-import io.reactivex.rxjava4.functions.Action;
+import io.reactivex.rxjava4.exceptions.*;
+import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
-import io.reactivex.rxjava4.testsupport.SuppressUndeliverable;
+import io.reactivex.rxjava4.testsupport.*;
 
 @Timeout(value = 5, unit = TimeUnit.MINUTES)
 public abstract class RxJavaTest {
@@ -76,5 +77,154 @@ public abstract class RxJavaTest {
         if (error != null) {
             throw error;
         }
+    }
+
+    /**
+     * Execute a test body with the help of a virtual thread executor service.
+     * <p>
+     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
+     * @param call the callback to give the VTE.
+     * @throws Throwable propagate exceptions
+     */
+    public static void withVirtual(Consumer<ExecutorService> call) throws Throwable {
+        try (var exec = new ExecutorIntercept(Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory()), false)) {
+            call.accept(exec);
+        }
+    }
+
+    /**
+     * Execute a call within a virtual thread of the standard virtual thread executor.
+     * @param call the call to invoke
+     * @throws Throwable the exception propagated out
+     */
+    public static void onVirtual(Consumer<ExecutorService> call) throws Throwable {
+        withVirtual(exec -> exec.submit(() -> {
+            try {
+                call.accept(exec);
+            } catch (Throwable ex) {
+                throw Exceptions.propagate(ex);
+            }
+        }).get());
+    }
+
+    record ExecutorIntercept(ExecutorService service, boolean printStackTrace) implements ExecutorService {
+
+        @Override
+        public void execute(Runnable command) {
+            service.execute(command);
+        }
+
+        @Override
+        public void shutdown() {
+            if (printStackTrace) {
+                new CancellationException("ExecutorIntercept::shutdown").printStackTrace();
+            }
+            service.shutdown();
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            if (printStackTrace) {
+                new CancellationException("ExecutorIntercept::shutdownNow").printStackTrace();
+            }
+            return service.shutdownNow();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return service.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return service.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return service.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            return service.submit(task);
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            return service.submit(task, result);
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            return service.submit(task);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            return service.invokeAll(tasks);
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return service.invokeAll(tasks, timeout, unit);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+                throws InterruptedException, ExecutionException {
+            return service.invokeAny(tasks);
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+                throws InterruptedException, ExecutionException, TimeoutException {
+            return service.invokeAny(tasks, timeout, unit);
+        }
+    }
+
+    /**
+     * Execute a test body with the help of a single thread executor service.
+     * <p>
+     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
+     * @param call the callback to give the VTE.
+     * @throws Throwable propagate exceptions
+     */
+    public static void withSingleExecutor(Consumer<ScheduledExecutorService> call) throws Throwable {
+        try (var exec = Executors.newSingleThreadScheduledExecutor()) {
+            call.accept(exec);
+        }
+    }
+
+    /**
+     * Execute a test body with the help of a cached executor service.
+     * <p>
+     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
+     * @param call the callback to give the VTE.
+     * @throws Throwable propagate exceptions
+     */
+    public static void withCachedExecutor(Consumer<ExecutorService> call) throws Throwable {
+        try (var exec = new ExecutorIntercept(Executors.newCachedThreadPool(), false)) {
+            call.accept(exec);
+        }
+    }
+
+    /**
+     * Enable thracking of the global errors for the duration of the action.
+     * @param action the action to run with a list of errors encountered
+     * @throws Throwable the exception rethrown from the action
+     */
+    public static void withErrorTracking(Consumer<List<Throwable>> action) throws Throwable {
+        List<Throwable> errors = trackPluginErrors();
+        try {
+            action.accept(errors);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    public static List<Throwable> trackPluginErrors() {
+        return TestHelper.trackPluginErrors();
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
@@ -192,7 +192,7 @@ public class DisposableTest extends RxJavaTest {
 
     @Test
     public void fromAutoCloseableThrows() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             AutoCloseable ac = () -> { throw new TestException(); };
 
             Disposable d = Disposable.fromAutoCloseable(ac);

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ExceptionsTest.java
@@ -188,4 +188,11 @@ public class ExceptionsTest extends RxJavaTest {
 
         assertEquals("Forced failure", ex.getCause().getMessage(), "" + ex.getCause());
     }
+
+    @Test
+    public void throwIfFatalLinkageError() {
+        assertThrows(LinkageError.class, () -> {
+            Exceptions.throwIfFatal(new LinkageError());
+        });
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ThrowableWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ThrowableWrapperTest.java
@@ -15,18 +15,11 @@ package io.reactivex.rxjava4.exceptions;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.Disposable;
-import io.reactivex.rxjava4.internal.util.ExceptionHelper;
-import io.reactivex.rxjava4.plugins.RxJavaPlugins;
-import io.reactivex.rxjava4.subjects.PublishSubject;
-import io.reactivex.rxjava4.testsupport.TestHelper;
 
 public class ThrowableWrapperTest extends RxJavaTest {
 
@@ -52,5 +45,26 @@ public class ThrowableWrapperTest extends RxJavaTest {
             assertEquals("You forgot to unwrap me!", ex.getMessage());
             assertTrue(ex.getCause() instanceof NullPointerException, ex.getCause().toString());
         }
+    }
+
+    @Test
+    public void virtualCreateUnwraps() {
+        Flowable.virtualCreate(_ -> {
+            throw new ThrowableWrapper(new TestException());
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void virtualTransformUnwraps() {
+        Flowable.just(1)
+        .virtualTransform((_, _, _) -> {
+            throw new ThrowableWrapper(new TestException());
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/exceptions/ThrowableWrapperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/exceptions/ThrowableWrapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.exceptions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.Disposable;
+import io.reactivex.rxjava4.internal.util.ExceptionHelper;
+import io.reactivex.rxjava4.plugins.RxJavaPlugins;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+public class ThrowableWrapperTest extends RxJavaTest {
+
+    @Test
+    public void basic() {
+        var original = new Throwable("original");
+
+        try {
+            throw new ThrowableWrapper(original);
+        } catch (RuntimeException ex) {
+            assertSame(original, ex.getCause());
+            assertEquals("You forgot to unwrap me!", ex.getMessage());
+            assertEquals("original", ex.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void basicNull() {
+        try {
+            throw new ThrowableWrapper(null);
+        } catch (RuntimeException ex) {
+            assertEquals("original is null", ex.getCause().getMessage());
+            assertEquals("You forgot to unwrap me!", ex.getMessage());
+            assertTrue(ex.getCause() instanceof NullPointerException, ex.getCause().toString());
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/CompletableToCompletionStageTest.java
@@ -111,7 +111,7 @@ public class CompletableToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void sourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Object v = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {
@@ -133,7 +133,7 @@ public class CompletableToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Object v = new Completable() /* NFI */ {
                 @Override
                 protected void subscribeActual(CompletableObserver observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableCollectWithCollectorTest.java
@@ -163,7 +163,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
 
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             var source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -359,7 +359,7 @@ public class FlowableCollectWithCollectorTest extends RxJavaTest {
 
     @Test
     public void collectorAccumulatorDropSignalsToFlowable() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             var source = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFlatMapStreamTest.java
@@ -180,7 +180,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
 
     @Test
     public void upstreamCancelledCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<Integer> ts = pp
@@ -262,7 +262,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
 
     @Test
     public void queueOverflow() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -329,7 +329,7 @@ public class FlowableFlatMapStreamTest extends RxJavaTest {
 
     @Test
     public void mapperThrowsWhenUpstreamErrors() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableFromStreamTest.java
@@ -276,7 +276,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void runToEndCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
             Flowable.fromStream(stream)
@@ -289,7 +289,7 @@ public class FlowableFromStreamTest extends RxJavaTest {
 
     @Test
     public void takeCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
             Flowable.fromStream(stream)

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrDefaultTest.java
@@ -136,7 +136,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -158,7 +158,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -284,7 +284,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -307,7 +307,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -431,7 +431,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -454,7 +454,7 @@ public class FlowableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/FlowableStageSubscriberOrErrorTest.java
@@ -135,7 +135,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -157,7 +157,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -281,7 +281,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -304,7 +304,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -425,7 +425,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {
@@ -448,7 +448,7 @@ public class FlowableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Subscriber<? super Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsFlowableTest.java
@@ -313,7 +313,7 @@ public class MaybeFlattenStreamAsFlowableTest extends RxJavaTest {
 
     @Test
     public void streamCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Maybe.just(1)
             .flattenStreamAsFlowable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeFlattenStreamAsObservableTest.java
@@ -293,7 +293,7 @@ public class MaybeFlattenStreamAsObservableTest extends RxJavaTest {
 
     @Test
     public void streamCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Maybe.just(1)
             .flattenStreamAsObservable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/MaybeToCompletionStageTest.java
@@ -131,7 +131,7 @@ public class MaybeToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void sourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {
@@ -153,7 +153,7 @@ public class MaybeToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Maybe<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(MaybeObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableCollectWithCollectorTest.java
@@ -166,7 +166,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
 
     @Test
     public void collectorAccumulatorDropSignals() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -362,7 +362,7 @@ public class ObservableCollectWithCollectorTest extends RxJavaTest {
 
     @Test
     public void collectorAccumulatorDropSignalsToObservable() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             var source = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFlatMapStreamTest.java
@@ -179,7 +179,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
     @Test
     public void upstreamCancelledCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserver<Integer> to = ps
@@ -273,7 +273,7 @@ public class ObservableFlatMapStreamTest extends RxJavaTest {
 
     @Test
     public void mapperThrowsWhenUpstreamErrors() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             AtomicInteger counter = new AtomicInteger();

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableFromStreamTest.java
@@ -277,7 +277,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
     @Test
     public void runToEndCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
             Observable.fromStream(stream)
@@ -290,7 +290,7 @@ public class ObservableFromStreamTest extends RxJavaTest {
 
     @Test
     public void takeCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Stream<Integer> stream = Stream.of(1, 2, 3, 4, 5).onClose(() -> { throw new TestException(); });
 
             Observable.fromStream(stream)

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrDefaultTest.java
@@ -135,7 +135,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -157,7 +157,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -283,7 +283,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -306,7 +306,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -430,7 +430,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -453,7 +453,7 @@ public class ObservableStageSubscriberOrDefaultTest extends RxJavaTest {
 
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/ObservableStageSubscriberOrErrorTest.java
@@ -134,7 +134,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void firstSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -156,7 +156,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void firstDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -280,7 +280,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void singleSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -303,7 +303,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void singleDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -424,7 +424,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void lastSourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {
@@ -447,7 +447,7 @@ public class ObservableStageSubscriberOrErrorTest extends RxJavaTest {
 
     @Test
     public void lastDoubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(Observer<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsFlowableTest.java
@@ -300,7 +300,7 @@ public class SingleFlattenStreamAsFlowableTest extends RxJavaTest {
 
     @Test
     public void streamCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.just(1)
             .flattenStreamAsFlowable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleFlattenStreamAsObservableTest.java
@@ -280,7 +280,7 @@ public class SingleFlattenStreamAsObservableTest extends RxJavaTest {
 
     @Test
     public void streamCloseCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.just(1)
             .flattenStreamAsObservable(v -> Stream.of(v).onClose(() -> { throw new TestException(); }))
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/jdk8/SingleToCompletionStageTest.java
@@ -111,7 +111,7 @@ public class SingleToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void sourceIgnoresCancel() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {
@@ -132,7 +132,7 @@ public class SingleToCompletionStageTest extends RxJavaTest {
 
     @Test
     public void doubleOnSubscribe() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Integer v = new Single<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(SingleObserver<? super Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableBlockingSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableBlockingSubscribeTest.java
@@ -21,14 +21,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Completable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class CompletableBlockingSubscribeTest {
+public class CompletableBlockingSubscribeTest extends RxJavaTest {
 
     @Test
     public void noArgComplete() {
@@ -45,7 +45,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void noArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Completable.error(new TestException())
             .blockingSubscribe();
 
@@ -55,7 +55,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void noArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Completable.error(new TestException())
             .delay(100, TimeUnit.MILLISECONDS, Schedulers.computation(), true)
             .blockingSubscribe();
@@ -87,7 +87,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void oneArgCompleteFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
             doThrow(new TestException()).when(action).run();
 
@@ -102,7 +102,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void oneArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
 
             Completable.error(new TestException())
@@ -116,7 +116,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void oneArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
 
             Completable.error(new TestException())
@@ -158,7 +158,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void twoArgCompleteFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
             doThrow(new TestException()).when(action).run();
             @SuppressWarnings("unchecked")
@@ -176,7 +176,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void twoArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
             @SuppressWarnings("unchecked")
             Consumer<? super Throwable> consumer = mock(Consumer.class);
@@ -193,7 +193,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
             @SuppressWarnings("unchecked")
             Consumer<? super Throwable> consumer = mock(Consumer.class);
@@ -211,7 +211,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action action = mock(Action.class);
             @SuppressWarnings("unchecked")
             Consumer<? super Throwable> consumer = mock(Consumer.class);
@@ -230,7 +230,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void twoArgInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             Action action = mock(Action.class);
@@ -311,7 +311,7 @@ public class CompletableBlockingSubscribeTest {
 
     @Test
     public void ovserverInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             TestObserver<Void> to = new TestObserver<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableDoOnLifecycleTest.java
@@ -61,7 +61,7 @@ public class CompletableDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);
@@ -93,7 +93,7 @@ public class CompletableDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onDisposeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromActionTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromActionTest.java
@@ -126,7 +126,7 @@ public class CompletableFromActionTest extends RxJavaTest {
 
     @Test
     public void disposeWhileRunningError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestObserver<Void> to = new TestObserver<>();
 
             Completable.fromAction(() -> {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromRunnableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableFromRunnableTest.java
@@ -125,7 +125,7 @@ public class CompletableFromRunnableTest extends RxJavaTest {
 
     @Test
     public void disposeWhileRunningError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestObserver<Void> to = new TestObserver<>();
 
             Completable.fromRunnable(() -> {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/completable/CompletableSafeSubscribeTest.java
@@ -28,11 +28,11 @@ import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class CompletableSafeSubscribeTest {
+public class CompletableSafeSubscribeTest extends RxJavaTest {
 
     @Test
     public void normalError() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             CompletableObserver consumer = mock(CompletableObserver.class);
 
             Completable.error(new TestException())
@@ -49,7 +49,7 @@ public class CompletableSafeSubscribeTest {
 
     @Test
     public void normalEmpty() throws Throwable  {
-        TestHelper.withErrorTracking(_ -> {
+        withErrorTracking(_ -> {
             CompletableObserver consumer = mock(CompletableObserver.class);
 
             Completable.complete()
@@ -64,7 +64,7 @@ public class CompletableSafeSubscribeTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             CompletableObserver consumer = mock(CompletableObserver.class);
             doThrow(new TestException()).when(consumer).onSubscribe(any());
 
@@ -94,7 +94,7 @@ public class CompletableSafeSubscribeTest {
 
     @Test
     public void onErrorCrash() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             CompletableObserver consumer = mock(CompletableObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());
 
@@ -123,7 +123,7 @@ public class CompletableSafeSubscribeTest {
 
     @Test
     public void onCompleteCrash() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             CompletableObserver consumer = mock(CompletableObserver.class);
             doThrow(new TestException()).when(consumer).onComplete();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCombineLatestTest.java
@@ -1288,7 +1288,7 @@ public class FlowableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void onErrorDisposeDelayErrorRace() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestException ex = new TestException();
 
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableConcatMapSchedulerTest.java
@@ -1068,7 +1068,7 @@ public class FlowableConcatMapSchedulerTest extends RxJavaTest {
 
     @Test
     public void mainErrorInnerErrorRace() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestException ex1 = new TestException();
             TestException ex2 = new TestException();
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -908,7 +908,7 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
     @Test
     public void signalsAfterMapperCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             new Flowable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Subscriber<? super @NonNull Integer> s) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableOnErrorCompleteTest.java
@@ -19,13 +19,13 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.processors.PublishProcessor;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 import io.reactivex.rxjava4.testsupport.*;
 
-public class FlowableOnErrorCompleteTest {
+public class FlowableOnErrorCompleteTest extends RxJavaTest {
 
     @Test
     public void normal() {
@@ -59,7 +59,7 @@ public class FlowableOnErrorCompleteTest {
 
     @Test
     public void error() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable.error(new TestException())
             .onErrorComplete()
             .test()
@@ -71,7 +71,7 @@ public class FlowableOnErrorCompleteTest {
 
     @Test
     public void errorMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable.error(new TestException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -83,7 +83,7 @@ public class FlowableOnErrorCompleteTest {
 
     @Test
     public void errorNotMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable.error(new IOException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -95,7 +95,7 @@ public class FlowableOnErrorCompleteTest {
 
     @Test
     public void errorPredicateCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestSubscriberEx<Object> ts = Flowable.error(new IOException())
             .onErrorComplete(_ -> { throw new TestException(); })
             .subscribeWith(new TestSubscriberEx<>())
@@ -110,7 +110,7 @@ public class FlowableOnErrorCompleteTest {
 
     @Test
     public void itemsThenError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable.range(1, 5)
             .map(v -> 4 / (3 - v))
             .onErrorComplete()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableReplayTest.java
@@ -1037,7 +1037,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void unsafeChildOnErrorThrows() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable<Integer> source = Flowable.<Integer>error(new IOException())
                     .replay()
                     .autoConnect();
@@ -1060,7 +1060,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void unsafeChildOnCompleteThrows() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable<Integer> source = Flowable.<Integer>empty()
                     .replay()
                     .autoConnect();
@@ -1896,7 +1896,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void unsafeChildOnErrorThrowsSizeBound() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable<Integer> source = Flowable.<Integer>error(new IOException())
                     .replay(1000)
                     .autoConnect();
@@ -1919,7 +1919,7 @@ public class FlowableReplayTest extends RxJavaTest {
 
     @Test
     public void unsafeChildOnCompleteThrowsSizeBound() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable<Integer> source = Flowable.<Integer>empty()
                     .replay(1000)
                     .autoConnect();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableSwitchTest.java
@@ -1005,7 +1005,7 @@ public class FlowableSwitchTest extends RxJavaTest {
 
     @Test
     public void innerIgnoresCancelAndErrors() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishProcessor<Integer> pp = PublishProcessor.create();
 
             TestSubscriber<Object> ts = pp

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableThrottleLatestTest.java
@@ -673,7 +673,7 @@ public class FlowableThrottleLatestTest extends RxJavaTest {
      */
     @Test
     public void onDroppedDisposeCrashesDrop() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishProcessor<Integer> pp =PublishProcessor.create();
 
             TestScheduler sch = new TestScheduler();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithStartEndFlowableTest.java
@@ -450,7 +450,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     @Test
     public void openError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestException ex1 = new TestException();
             TestException ex2 = new TestException();
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -487,7 +487,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     @Test
     public void closeError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
             AtomicReference<Subscriber<? super Integer>> ref2 = new AtomicReference<>();
 
@@ -601,7 +601,7 @@ public class FlowableWindowWithStartEndFlowableTest extends RxJavaTest {
 
     @Test
     public void mainIgnoresCancelBeforeOnError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Flowable.fromPublisher(s -> {
                 s.onSubscribe(new BooleanSubscription());
                 s.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableWindowWithTimeTest.java
@@ -482,7 +482,7 @@ public class FlowableWindowWithTimeTest extends RxJavaTest {
 
             tsInner.assertError(MissingBackpressureException.class);
 
-            assertTrue(errors.isEmpty());
+            assertTrue(errors.isEmpty(), errors.toString());
         } finally {
             RxJavaPlugins.reset();
         }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeBlockingSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeBlockingSubscribeTest.java
@@ -21,14 +21,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Maybe;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class MaybeBlockingSubscribeTest {
+public class MaybeBlockingSubscribeTest extends RxJavaTest {
 
     @Test
     public void noArgSuccess() {
@@ -58,7 +58,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void noArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Maybe.error(new TestException())
             .blockingSubscribe();
 
@@ -68,7 +68,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void noArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Maybe.error(new TestException())
             .delay(100, TimeUnit.MILLISECONDS, Schedulers.computation())
             .blockingSubscribe();
@@ -125,7 +125,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void oneArgSuccessFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             doThrow(new TestException()).when(success).accept(any());
@@ -141,7 +141,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void oneArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
 
@@ -156,7 +156,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void oneArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
 
@@ -230,7 +230,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void twoArgSuccessFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             doThrow(new TestException()).when(success).accept(any());
@@ -249,7 +249,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void twoArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -267,7 +267,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -286,7 +286,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -354,7 +354,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void threeArgEmptyFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -377,7 +377,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void threeArgInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             @SuppressWarnings("unchecked")
@@ -482,7 +482,7 @@ public class MaybeBlockingSubscribeTest {
 
     @Test
     public void ovserverInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             TestObserver<Object> to = new TestObserver<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeDoOnLifecycleTest.java
@@ -76,7 +76,7 @@ public class MaybeDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);
@@ -109,7 +109,7 @@ public class MaybeDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onDisposeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/maybe/MaybeSafeSubscribeTest.java
@@ -28,11 +28,11 @@ import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class MaybeSafeSubscribeTest {
+public class MaybeSafeSubscribeTest extends RxJavaTest {
 
     @Test
     public void normalSuccess() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
 
@@ -50,7 +50,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void normalError() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
 
@@ -68,7 +68,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void normalEmpty() throws Throwable  {
-        TestHelper.withErrorTracking(_ -> {
+        withErrorTracking(_ -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
 
@@ -84,7 +84,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onSubscribe(any());
@@ -116,7 +116,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void onSuccessCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onSuccess(any());
@@ -141,7 +141,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void onErrorCrash() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());
@@ -171,7 +171,7 @@ public class MaybeSafeSubscribeTest {
 
     @Test
     public void onCompleteCrash() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             MaybeObserver<Integer> consumer = mock(MaybeObserver.class);
             doThrow(new TestException()).when(consumer).onComplete();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCombineLatestTest.java
@@ -1008,7 +1008,7 @@ public class ObservableCombineLatestTest extends RxJavaTest {
 
     @Test
     public void onErrorDisposeDelayErrorRace() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestException ex = new TestException();
 
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -864,7 +864,7 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
     @Test
     public void signalsAfterMapperCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             new Observable<Integer>() /* NFI */ {
                 @Override
                 protected void subscribeActual(@NonNull Observer<? super @NonNull Integer> observer) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableOnErrorCompleteTest.java
@@ -19,13 +19,13 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.PublishSubject;
 import io.reactivex.rxjava4.testsupport.*;
 
-public class ObservableOnErrorCompleteTest {
+public class ObservableOnErrorCompleteTest extends RxJavaTest {
 
     @Test
     public void normal() {
@@ -45,7 +45,7 @@ public class ObservableOnErrorCompleteTest {
 
     @Test
     public void error() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Observable.error(new TestException())
             .onErrorComplete()
             .test()
@@ -57,7 +57,7 @@ public class ObservableOnErrorCompleteTest {
 
     @Test
     public void errorMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Observable.error(new TestException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -69,7 +69,7 @@ public class ObservableOnErrorCompleteTest {
 
     @Test
     public void errorNotMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Observable.error(new IOException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -81,7 +81,7 @@ public class ObservableOnErrorCompleteTest {
 
     @Test
     public void errorPredicateCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestObserverEx<Object> to = Observable.error(new IOException())
             .onErrorComplete(_ -> { throw new TestException(); })
             .subscribeWith(new TestObserverEx<>())
@@ -96,7 +96,7 @@ public class ObservableOnErrorCompleteTest {
 
     @Test
     public void itemsThenError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Observable.range(1, 5)
             .map(v -> 4 / (3 - v))
             .onErrorComplete()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableSwitchTest.java
@@ -1141,7 +1141,7 @@ public class ObservableSwitchTest extends RxJavaTest {
 
     @Test
     public void innerIgnoresCancelAndErrors() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             TestObserver<Object> to = ps

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableThrottleLatestTest.java
@@ -616,7 +616,7 @@ public class ObservableThrottleLatestTest extends RxJavaTest {
      */
     @Test
     public void onDroppedDisposeCrashesDrop() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishSubject<Integer> ps = PublishSubject.create();
 
             TestScheduler sch = new TestScheduler();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableWindowWithStartEndObservableTest.java
@@ -438,7 +438,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
 
     @Test
     public void openError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestException ex1 = new TestException();
             TestException ex2 = new TestException();
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
@@ -475,7 +475,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
 
     @Test
     public void closeError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             AtomicReference<Observer<? super Integer>> ref1 = new AtomicReference<>();
             AtomicReference<Observer<? super Integer>> ref2 = new AtomicReference<>();
 
@@ -584,7 +584,7 @@ public class ObservableWindowWithStartEndObservableTest extends RxJavaTest {
 
     @Test
     public void mainIgnoresCancelBeforeOnError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Observable.unsafeCreate(s -> {
                 s.onSubscribe(Disposable.empty());
                 s.onNext(1);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleBlockingSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleBlockingSubscribeTest.java
@@ -21,14 +21,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Single;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class SingleBlockingSubscribeTest {
+public class SingleBlockingSubscribeTest extends RxJavaTest{
 
     @Test
     public void noArgSuccess() {
@@ -45,7 +45,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void noArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .blockingSubscribe();
 
@@ -55,7 +55,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void noArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .delay(100, TimeUnit.MILLISECONDS, Schedulers.computation(), true)
             .blockingSubscribe();
@@ -89,7 +89,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void oneArgSuccessFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             doThrow(new TestException()).when(success).accept(any());
@@ -105,7 +105,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void oneArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
 
@@ -120,7 +120,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void oneArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
 
@@ -165,7 +165,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void twoArgSuccessFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             doThrow(new TestException()).when(success).accept(any());
@@ -184,7 +184,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void twoArgError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -202,7 +202,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorAsync() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -221,7 +221,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void twoArgErrorFails() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<Integer> success = mock(Consumer.class);
             @SuppressWarnings("unchecked")
@@ -241,7 +241,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void twoArgInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             @SuppressWarnings("unchecked")
@@ -323,7 +323,7 @@ public class SingleBlockingSubscribeTest {
 
     @Test
     public void ovserverInterrupted() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Action onDispose = mock(Action.class);
 
             TestObserver<Object> to = new TestObserver<>();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnLifecycleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleDoOnLifecycleTest.java
@@ -61,7 +61,7 @@ public class SingleDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);
@@ -93,7 +93,7 @@ public class SingleDoOnLifecycleTest extends RxJavaTest {
 
     @Test
     public void onDisposeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             Consumer<? super Disposable> onSubscribe = mock(Consumer.class);
             Action onDispose = mock(Action.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleFlatMapNotificationTest.java
@@ -84,7 +84,7 @@ public class SingleFlatMapNotificationTest extends RxJavaTest {
 
     @Test
     public void onErrorSuccess() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .flatMap(_ -> Single.just(2), _ -> Single.just(3))
             .test()
@@ -96,7 +96,7 @@ public class SingleFlatMapNotificationTest extends RxJavaTest {
 
     @Test
     public void onErrorError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .flatMap(_ -> Single.just(2), _ -> Single.<Integer>error(new IOException()))
             .test()

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorCompleteTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleOnErrorCompleteTest.java
@@ -19,13 +19,13 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Single;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.subjects.SingleSubject;
 import io.reactivex.rxjava4.testsupport.*;
 
-public class SingleOnErrorCompleteTest {
+public class SingleOnErrorCompleteTest extends RxJavaTest {
 
     @Test
     public void normal() {
@@ -37,7 +37,7 @@ public class SingleOnErrorCompleteTest {
 
     @Test
     public void error() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .onErrorComplete()
             .test()
@@ -49,7 +49,7 @@ public class SingleOnErrorCompleteTest {
 
     @Test
     public void errorMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new TestException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -61,7 +61,7 @@ public class SingleOnErrorCompleteTest {
 
     @Test
     public void errorNotMatches() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Single.error(new IOException())
             .onErrorComplete(error -> error instanceof TestException)
             .test()
@@ -73,7 +73,7 @@ public class SingleOnErrorCompleteTest {
 
     @Test
     public void errorPredicateCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestObserverEx<Object> to = Single.error(new IOException())
             .onErrorComplete(_ -> { throw new TestException(); })
             .subscribeWith(new TestObserverEx<>())

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/single/SingleSafeSubscribeTest.java
@@ -28,11 +28,11 @@ import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class SingleSafeSubscribeTest {
+public class SingleSafeSubscribeTest extends RxJavaTest {
 
     @Test
     public void normalSuccess() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
 
@@ -50,7 +50,7 @@ public class SingleSafeSubscribeTest {
 
     @Test
     public void normalError() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
 
@@ -68,7 +68,7 @@ public class SingleSafeSubscribeTest {
 
     @Test
     public void onSubscribeCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
             doThrow(new TestException()).when(consumer).onSubscribe(any());
@@ -99,7 +99,7 @@ public class SingleSafeSubscribeTest {
 
     @Test
     public void onSuccessCrash() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
             doThrow(new TestException()).when(consumer).onSuccess(any());
@@ -124,7 +124,7 @@ public class SingleSafeSubscribeTest {
 
     @Test
     public void onErrorCrash() throws Throwable  {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             @SuppressWarnings("unchecked")
             SingleObserver<Integer> consumer = mock(SingleObserver.class);
             doThrow(new TestException()).when(consumer).onError(any());

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
@@ -18,12 +18,12 @@ import java.util.*;
 
 import org.junit.jupiter.api.*;
 
-import io.reactivex.rxjava4.core.CompletionStageDisposable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.CompositeException;
 import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 
-public abstract class StreamableBaseTest {
+public abstract class StreamableBaseTest extends RxJavaTest {
 
     protected java.util.function.Consumer<Cleaner.Cleanable> stageTrackingState;
 
@@ -70,5 +70,4 @@ public abstract class StreamableBaseTest {
     protected final void setUndeliverablesExpected(boolean isExpected) {
         undeliverablesExpected = isExpected;
     }
-
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDeferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDeferTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+@Isolated
+public class StreamableDeferTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        var counter = new AtomicInteger();
+
+        var source = Streamable.defer(() -> {
+
+            return Streamable.just(counter.getAndIncrement());
+        });
+
+        for (int i = 0; i < 5; i++) {
+            source.test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(i);
+        }
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.defer(() -> { throw new TestException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableErrorTest.java
@@ -13,6 +13,8 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.Streamable;
 import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableError.ErrorStreamer;
 
 @Isolated
 public class StreamableErrorTest extends StreamableBaseTest {
@@ -40,5 +43,13 @@ public class StreamableErrorTest extends StreamableBaseTest {
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    public void currentThrows() {
+        assertThrows(IllegalStateException.class, () -> {
+            new ErrorStreamer<>(new TestException()).current();
+        });
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableErrorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableErrorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+@Isolated
+public class StreamableErrorTest extends StreamableBaseTest {
+
+    @Test
+    public void normalSingleExecutor() throws Throwable {
+        withCachedExecutor(exec -> {
+            Streamable.error(new TestException())
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(TestException.class);
+        });
+    }
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.error(new TestException())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.disposables.CompositeDisposable;
+import io.reactivex.rxjava4.exceptions.*;
+
+@Isolated
+public class StreamableForEachTest extends StreamableBaseTest {
+
+    @Test
+    public void forEachCheckedCrash() {
+        var ex = assertThrows(ThrowableWrapper.class, () -> {
+            Streamable.just(1)
+            .forEach(_ -> {
+                throw new Exception("test");
+            })
+            .await()
+            ;
+        });
+
+        assertEquals("test", ex.getCause().getMessage());
+    }
+
+    @Test
+    public void forEachUncheckedCrash() {
+        var ex = assertThrows(TestException.class, () -> {
+            Streamable.just(1)
+            .forEach(_ -> {
+                throw new TestException("test");
+            })
+            .await()
+            ;
+        });
+
+        assertEquals("test", ex.getMessage());
+    }
+
+    @Test
+    public void forEachExecCheckedCrash() throws Throwable {
+        withCachedExecutor(exec -> {
+            var ex = assertThrows(ThrowableWrapper.class, () -> {
+                Streamable.just(1)
+                .forEach(_ -> {
+                    throw new Exception("test");
+                }, exec)
+                .await()
+                ;
+            });
+
+            assertEquals("test", ex.getCause().getMessage());
+        });
+    }
+
+    @Test
+    public void forEachExecUncheckedCrash() throws Throwable {
+        withCachedExecutor(exec -> {
+            var ex = assertThrows(TestException.class, () -> {
+                Streamable.just(1)
+                .forEach(_ -> {
+                    throw new TestException("test");
+                }, exec)
+                .await()
+                ;
+            });
+
+            assertEquals("test", ex.getMessage());
+        });
+    }
+
+
+    @Test
+    public void forEachBiCheckedCrash() throws Throwable {
+        withVirtual(exec -> {
+            var ex = assertThrows(ThrowableWrapper.class, () -> {
+                Streamable.just(1)
+                .forEach((_, _) -> {
+                    throw new Exception("test");
+                }, new CompositeDisposable(), exec)
+                .await()
+                ;
+            });
+
+            assertEquals("test", ex.getCause().getMessage());
+        });
+    }
+
+    @Test
+    public void forEachBiUncheckedCrash() throws Throwable {
+        withVirtual(exec -> {
+            var ex = assertThrows(TestException.class, () -> {
+                Streamable.just(1)
+                .forEach((_, _) -> {
+                    throw new TestException("test");
+                }, new CompositeDisposable(), exec)
+                .await()
+                ;
+            });
+
+            assertEquals("test", ex.getMessage());
+        });
+    }
+
+    @Test
+    public void forEachBiUncheckedPropagation() throws Throwable {
+        withVirtual(exec -> {
+            var ex = assertThrows(TestException.class, () -> {
+                Streamable.error(new TestException("test"))
+                .forEach((_, _) -> {
+                }, new CompositeDisposable(), exec)
+                .await()
+                ;
+            });
+
+            assertEquals("test", ex.getMessage());
+        });
+    }
+
+    @Test
+    public void forEachOutsideCancel() {
+        var cd = new CompositeDisposable();
+        var counter = new AtomicInteger();
+
+        assertThrows(CancellationException.class, () -> {
+            Streamable.range(1, 5)
+            .forEach(_ -> {
+                counter.getAndIncrement();
+                cd.dispose();
+            }, cd)
+            .await();
+        });
+
+        assertTrue(cd.isDisposed(), "cd was not disposed");
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void forEachBiOutsideCancel() throws Throwable {
+        withVirtual(exec -> {
+            var cd = new CompositeDisposable();
+            var counter = new AtomicInteger();
+
+            assertThrows(CancellationException.class, () -> {
+                Streamable.range(1, 5)
+                .forEach((_, _) -> {
+                    counter.getAndIncrement();
+                    cd.dispose();
+                }, cd, exec)
+                .await();
+            });
+
+            assertTrue(cd.isDisposed(), "cd was not disposed");
+            assertEquals(1, counter.get());
+        });
+    }
+
+    @Test
+    public void forEachBiInsideCancel() throws Throwable {
+        withVirtual(exec -> {
+            var cd = new CompositeDisposable();
+            var counter = new AtomicInteger();
+
+            Streamable.range(1, 5)
+            .forEach((_, s) -> {
+                counter.getAndIncrement();
+                s.dispose();
+            }, cd, exec)
+            .await();
+
+            assertFalse(cd.isDisposed(), "cd was disposed");
+            assertEquals(1, counter.get());
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
@@ -88,7 +88,6 @@ public class StreamableForEachTest extends StreamableBaseTest {
         });
     }
 
-
     @Test
     public void forEachBiCheckedCrash() throws Throwable {
         withVirtual(exec -> {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromArrayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromArrayTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+
+@Isolated
+public class StreamableFromArrayTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.fromArray(1, 2, 3)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void hasNull() throws Throwable {
+        Streamable.fromArray(1, null, 3)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class, 1)
+        .assertError(t -> t.getMessage().equals("Item at index 1 is null."));
+        ;
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
@@ -101,4 +101,9 @@ public class StreamableRangeTest extends StreamableBaseTest {
         });
     }
 
+
+    @Test
+    public void underNoOverflowLong() throws Throwable {
+        Streamable.rangeLong(-2, Long.MAX_VALUE);
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+
+@Isolated
+public class StreamableRangeTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 3)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void normal1() throws Throwable {
+        Streamable.range(1, 1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void normal0() throws Throwable {
+        Streamable.range(1, 0)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void normalLong() throws Throwable {
+        Streamable.rangeLong(1, 3)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1L, 2L, 3L);
+    }
+
+    @Test
+    public void normal1Long() throws Throwable {
+        Streamable.rangeLong(1, 1)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1L);
+    }
+
+    @Test
+    public void normal0Long() throws Throwable {
+        Streamable.rangeLong(1, 0)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void underflow() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Streamable.range(1, -1);
+        });
+    }
+
+    @Test
+    public void underOverflow() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Streamable.range(2, Integer.MAX_VALUE);
+        });
+    }
+
+    @Test
+    public void underflowLong() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Streamable.rangeLong(1, -1);
+        });
+    }
+
+    @Test
+    public void underOverflowLong() throws Throwable {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Streamable.rangeLong(2, Long.MAX_VALUE);
+        });
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableRangeTest.java
@@ -101,7 +101,6 @@ public class StreamableRangeTest extends StreamableBaseTest {
         });
     }
 
-
     @Test
     public void underNoOverflowLong() throws Throwable {
         Streamable.rangeLong(-2, Long.MAX_VALUE);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTakeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTakeTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Flowable;
+
+@Isolated
+public class StreamableTakeTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        var isCancelled = new AtomicBoolean();
+
+        Flowable.range(1, 10)
+        .doOnCancel(() -> isCancelled.set(true))
+        .toStreamable()
+        .take(5)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertTrue(isCancelled.get(), "Cancel was not propagated");
+    }
+
+    @Test
+    public void fewer() throws Throwable {
+        var isCancelled = new AtomicBoolean();
+
+        Flowable.range(1, 4)
+        .doOnCancel(() -> isCancelled.set(true))
+        .toStreamable()
+        .take(5)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4);
+
+        assertFalse(isCancelled.get(), "Cancel was propagated!");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
@@ -266,6 +266,24 @@ public class StreamableTest extends StreamableBaseTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(1, 2);
 
+        });
+    }
+
+    @Test
+    public void fromPublisher() throws Throwable {
+        Streamable.fromPublisher(Flowable.range(1, 5))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void fromPublisherExec() throws Throwable {
+        withVirtual(exec -> {
+            Streamable.fromPublisher(Flowable.range(1, 5), exec)
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5);
         });
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -25,14 +25,13 @@ import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
-import io.reactivex.rxjava4.testsupport.TestHelper;
 
 @Isolated
 public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void empty() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
 
             var ts = new TestSubscriber<Integer>();
             ts.onSubscribe(EmptySubscription.INSTANCE);
@@ -54,7 +53,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void just() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
 
             var ts = new TestSubscriber<Integer>();
             ts.onSubscribe(EmptySubscription.INSTANCE);
@@ -76,7 +75,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @RepeatedTest(100)
     public void fromFlowable() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
             Flowable.range(1, 10)
             .toStreamable(exec)
             .test(exec)
@@ -91,7 +90,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @RepeatedTest(100)
     public void fromFlowableToStreamableToFlowable() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
             Flowable.range(1, 10)
             .toStreamable(exec)
             .toFlowable(exec)
@@ -107,7 +106,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @RepeatedTest(100)
     public void createAndTransform() throws Throwable {
-        TestHelper.onVirtual(exec -> {
+        onVirtual(exec -> {
             Streamable.<Integer>create(emitter -> {
                 for (int i = 1; i < 11; i++) {
                     emitter.emit(i);
@@ -125,7 +124,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @RepeatedTest(100)
     public void flowableRangeAndTransform() throws Throwable {
-        TestHelper.onVirtual(exec -> {
+        onVirtual(exec -> {
             Flowable.range(1, 10)
             .toStreamable(exec)
             .transform((item, emitter, _) -> emitter.emit(-item - 1), exec)
@@ -140,7 +139,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void flowableRangeAndTransform1() throws Throwable {
-        TestHelper.onVirtual(exec -> {
+        onVirtual(exec -> {
             System.out.println(">> START");
             Flowable.range(1, 10)
             .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
@@ -164,7 +163,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void flowableRangeAndTransformFlowable1() throws Throwable {
-        TestHelper.onVirtual(exec -> {
+        onVirtual(exec -> {
             System.out.println(">> START");
             Flowable.range(1, 10)
             .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
@@ -193,7 +192,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void flowableRangeAndTransform2() throws Throwable {
-        TestHelper.withCachedExecutor(exec -> {
+        withCachedExecutor(exec -> {
             System.out.println(">> START");
             var ts = Flowable.range(1, 10)
             .doOnSubscribe(_ -> System.out.println("Flowable::doOnSubscribe"))
@@ -222,7 +221,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void rangeTransformFilter() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.range(1, 10)
+        withVirtual(exec -> Flowable.range(1, 10)
         .toStreamable(exec)
         .transform((item, emitter, _) -> {
             if ((item & 1) == 0) {
@@ -236,7 +235,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void rangeTransformTake() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
             var cancelled = new AtomicInteger();
             Flowable.range(1, 10)
             .doOnCancel(cancelled::incrementAndGet)
@@ -257,7 +256,7 @@ public class StreamableTest extends StreamableBaseTest {
 
     @Test
     public void concat() throws Throwable {
-        TestHelper.withVirtual(exec -> {
+        withVirtual(exec -> {
 
             var srcs = Flowable.just(Streamable.just(1), Streamable.empty(), Streamable.just(2))
             .toStreamable();

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SingleSchedulerTest.java
@@ -115,7 +115,7 @@ public class SingleSchedulerTest extends AbstractSchedulerTests {
 
     @Test
     public void zeroPeriodRejectedExecution() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             Scheduler s = RxJavaPlugins.createSingleScheduler(new RxThreadFactory("Test"));
             s.shutdown();
             Runnable run = mock(Runnable.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualCreateTest.java
@@ -29,7 +29,6 @@
 
 package io.reactivex.rxjava4.internal.virtual;
 
-import static io.reactivex.rxjava4.testsupport.TestHelper.withVirtual;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -40,9 +39,10 @@ import org.junit.jupiter.api.Test;
 
 import io.reactivex.rxjava4.core.Flowable;
 import io.reactivex.rxjava4.core.config.StandardBufferedConfig;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableBaseTest;
 import io.reactivex.rxjava4.schedulers.Schedulers;
 
-public class VirtualCreateTest {
+public class VirtualCreateTest extends StreamableBaseTest {
 
     @Test
     public void checkIsInsideVirtualThread() {

--- a/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/virtual/VirtualTransformTest.java
@@ -21,12 +21,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.config.StandardBufferedConfig;
 import io.reactivex.rxjava4.schedulers.Schedulers;
-import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class VirtualTransformTest {
+public class VirtualTransformTest extends RxJavaTest {
 
     @Test
     public void checkIsInsideVirtualThread() {
@@ -46,7 +45,7 @@ public class VirtualTransformTest {
 
     @Test
     public void errorUpstream() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.error(new IOException())
+        withVirtual(exec -> Flowable.error(new IOException())
         .virtualTransform((v, e, _) -> e.emit(v), exec)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -55,7 +54,7 @@ public class VirtualTransformTest {
 
     @Test
     public void errorTransform() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.range(1, 5)
+        withVirtual(exec -> Flowable.range(1, 5)
         .virtualTransform((_, _, _) -> { throw new IOException(); }, exec)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -64,7 +63,7 @@ public class VirtualTransformTest {
 
     @Test
     public void take() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.range(1, 5)
+        withVirtual(exec -> Flowable.range(1, 5)
         .virtualTransform((v, e, _) -> e.emit(v), exec)
         .take(2)
         .test()
@@ -74,7 +73,7 @@ public class VirtualTransformTest {
 
     @Test
     public void observeOn() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.range(1, 10000)
+        withVirtual(exec -> Flowable.range(1, 10000)
         .virtualTransform((v, e, _) -> e.emit(v), exec)
         .observeOn(Schedulers.single(), new StandardBufferedConfig(false, 2))
         .test()
@@ -85,7 +84,7 @@ public class VirtualTransformTest {
 
     @Test
     public void empty() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.empty()
+        withVirtual(exec -> Flowable.empty()
         .virtualTransform((v, e, _) -> e.emit(v), exec)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
@@ -94,7 +93,7 @@ public class VirtualTransformTest {
 
     @Test
     public void emptyNever() throws Throwable {
-        TestHelper.withVirtual(exec -> Flowable.just(1).concatWith(Flowable.never())
+        withVirtual(exec -> Flowable.just(1).concatWith(Flowable.never())
         .virtualTransform((v, e, _) -> e.emit(v), exec)
         .test()
         .awaitDone(1, TimeUnit.SECONDS)

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelJoinTest.java
@@ -429,7 +429,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void onNextMissingBackpressureRace() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();
@@ -473,7 +473,7 @@ public class ParallelJoinTest extends RxJavaTest {
 
     @Test
     public void onNextMissingBackpressureDelayErrorRace() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
 
                 AtomicReference<Subscriber<? super Integer>> ref1 = new AtomicReference<>();

--- a/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
+++ b/src/test/java/io/reactivex/rxjava4/parallel/ParallelSortedJoinTest.java
@@ -193,7 +193,7 @@ public class ParallelSortedJoinTest extends RxJavaTest {
 
     @Test
     public void comparatorCrashWhileMainOnError() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             PublishProcessor<List<Integer>> pp1 = PublishProcessor.create();
             PublishProcessor<List<Integer>> pp2 = PublishProcessor.create();
 

--- a/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/plugins/RxJavaPluginsTest.java
@@ -39,6 +39,7 @@ import io.reactivex.rxjava4.internal.operators.maybe.MaybeError;
 import io.reactivex.rxjava4.internal.operators.observable.ObservableRange;
 import io.reactivex.rxjava4.internal.operators.parallel.ParallelFromPublisher;
 import io.reactivex.rxjava4.internal.operators.single.SingleJust;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableError;
 import io.reactivex.rxjava4.internal.schedulers.ImmediateThinScheduler;
 import io.reactivex.rxjava4.internal.subscriptions.ScalarSubscription;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
@@ -924,6 +925,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             BiFunction<? super Completable, ? super CompletableObserver, ? extends CompletableObserver> completableObserver2completableObserver
                 = (_, completableObserver) -> completableObserver;
             Function<? super Completable, ? extends Completable> completable2completable = completable -> completable;
+            Function<? super Streamable, ? extends Streamable> streamable2streamable = streamable -> streamable;
 
             RxJavaPlugins.setInitComputationSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setComputationSchedulerHandler(scheduler2scheduler);
@@ -949,6 +951,7 @@ public class RxJavaPluginsTest extends RxJavaTest {
             RxJavaPlugins.setInitNewThreadSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setInitCachedSchedulerHandler(callable2scheduler);
             RxJavaPlugins.setInitVirtualSchedulerHandler(callable2scheduler);
+            RxJavaPlugins.setOnStreamableAssembly(streamable2streamable);
         } finally {
             RxJavaPlugins.reset();
         }
@@ -1018,6 +1021,12 @@ public class RxJavaPluginsTest extends RxJavaTest {
             };
 
             assertSame(myb, RxJavaPlugins.onAssembly(myb));
+
+            assertNull(RxJavaPlugins.onAssembly((Streamable)null));
+
+            Streamable str = _ -> null;
+
+            assertSame(str, RxJavaPlugins.onAssembly(str));
 
             Runnable action = Functions.EMPTY_RUNNABLE;
             assertSame(action, RxJavaPlugins.onSchedule(action));
@@ -1360,6 +1369,30 @@ public class RxJavaPluginsTest extends RxJavaTest {
 
         Maybe.empty()
         .test()
+        .assertNoValues()
+        .assertNoErrors()
+        .assertComplete();
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void streamableCreate() {
+        try {
+            RxJavaPlugins.setOnStreamableAssembly(_ -> new StreamableError(new TestException()));
+
+            Streamable.empty()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertNoValues()
+            .assertNotComplete()
+            .assertError(TestException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+        // make sure the reset worked
+        Streamable.empty()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
         .assertNoValues()
         .assertNoErrors()
         .assertComplete();

--- a/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/SchedulerTest.java
@@ -58,7 +58,7 @@ public class SchedulerTest extends RxJavaTest {
 
     @Test
     public void periodicDirectThrows() throws Throwable {
-        TestHelper.withErrorTracking(errors -> {
+        withErrorTracking(errors -> {
             TestScheduler scheduler = new TestScheduler();
 
             try {

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -68,6 +68,14 @@ public enum TestHelper {
      */
     public static final int RACE_LONG_LOOPS = 10000;
 
+    public static List<Throwable> trackPluginErrors() {
+        final List<Throwable> list = Collections.synchronizedList(new ArrayList<>());
+
+        RxJavaPlugins.setErrorHandler(list::add);
+
+        return list;
+    }
+
     /**
      * Mocks a subscriber and prepares it to request {@link Long#MAX_VALUE}.
      * @param <T> the value type
@@ -146,14 +154,6 @@ public enum TestHelper {
             ae.initCause(ex);
             throw ae;
         }
-    }
-
-    public static List<Throwable> trackPluginErrors() {
-        final List<Throwable> list = Collections.synchronizedList(new ArrayList<>());
-
-        RxJavaPlugins.setErrorHandler(list::add);
-
-        return list;
     }
 
     public static void assertError(List<Throwable> list, int index, Class<? extends Throwable> clazz) {
@@ -3682,20 +3682,6 @@ public enum TestHelper {
     }
 
     /**
-     * Enable thracking of the global errors for the duration of the action.
-     * @param action the action to run with a list of errors encountered
-     * @throws Throwable the exception rethrown from the action
-     */
-    public static void withErrorTracking(Consumer<List<Throwable>> action) throws Throwable {
-        List<Throwable> errors = trackPluginErrors();
-        try {
-            action.accept(errors);
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    /**
      * Assert if the given CompletableFuture fails with a specified error inside an ExecutionException.
      * @param cf the CompletableFuture to test
      * @param error the error class expected
@@ -3885,137 +3871,6 @@ public enum TestHelper {
         @Override
         public void cancel() {
             upstream.cancel();
-        }
-    }
-
-    /**
-     * Execute a test body with the help of a virtual thread executor service.
-     * <p>
-     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
-     * @param call the callback to give the VTE.
-     * @throws Throwable propagate exceptions
-     */
-    public static void withVirtual(Consumer<ExecutorService> call) throws Throwable {
-        try (var exec = new ExecutorIntercept(Executors.newThreadPerTaskExecutor(Thread.ofVirtual().factory()), false)) {
-            call.accept(exec);
-        }
-    }
-
-    /**
-     * Execute a call within a virtual thread of the standard virtual thread executor.
-     * @param call the call to invoke
-     * @throws Throwable the exception propagated out
-     */
-    public static void onVirtual(Consumer<ExecutorService> call) throws Throwable {
-        withVirtual(exec -> exec.submit(() -> {
-            try {
-                call.accept(exec);
-            } catch (Throwable ex) {
-                throw Exceptions.propagate(ex);
-            }
-        }).get());
-    }
-
-    record ExecutorIntercept(ExecutorService service, boolean printStackTrace) implements ExecutorService {
-
-        @Override
-        public void execute(Runnable command) {
-            service.execute(command);
-        }
-
-        @Override
-        public void shutdown() {
-            if (printStackTrace) {
-                new CancellationException("ExecutorIntercept::shutdown").printStackTrace();
-            }
-            service.shutdown();
-        }
-
-        @Override
-        public List<Runnable> shutdownNow() {
-            if (printStackTrace) {
-                new CancellationException("ExecutorIntercept::shutdownNow").printStackTrace();
-            }
-            return service.shutdownNow();
-        }
-
-        @Override
-        public boolean isShutdown() {
-            return service.isShutdown();
-        }
-
-        @Override
-        public boolean isTerminated() {
-            return service.isTerminated();
-        }
-
-        @Override
-        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-            return service.awaitTermination(timeout, unit);
-        }
-
-        @Override
-        public <T> Future<T> submit(Callable<T> task) {
-            return service.submit(task);
-        }
-
-        @Override
-        public <T> Future<T> submit(Runnable task, T result) {
-            return service.submit(task, result);
-        }
-
-        @Override
-        public Future<?> submit(Runnable task) {
-            return service.submit(task);
-        }
-
-        @Override
-        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-            return service.invokeAll(tasks);
-        }
-
-        @Override
-        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                throws InterruptedException {
-            return service.invokeAll(tasks, timeout, unit);
-        }
-
-        @Override
-        public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-                throws InterruptedException, ExecutionException {
-            return service.invokeAny(tasks);
-        }
-
-        @Override
-        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-                throws InterruptedException, ExecutionException, TimeoutException {
-            return service.invokeAny(tasks, timeout, unit);
-        }
-    }
-
-    /**
-     * Execute a test body with the help of a single thread executor service.
-     * <p>
-     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
-     * @param call the callback to give the VTE.
-     * @throws Throwable propagate exceptions
-     */
-    public static void withSingleExecutor(Consumer<ScheduledExecutorService> call) throws Throwable {
-        try (var exec = Executors.newSingleThreadScheduledExecutor()) {
-            call.accept(exec);
-        }
-    }
-
-    /**
-     * Execute a test body with the help of a cached executor service.
-     * <p>
-     * Don't forget to {@link ExecutorService#submit(Callable)} your work!
-     * @param call the callback to give the VTE.
-     * @throws Throwable propagate exceptions
-     */
-    public static void withCachedExecutor(Consumer<ExecutorService> call) throws Throwable {
-        try (var exec = new ExecutorIntercept(Executors.newCachedThreadPool(), false)) {
-            call.accept(exec);
         }
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckSourceAnnotationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckSourceAnnotationTest.java
@@ -428,7 +428,7 @@ public class CheckSourceAnnotationTest extends RxJavaTest {
             }
 
             for (String typeName : TYPES_REQUIRING_NONNULL_TYPE_ARG_ON_FUNC) {
-                if (line.matches(".*Function\\d?<.*, (\\? (extends|super) )?" + typeName + ".*")) {
+                if (line.matches(".*Function\\d?<.*, (\\? (extends|super) )?" + typeName + "[,>].*")) {
                     errorCount++;
                     errors.append("L")
                     .append(j)
@@ -484,7 +484,9 @@ public class CheckSourceAnnotationTest extends RxJavaTest {
             "BackpressureOverflowStrategy", "BackpressureStrategy",
             "Subject", "Processor", "FlowableProcessor",
 
-            "T", "R", "U", "V"
+            "T", "R", "U", "V",
+
+            "Streamable", "Streamer"
     );
 
     static final List<String> TYPES_REQUIRING_NONNULL_TYPE_ARG = Arrays.asList(


### PR DESCRIPTION
Also

- Fix missing `onAssembly` calls
- Update `RxJavaPlugins` to support `Streamable` `onAssembly` calls
- Inlined a few `TestHelper.withXXX` into `RxJavaTest`.
- Added missing `extends RxJavaTest`s.
- Introduce `ThrowableWrapper` as a special class indicating it holds some exception that needs to be propagated.
- Make sure `Streamable` unwraps the `ThrowableWrapper`s the right time
