### PR TITLE
4.x: Streamable + fromIterable, fromStream, hide, never, fixes

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -16,6 +16,7 @@ package io.reactivex.rxjava4.core;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.disposables.*;
@@ -54,17 +55,6 @@ public interface Streamable<@NonNull T> {
     // HELPERS
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
-    // TODO, why no public final so it is not unnecessarily reimplemented, Java?
-    /**
-     * Realizes the stream and returns an interface that lets one consume it.
-     * @return the Streamer instance to consume.
-     */
-    @CheckReturnValue
-    @NonNull
-    default Streamer<T> stream() {
-        return stream(new CompositeDisposable()); // FIXME, use a practically no-op disposable container instead
-    }
-
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     // Data sources and wrappers
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
@@ -74,10 +64,11 @@ public interface Streamable<@NonNull T> {
      * @param <T> the element type
      * @return the {@code Streamable} instance
      */
+    @SuppressWarnings("unchecked")
     @CheckReturnValue
     @NonNull
     static <@NonNull T> Streamable<T> empty() {
-        return RxJavaPlugins.onAssembly(new StreamableEmpty<>());
+        return RxJavaPlugins.onAssembly((Streamable<T>)StreamableEmpty.INSTANCE);
     }
 
     /**
@@ -101,17 +92,46 @@ public interface Streamable<@NonNull T> {
      * @throws NullPointerException if {@code items} is {@code null}
      */
     @SafeVarargs
+    @CheckReturnValue
     @NonNull
-    static <@NonNull T> Streamable<T> fromArray(T... items) {
+    static <@NonNull T> Streamable<T> fromArray(@NonNull T... items) {
         Objects.requireNonNull(items, "items is null");
         return RxJavaPlugins.onAssembly(new StreamableFromArray<>(items));
     }
 
     /**
-     * Convert any Flow.Publisher into a Streamable sequence.
+     * Streams all elements of the given {@link Iterable} sequence.
+     * @param <T> the element type of the items
+     * @param items the iterable of items to stream
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code items} is {@code null}
+     */
+    @CheckReturnValue
+    @NonNull
+    static <@NonNull T> Streamable<T> fromIterable(@NonNull Iterable<? extends T> items) {
+        Objects.requireNonNull(items, "items is null");
+        return RxJavaPlugins.onAssembly(new StreamableFromIterable<>(items));
+    }
+
+    /**
+     * Streams all elements of the given {@link Stream} sequence.
+     * @param <T> the element type of the items
+     * @param items the stream of items to stream
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code items} is {@code null}
+     */
+    @CheckReturnValue
+    @NonNull
+    static <@NonNull T> Streamable<T> fromStream(@NonNull Stream<? extends T> items) {
+        Objects.requireNonNull(items, "items is null");
+        return RxJavaPlugins.onAssembly(new StreamableFromStream<>(items));
+    }
+
+    /**
+     * Convert any {@link java.util.concurrent.Flow.Publisher} into a {@code Streamable} sequence.
      * @param <T> the element type
      * @param source Flow.Publisher to convert
-     * @return the new Streamable instance
+     * @return the new {@code Streamable} instance
      */
     @CheckReturnValue
     @NonNull
@@ -121,17 +141,30 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
-     * Convert any Flow.Publisher into a Streamable sequence.
+     * Convert any {@link java.util.concurrent.Flow.Publisher} into a {@code Streamable} sequence.
      * @param <T> the element type
      * @param source Flow.Publisher to convert
      * @param executor where the conversion will run
-     * @return the new Streamable instance
+     * @return the new {@code Streamable} instance
      */
     @CheckReturnValue
     @NonNull
     static <T> Streamable<T> fromPublisher(@NonNull Flow.Publisher<T> source, @NonNull ExecutorService executor) {
         Objects.requireNonNull(source, "source is null");
+        Objects.requireNonNull(executor, "executor is null");
         return RxJavaPlugins.onAssembly(new StreamableFromPublisher<>(source, executor));
+    }
+
+    /**
+     * Returns an {@code Streamable} that never produces an item and never terminates.
+     * @param <T> the element type
+     * @return the {@code Streamable} instance
+     */
+    @SuppressWarnings("unchecked")
+    @CheckReturnValue
+    @NonNull
+    static <@NonNull T> Streamable<T> never() {
+        return RxJavaPlugins.onAssembly((Streamable<T>)StreamableNever.INSTANCE);
     }
 
     /**
@@ -139,6 +172,17 @@ public interface Streamable<@NonNull T> {
      * which is free to block and is natively backpressured.
      * <p>
      * Runs on the {@link Schedulers#virtual()} scheduler.
+     * <p>
+     * Example
+     * <pre><code>
+     * Streamable.create(emitter -> {
+     *     emitter.emit(1);
+     *     emitter.emit(2);
+     *     emitter.emit(3);
+     * })
+     * .forEach(System.out::println)
+     * ;
+     * </code></pre>
      * @param <T> the element type
      * @param generator the generator to use
      * @return the streamable instance
@@ -156,6 +200,17 @@ public interface Streamable<@NonNull T> {
      * which is free to block and is natively backpressured.
      * <p>
      * Runs on the given scheduler.
+     * <p>
+     * Example
+     * <pre><code>
+     * Streamable.create(emitter -> {
+     *     emitter.emit(1);
+     *     emitter.emit(2);
+     *     emitter.emit(3);
+     * }, Schedulers.cached())
+     * .forEach(System.out::println)
+     * ;
+     * </code></pre>
      * @param <T> the element type
      * @param generator the generator to use
      * @param scheduler the scheduler to run the virtual generator on
@@ -195,8 +250,12 @@ public interface Streamable<@NonNull T> {
      * @return the new Streamable instance
      */
     @SuppressWarnings("unchecked")
+    @CheckReturnValue
     @NonNull
-    static <@NonNull T> Streamable<CompletionStage<T>> fromStages(@NonNull Iterable<? extends CompletionStage<? extends T>> stages, ExecutorService executor) {
+    static <@NonNull T> Streamable<CompletionStage<T>> fromStages(
+            @NonNull Iterable<? extends CompletionStage<? extends T>> stages, ExecutorService executor) {
+        Objects.requireNonNull(stages, "stages is null");
+        Objects.requireNonNull(executor, "executor is null");
         return create(emitter -> {
             var list = new ArrayList<CompletionStage<? extends T>>();
             for(var stage : stages) {
@@ -217,6 +276,8 @@ public interface Streamable<@NonNull T> {
      * @return the new {@code Streamable} instance
      * @throws NullPointerException if {@code supplier} is {@code null}
      */
+    @CheckReturnValue
+    @NonNull
     static <@NonNull T> Streamable<T> defer(Supplier<? extends Streamable<? extends T>> supplier) {
         Objects.requireNonNull(supplier, "supplier is null");
         return RxJavaPlugins.onAssembly(new StreamableDefer<>(supplier));
@@ -230,28 +291,35 @@ public interface Streamable<@NonNull T> {
      * @return the new {@code Streamable} instance
      * @throws NullPointerException if {@code throwable} is {@code null}
      */
+    @CheckReturnValue
+    @NonNull
     static <@NonNull T> Streamable<T> error(Throwable throwable) {
         Objects.requireNonNull(throwable, "throwable is null");
         return RxJavaPlugins.onAssembly(new StreamableError<>(throwable));
     }
 
     /**
-     * Emits the elements of each inner sequence produced by the outher sequence.
+     * Emits the elements of each inner sequence produced by the outer sequence.
      * @param <T> the common element type
      * @param sources a streamable of inner streamables
-     * @param exec the executorservice where to run the virtual wait
-     * @return the new Streamable instance.
+     * @param executor the executorservice where to run the virtual wait
+     * @return the new {@code Streamable} instance.
+     * @throws NullPointerException if {@code sources} or {@code exec} is {@code null}
      */
-    static <@NonNull T> Streamable<T> concat(Streamable<? extends Streamable<? extends T>> sources, ExecutorService exec) {
+    @CheckReturnValue
+    @NonNull
+    static <@NonNull T> Streamable<T> concat(Streamable<? extends Streamable<? extends T>> sources, ExecutorService executor) {
+        Objects.requireNonNull(sources, "sources is null");
+        Objects.requireNonNull(executor, "executor is null");
         return create(emitter -> {
             try (var mainSource = sources.forEach(item -> {
-                try (var innerSource = item.forEach(emitter::emit, emitter.canceller().derive(), exec)) {
+                try (var innerSource = item.forEach(emitter::emit, emitter.canceller().derive(), executor)) {
                     innerSource.await(emitter.canceller());
                 }
-            }, emitter.canceller(), exec)) {
+            }, emitter.canceller(), executor)) {
                 mainSource.await(emitter.canceller());
             }
-        }, exec);
+        }, executor);
     }
 
     /**
@@ -260,6 +328,8 @@ public interface Streamable<@NonNull T> {
      * @param count the number of elements to emit
      * @return the new {@code Streamable} instance
      */
+    @CheckReturnValue
+    @NonNull
     static Streamable<Integer> range(int start, int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -282,6 +352,8 @@ public interface Streamable<@NonNull T> {
      * @param count the number of elements to emit
      * @return the new {@code Streamable} instance
      */
+    @CheckReturnValue
+    @NonNull
     static Streamable<Long> rangeLong(long start, long count) {
         if (count < 0) {
             throw new IllegalArgumentException("count >= 0 required but it was " + count);
@@ -335,12 +407,24 @@ public interface Streamable<@NonNull T> {
      * Transforms the upstream sequence into zero or more elements for the downstream.
      * @param <R> the result element type
      * @param transformer the interface to implement the transforming logic
-     * @return the new Streamable instance
+     * @return the new {@code Streamable} instance
      */
     @CheckReturnValue
     @NonNull
     default <@NonNull R> Streamable<R> transform(@NonNull VirtualTransformer<T, R> transformer) {
         return transform(transformer, Executors.newVirtualThreadPerTaskExecutor());
+    }
+
+    /**
+     * Hides the identity of this {@code Streamable} and its {@link Streamer}.
+     * <p>
+     * Use it to break optimizations or hide concrete implementations.
+     * @return the new {@code Streamable} instance
+     */
+    @CheckReturnValue
+    @NonNull
+    default Streamable<T> hide() {
+        return RxJavaPlugins.onAssembly(new StreamableHide<>(this));
     }
 
     /**
@@ -370,6 +454,8 @@ public interface Streamable<@NonNull T> {
      * @param n the maximum number of items to relay
      * @return the new {@code Streamable} instance
      */
+    @CheckReturnValue
+    @NonNull
     default Streamable<T> take(long n) {
         ObjectHelper.verifyPositive(n, "n");
         return defer(() -> {

--- a/src/main/java/io/reactivex/rxjava4/core/Streamer.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamer.java
@@ -132,37 +132,6 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
     }
 
     /**
-     * Hides the identity of this Streamer for debug or deoptimization purposes.
-     * @return the augmented streamer, always unique.
-     */
-    default Streamer<T> hide() {
-        return new HiddenStreamer<>(this);
-    }
-
-    /**
-     * Hides the identity of the Streamer for debug or deoptimization purposes.
-     * @param <T> the element type of the streamer
-     */
-    static record HiddenStreamer<T>(@NonNull Streamer<T> streamer) implements Streamer<T> {
-
-        @Override
-        public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
-            return streamer.next(cancellation);
-        }
-
-        @Override
-        public @NonNull T current() {
-            return streamer.current();
-        }
-
-        @Override
-        public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
-            return streamer.finish(cancellation);
-        }
-
-    }
-
-    /**
      * Moves and awaits the sequence's next element, returns false if there are no more
      * data.
      * @return true if the next element via {@link #current()} can be read, or false if
@@ -212,7 +181,7 @@ public interface Streamer<@NonNull T> extends AutoCloseable, AwaitCoordinator {
 
     /**
      * Use this constant in {@link #finish(DisposableContainer)} to indicate
-     * the cleanupp was done synchronously.
+     * the cleanup was done synchronously.
      */
     CompletionStage<Void> FINISHED = CompletableFuture.completedStage(null);
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/fuseable/HasUpstreamStreamableSource.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/fuseable/HasUpstreamStreamableSource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.fuseable;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.Streamable;
+
+/**
+ * Interface indicating the implementor has an upstream Streamable-like source available
+ * via {@link #source()} method.
+ *
+ * @param <T> the value type
+ */
+public interface HasUpstreamStreamableSource<@NonNull T> {
+    /**
+     * Returns the upstream source of this Streamable.
+     * <p>Allows discovering the chain of streamables.
+     * @return the source Streamable
+     */
+    @NonNull
+    Streamable<T> source();
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterable.java
@@ -13,46 +13,58 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableEmpty.EmptyStreamer;
 
-public record StreamableFromArray<T>(@NonNull T[] items) implements Streamable<T> {
+public record StreamableFromIterable<T>(@NonNull Iterable<? extends T> items) implements Streamable<T> {
 
+    @SuppressWarnings("unchecked")
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new FromArrayStreamer<>(items);
+        Iterator<? extends T> iterator;
+        try {
+            iterator = Objects.requireNonNull(items.iterator(), "iterator is null");
+            if (!iterator.hasNext()) {
+                return (Streamer<T>)EmptyStreamer.INSTANCE;
+            }
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            return StreamableError.createFailed(ex);
+        }
+        return new IteratorStreamer<>(iterator);
     }
 
-    static final class FromArrayStreamer<T> implements Streamer<T> {
+    static final class IteratorStreamer<T> implements Streamer<T> {
 
-        final T[] items;
+        Iterator<? extends T> iterator;
 
-        volatile int index;
+        long index;
 
         volatile T current;
 
-        public FromArrayStreamer(T[] items) {
-            this.items = items;
+        IteratorStreamer(Iterator<? extends T> iterator) {
+            this.iterator = iterator;
         }
 
         @Override
         public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
-            var i = index;
-            if (i >= items.length) {
-                return NEXT_FALSE;
+            if (index == 0L || iterator.hasNext()) {
+                var v = iterator.next();
+                current = v;
+                if (v == null) {
+                    return CompletableFuture.failedStage(new NullPointerException("Item at index " + index + " is null."));
+                }
+                index++;
+                return NEXT_TRUE;
             }
-            var nextItem = items[i];
-            if (nextItem == null) {
-                index = items.length;
-                current = null;
-                return CompletableFuture.failedStage(new NullPointerException("Item at index " + i + " is null."));
-            }
-            current = nextItem;
-            index = i + 1;
-            return NEXT_TRUE;
+            current = null;
+            return NEXT_FALSE;
         }
 
         @Override
@@ -62,7 +74,7 @@ public record StreamableFromArray<T>(@NonNull T[] items) implements Streamable<T
 
         @Override
         public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
-            index = items.length;
+            iterator = null;
             current = null;
             return FINISHED;
         }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromStream.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableEmpty.EmptyStreamer;
+
+public record StreamableFromStream<T>(@NonNull Stream<? extends T> items) implements Streamable<T> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        var iterator = Objects.requireNonNull(items.iterator(), "iterator is null");
+        if (!iterator.hasNext()) {
+            return (Streamer<T>)EmptyStreamer.INSTANCE;
+        }
+        return new StreamableFromIterable.IteratorStreamer<>(iterator);
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHide.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHide.java
@@ -13,58 +13,36 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CompletionStage;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamStreamableSource;
 
-public record StreamableFromArray<T>(@NonNull T[] items) implements Streamable<T> {
+public record StreamableHide<T>(Streamable<T> source)
+implements Streamable<T>, HasUpstreamStreamableSource<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new FromArrayStreamer<>(items);
+        return new HideStreamer<>(source.stream(cancellation));
     }
 
-    static final class FromArrayStreamer<T> implements Streamer<T> {
-
-        final T[] items;
-
-        volatile int index;
-
-        volatile T current;
-
-        public FromArrayStreamer(T[] items) {
-            this.items = items;
-        }
+    record HideStreamer<T>(Streamer<T> streamer) implements Streamer<T> {
 
         @Override
         public @NonNull CompletionStage<Boolean> next(@NonNull DisposableContainer cancellation) {
-            var i = index;
-            if (i >= items.length) {
-                return NEXT_FALSE;
-            }
-            var nextItem = items[i];
-            if (nextItem == null) {
-                index = items.length;
-                current = null;
-                return CompletableFuture.failedStage(new NullPointerException("Item at index " + i + " is null."));
-            }
-            current = nextItem;
-            index = i + 1;
-            return NEXT_TRUE;
+            return streamer.next(cancellation);
         }
 
         @Override
         public @NonNull T current() {
-            return current;
+            return streamer.current();
         }
 
         @Override
         public @NonNull CompletionStage<Void> finish(@NonNull DisposableContainer cancellation) {
-            index = items.length;
-            current = null;
-            return FINISHED;
+            return streamer.finish(cancellation);
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -13,32 +13,27 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletionStage;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
 
 public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
-        return new JustStreamer<>(item, cancellation);
+        return new JustStreamer<>(item);
     }
 
-    static final class JustStreamer<T> implements Streamer<T>, Disposable {
+    static final class JustStreamer<T> implements Streamer<T> {
 
         volatile T item;
 
-        volatile DisposableContainer cancellation;
-
         volatile int stage;
 
-        JustStreamer(T item, DisposableContainer cancellation) {
+        JustStreamer(T item) {
             this.item = item;
-            this.cancellation = cancellation;
-            cancellation.add(this);
         }
 
         @Override
@@ -55,42 +50,14 @@ public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
         @Override
         public @NonNull T current() {
-            var item = this.item;
-            if (stage == 0) {
-                throw new NoSuchElementException("Streamable.just not yet started!");
-            }
-            if (stage == 2) {
-                throw new NoSuchElementException("Streamable.just already completed!");
-            }
             return item;
         }
 
         @Override
         public @NonNull CompletionStage<Void> finish(DisposableContainer canceller) {
             item = null;
-            cancellation = null;
             stage = 2;
             return FINISHED;
-        }
-
-        @Override
-        public void close() {
-            Streamer.super.close();
-        }
-
-        @Override
-        public boolean isDisposed() {
-            return stage == 2;
-        }
-
-        @Override
-        public void dispose() {
-            var dc = cancellation;
-            if (dc != null) {
-                if (dc.delete(this)) {
-                    close(); // FIXME not sure about this!
-                }
-            }
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableJust.java
@@ -22,10 +22,6 @@ import io.reactivex.rxjava4.disposables.*;
 
 public record StreamableJust<T>(@NonNull T item) implements Streamable<T> {
 
-    public StreamableJust {
-        Objects.requireNonNull(item, "item is null");
-    }
-
     @Override
     public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
         return new JustStreamer<>(item, cancellation);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableNever.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableNever.java
@@ -20,22 +20,24 @@ import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.*;
 
-public enum StreamableEmpty implements Streamable<Object> {
+public enum StreamableNever implements Streamable<Object> {
 
     INSTANCE;
 
     @Override
     public @NonNull Streamer<Object> stream(@NonNull DisposableContainer cancellation) {
-        return EmptyStreamer.INSTANCE;
+        return NeverStreamer.INSTANCE;
     }
 
-    enum EmptyStreamer implements Streamer<Object> {
+    enum NeverStreamer implements Streamer<Object> {
 
         INSTANCE;
 
         @Override
         public @NonNull CompletionStage<Boolean> next(DisposableContainer cancellation) {
-            return NEXT_FALSE;
+            var cf = new CompletableFuture<Boolean>();
+            cancellation.subscribe(Disposable.fromFuture(cf, true));
+            return cf;
         }
 
         @Override

--- a/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
@@ -647,6 +647,60 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     }
 
     /**
+     * Returns true if an await timed out.
+     * @return true if one of the timeout-based await methods has timed out.
+     * <p>History: 2.0.7 - experimental
+     * @see #clearTimeout()
+     * @see #assertTimeout()
+     * @see #assertNoTimeout()
+     * @since 2.1
+     */
+    public final boolean isTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Clears the timeout flag set by the await methods when they timed out.
+     * <p>History: 2.0.7 - experimental
+     * @return this
+     * @since 2.1
+     * @see #isTimeout()
+     */
+    @SuppressWarnings("unchecked")
+    public final U clearTimeout() {
+        timeout = false;
+        return (U)this;
+    }
+
+    /**
+     * Asserts that some awaitX method has timed out.
+     * <p>History: 2.0.7 - experimental
+     * @return this
+     * @since 2.1
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertTimeout() {
+        if (!timeout) {
+            throw fail("No timeout?!");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Asserts that some awaitX method has not timed out.
+     * <p>History: 2.0.7 - experimental
+     * @return this
+     * @since 2.1
+     */
+    @SuppressWarnings("unchecked")
+    public final U assertNoTimeout() {
+        if (timeout) {
+            throw fail("Timeout?!");
+        }
+        return (U)this;
+    }
+
+    /**
      * Returns true if this test consumer was cancelled/disposed.
      * @return true if this test consumer was cancelled/disposed.
      */

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEachTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.Streamable;
@@ -145,6 +145,7 @@ public class StreamableForEachTest extends StreamableBaseTest {
             .forEach(_ -> {
                 counter.getAndIncrement();
                 cd.dispose();
+                Thread.sleep(10); // The body may fall off faster than the cancel can propagate out, so sleep
             }, cd)
             .await();
         });
@@ -164,6 +165,7 @@ public class StreamableForEachTest extends StreamableBaseTest {
                 .forEach((_, _) -> {
                     counter.getAndIncrement();
                     cd.dispose();
+                    Thread.sleep(10); // The body may fall off faster than the cancel can propagate out, so sleep
                 }, cd, exec)
                 .await();
             });

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterableTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.Streamable;
-import io.reactivex.rxjava4.exceptions.TestException;
 
 @Isolated
 public class StreamableFromIterableTest extends StreamableBaseTest {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromIterableTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+@Isolated
+public class StreamableFromIterableTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.fromStream(List.of(1, 2, 3).stream())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Streamable.fromStream(List.of().stream())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void one() throws Throwable {
+        Streamable.fromStream(List.of(1).stream())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void hasNull() throws Throwable {
+        Streamable.fromStream(Arrays.asList(1, null, 3).stream())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class, 1)
+        .assertError(t -> t.getMessage().equals("Item at index 1 is null."));
+        ;
+    }
+
+    @Test
+    public void hasNull2() throws Throwable {
+        Streamable.fromStream(Arrays.asList(null, 1, 2, 3).stream())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class)
+        .assertError(t -> t.getMessage().equals("Item at index 0 is null."));
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromStreamTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromStreamTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+@Isolated
+public class StreamableFromStreamTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.fromIterable(List.of(1, 2, 3))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Streamable.fromIterable(List.of())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void one() throws Throwable {
+        Streamable.fromIterable(List.of(1))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1);
+    }
+
+    @Test
+    public void hasNull() throws Throwable {
+        Streamable.fromIterable(Arrays.asList(1, null, 3))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class, 1)
+        .assertError(t -> t.getMessage().equals("Item at index 1 is null."));
+        ;
+    }
+
+    @Test
+    public void hasNull2() throws Throwable {
+        Streamable.fromIterable(Arrays.asList(null, 1, 2, 3))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class)
+        .assertError(t -> t.getMessage().equals("Item at index 0 is null."));
+        ;
+    }
+
+    @Test
+    public void iteratorThrows() throws Throwable {
+        Streamable.fromIterable(() -> { throw new TestException("test"); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class)
+        .assertError(t -> t.getMessage().equals("test"));
+        ;
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -15,15 +15,17 @@ package io.reactivex.rxjava4.internal.operators.streamable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.concurrent.TimeUnit;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.parallel.Isolated;
 
 import io.reactivex.rxjava4.core.*;
-import io.reactivex.rxjava4.exceptions.*;
+import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.internal.subscriptions.EmptySubscription;
+import io.reactivex.rxjava4.schedulers.Schedulers;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
 @Isolated
@@ -285,5 +287,85 @@ public class StreamableTest extends StreamableBaseTest {
             .awaitDone(5, TimeUnit.SECONDS)
             .assertResult(1, 2, 3, 4, 5);
         });
+    }
+
+    @Test
+    public void emptyCurrentThrows() {
+        assertThrows(NoSuchElementException.class, () -> {
+            StreamableEmpty.EmptyStreamer.INSTANCE.current();
+        });
+    }
+
+    @Test
+    public void neverCurrentThrows() {
+        assertThrows(NoSuchElementException.class, () -> {
+            StreamableNever.NeverStreamer.INSTANCE.current();
+        });
+    }
+
+    @Test
+    public void never() {
+        Streamable.never()
+        .test()
+        .awaitDone(100, TimeUnit.MILLISECONDS)
+        .assertTimeout();
+    }
+
+    @Test
+    public void never2() throws Throwable {
+        withCachedExecutor(exec -> {
+            Streamable.never()
+            .test(exec)
+            .awaitDone(100, TimeUnit.MILLISECONDS)
+            .assertTimeout();
+        });
+    }
+
+    @Test
+    public void fromStages() throws Throwable {
+        withVirtual(exec -> {
+            Streamable.fromStages(List.of(
+                    CompletableFuture.completedFuture(1),
+                    CompletableFuture.completedFuture(2),
+                    CompletableFuture.completedFuture(3)
+                ), exec
+            )
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValueCount(3)
+            .assertNoErrors()
+            .assertComplete();
+        });
+    }
+
+    @Test
+    public void createPlain() {
+        Streamable.create(emitter -> {
+            emitter.emit(1);
+            emitter.emit(2);
+            emitter.emit(3);
+        })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void createScheduler() {
+        Streamable.create(emitter -> {
+            emitter.emit(1);
+            emitter.emit(2);
+            emitter.emit(3);
+        }, Schedulers.cached())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3);
+    }
+
+    @Test
+    public void hide() {
+        var str = Streamable.empty().hide();
+
+        assertFalse(str instanceof StreamableEmpty, str.getClass().toString());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerIsolatedTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.schedulers;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.core.Scheduler.Worker;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+@Isolated
+public class SharedSchedulerIsolatedTest extends RxJavaTest {
+
+    long memoryUsage() {
+        return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
+    }
+
+    @Test
+    public void noleak() throws Exception {
+        var scheduler = Schedulers.cached().share();
+        try {
+            Worker worker = scheduler.createWorker();
+
+            worker.schedule(Functions.EMPTY_RUNNABLE);
+
+            System.gc();
+            Thread.sleep(500);
+
+            long before = memoryUsage();
+            System.out.printf("Start: %.1f%n", before / 1024.0 / 1024.0);
+
+            for (int i = 0; i < 300 * 1000; i++) {
+                worker.schedule(Functions.EMPTY_RUNNABLE, 1, TimeUnit.DAYS);
+            }
+
+            long middle = memoryUsage();
+
+            System.out.printf("Middle: %.1f -> %.1f%n", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0);
+
+            worker.dispose();
+
+            System.gc();
+
+            Thread.sleep(100);
+
+            int wait = 400;
+
+            long after = memoryUsage();
+
+            while (wait-- > 0) {
+                System.out.printf("Usage: %.1f -> %.1f -> %.1f%n", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0, after / 1024.0 / 1024.0);
+
+                if (middle > after * 2) {
+                    return;
+                }
+
+                Thread.sleep(100);
+
+                System.gc();
+
+                Thread.sleep(100);
+
+                after = memoryUsage();
+            }
+
+            fail(String.format("Looks like there is a memory leak: %.1f -> %.1f -> %.1f", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0, after / 1024.0 / 1024.0));
+
+        } finally {
+            scheduler.shutdown();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SharedSchedulerTest.java
@@ -15,22 +15,20 @@ package io.reactivex.rxjava4.internal.schedulers;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.lang.management.ManagementFactory;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.*;
 
-import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.Scheduler.Worker;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.functions.Function;
-import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.internal.schedulers.SharedScheduler.SharedWorker.SharedAction;
 import io.reactivex.rxjava4.schedulers.*;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
-public class SharedSchedulerTest implements Runnable {
+public class SharedSchedulerTest extends RxJavaTest implements Runnable {
 
     volatile int calls;
 
@@ -70,65 +68,6 @@ public class SharedSchedulerTest implements Runnable {
             }
 
             assertEquals(1, threads.size());
-        } finally {
-            scheduler.shutdown();
-        }
-    }
-
-    long memoryUsage() {
-        return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed();
-    }
-
-    @Test
-    public void noleak() throws Exception {
-        var scheduler = Schedulers.cached().share();
-        try {
-            Worker worker = scheduler.createWorker();
-
-            worker.schedule(Functions.EMPTY_RUNNABLE);
-
-            System.gc();
-            Thread.sleep(500);
-
-            long before = memoryUsage();
-            System.out.printf("Start: %.1f%n", before / 1024.0 / 1024.0);
-
-            for (int i = 0; i < 200 * 1000; i++) {
-                worker.schedule(Functions.EMPTY_RUNNABLE, 1, TimeUnit.DAYS);
-            }
-
-            long middle = memoryUsage();
-
-            System.out.printf("Middle: %.1f -> %.1f%n", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0);
-
-            worker.dispose();
-
-            System.gc();
-
-            Thread.sleep(100);
-
-            int wait = 400;
-
-            long after = memoryUsage();
-
-            while (wait-- > 0) {
-                System.out.printf("Usage: %.1f -> %.1f -> %.1f%n", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0, after / 1024.0 / 1024.0);
-
-                if (middle > after * 2) {
-                    return;
-                }
-
-                Thread.sleep(100);
-
-                System.gc();
-
-                Thread.sleep(100);
-
-                after = memoryUsage();
-            }
-
-            fail(String.format("Looks like there is a memory leak: %.1f -> %.1f -> %.1f", before / 1024.0 / 1024.0, middle / 1024.0 / 1024.0, after / 1024.0 / 1024.0));
-
         } finally {
             scheduler.shutdown();
         }

--- a/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
+++ b/src/test/java/io/reactivex/rxjava4/schedulers/TestSchedulerTest.java
@@ -31,6 +31,7 @@ import io.reactivex.rxjava4.internal.subscriptions.BooleanSubscription;
 import io.reactivex.rxjava4.internal.util.ExceptionHelper;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.TestScheduler.*;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
 
 public class TestSchedulerTest extends RxJavaTest {
 
@@ -341,5 +342,33 @@ public class TestSchedulerTest extends RxJavaTest {
         ts.advanceTimeBy(1, TimeUnit.SECONDS);
 
         assertEquals(0, run.get());
+    }
+
+    @Test
+    public void timeout() {
+        var ts = new TestSubscriber<>();
+        ts.onSubscribe(new BooleanSubscription());
+
+        assertFalse(ts.isTimeout(), "Has timeout?");
+
+        ts.awaitDone(1, TimeUnit.MICROSECONDS);
+
+        assertTrue(ts.isTimeout(), "Has no timeout?");
+
+        ts.assertTimeout();
+
+        assertThrows(AssertionError.class, () -> {
+            ts.assertNoTimeout();
+        });
+
+        ts.clearTimeout();
+
+        assertFalse(ts.isTimeout(), "Has timeout?");
+        ts.assertNoTimeout();
+
+        assertThrows(AssertionError.class, () -> {
+            ts.assertTimeout();
+        });
+
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -1662,15 +1662,9 @@ public class TestSubscriberTest extends RxJavaTest {
         assertTrue(d.isDisposed(), "d is disposed");
     }
 
-    static final class TestSubscriberImpl<T> extends TestSubscriber<T> {
-        public boolean isTimeout() {
-            return timeout;
-        }
-    }
-
     @Test
     public void awaitCountTimeout() {
-        TestSubscriberImpl<Integer> ts = new TestSubscriberImpl<>();
+        TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
         ts.awaitCount(1);
         assertTrue(ts.isTimeout());

--- a/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/BaseTestConsumerEx.java
@@ -206,60 +206,6 @@ extends BaseTestConsumer<T, U> {
     }
 
     /**
-     * Returns true if an await timed out.
-     * @return true if one of the timeout-based await methods has timed out.
-     * <p>History: 2.0.7 - experimental
-     * @see #clearTimeout()
-     * @see #assertTimeout()
-     * @see #assertNoTimeout()
-     * @since 2.1
-     */
-    public final boolean isTimeout() {
-        return timeout;
-    }
-
-    /**
-     * Clears the timeout flag set by the await methods when they timed out.
-     * <p>History: 2.0.7 - experimental
-     * @return this
-     * @since 2.1
-     * @see #isTimeout()
-     */
-    @SuppressWarnings("unchecked")
-    public final U clearTimeout() {
-        timeout = false;
-        return (U)this;
-    }
-
-    /**
-     * Asserts that some awaitX method has timed out.
-     * <p>History: 2.0.7 - experimental
-     * @return this
-     * @since 2.1
-     */
-    @SuppressWarnings("unchecked")
-    public final U assertTimeout() {
-        if (!timeout) {
-            throw fail("No timeout?!");
-        }
-        return (U)this;
-    }
-
-    /**
-     * Asserts that some awaitX method has not timed out.
-     * <p>History: 2.0.7 - experimental
-     * @return this
-     * @since 2.1
-     */
-    @SuppressWarnings("unchecked")
-    public final U assertNoTimeout() {
-        if (timeout) {
-            throw fail("Timeout?!");
-        }
-        return (U)this;
-    }
-
-    /**
      * Returns the internal shared list of errors.
      * @return Returns the internal shared list of errors.
      */

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -771,6 +771,9 @@ public class CheckParamValidationTest extends RxJavaTest {
                 if (m.getDeclaringClass() != clazz) {
                     continue;
                 }
+                if (Modifier.isAbstract(m.getModifiers())) {
+                    continue;
+                }
 
                 String key = clazz.getName() + " " + m.getName();
 

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -30,6 +30,7 @@ import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.*;
 import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.internal.operators.streamable.StreamableNever;
 import io.reactivex.rxjava4.parallel.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;
@@ -69,6 +70,11 @@ public class CheckParamValidationTest extends RxJavaTest {
     @Test @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
     public void checkParallelFlowable() {
         checkClass(ParallelFlowable.class);
+    }
+
+    @Test @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    public void checkStreamable() {
+        checkClass(Streamable.class);
     }
 
     // ---------------------------------------------------------------------------------------
@@ -519,6 +525,10 @@ public class CheckParamValidationTest extends RxJavaTest {
 
         addIgnore(new ParamIgnore(Completable.class, "unsafeCreate", CompletableSource.class));
 
+        // needs special param validation due to (long)start + end - 1 <= Integer.MAX_VALUE
+        addIgnore(new ParamIgnore(Streamable.class, "range", Integer.TYPE, Integer.TYPE));
+        addIgnore(new ParamIgnore(Streamable.class, "rangeLong", Long.TYPE, Long.TYPE));
+
         // -----------------------------------------------------------------------------------
 
         defaultValues = new HashMap<>();
@@ -537,6 +547,8 @@ public class CheckParamValidationTest extends RxJavaTest {
 
         defaultValues.put(CompletableSource.class, new NeverCompletable());
         defaultValues.put(Completable.class, new NeverCompletable());
+
+        defaultValues.put(Streamable.class, StreamableNever.INSTANCE);
 
         defaultValues.put(Action.class, Functions.EMPTY_ACTION);
         defaultValues.put(Runnable.class, Functions.EMPTY_RUNNABLE);
@@ -668,6 +680,9 @@ public class CheckParamValidationTest extends RxJavaTest {
         addDefaultInstance(Maybe.class, Maybe.just(1).hide(), "Just(1).Hide()");
 
         addDefaultInstance(ParallelFlowable.class, Flowable.just(1).parallel(), "Just(1)");
+
+        addDefaultInstance(Streamable.class, Streamable.just(1), "Just(1)");
+        addDefaultInstance(Streamable.class, Streamable.just(1).hide(), "Just(1).Hide()");
     }
 
     static void addIgnore(ParamIgnore ignore) {
@@ -867,8 +882,11 @@ public class CheckParamValidationTest extends RxJavaTest {
                             Throwable error = null;
                             errors.clear();
                             try {
-                                m.invoke(baseObject, callParams2);
+                                var result = m.invoke(baseObject, callParams2);
                                 success = true;
+                                if (result instanceof CompletionStageDisposable csd) {
+                                    csd.ignore();
+                                }
                             } catch (Throwable ex) {
                                 // let it fail
                                 error = ex;


### PR DESCRIPTION
Also includes test improvements across.

Removed `default Streamer<T> stream()` because implementations should always handle the `DisposableContainer` for cancellation purposes.