### PR TITLE
4.x: Streamable: +delay +timeout +zip +onErrorResumeNext, cleanup

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/StreamProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/core/StreamProcessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Processor;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+
+/**
+ * A {@link Processor}-like interface combining the {@code Streamable} interface and the
+ * {@link StreamerInput} interface to establish a push-pull bridge based on {@link CompletionStage}-based
+ * asynchronous processing and dispatching of values and errors.
+ * @param <In> the element type of the input side
+ * @param <Out> the element type of the output side
+ * @since 4.0.0
+ */
+public interface StreamProcessor<@NonNull In, @NonNull Out> extends Streamable<Out>, StreamerInput<In> {
+
+}

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava4.core;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
+import java.util.stream.*;
 
 import io.reactivex.rxjava4.annotations.*;
 import io.reactivex.rxjava4.core.config.*;
@@ -539,9 +539,55 @@ public interface Streamable<@NonNull T> {
         return RxJavaPlugins.onAssembly(new StreamableTimer(delay, unit, null, executor));
     }
 
+    /**
+     * Takes the next element from each source {@code Streamable} and emits them a a single
+     * row of {@link List}.
+     * <p>
+     * If any of the sources is shorter than the rest or any of them fails, the
+     * sequence is completed early normally or with an exception, respectively.
+     * @param <T> the common element type of the sequences
+     * @param sources the iterable sequence of the source {@code Streamable}s
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code sources} is {@&ode null}
+     */
+    static <T> Streamable<List<T>> zip(Iterable<? extends Streamable<? extends T>> sources) {
+        Objects.requireNonNull(sources, "sources is null");
+        return RxJavaPlugins.onAssembly(new StreamableZip<>(sources));
+    }
+
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
     // Operators
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
+
+    /**
+     * Collects all upstream values via the use of a {@link Collector} configuration
+     * and emits its resulting value as a single item of the returned {@code Streamable}.
+     * <p>
+     * See {@link Collectors} for the most typical collector standard implementations.
+     * @param <A> the accumulator type of the collector
+     * @param <R> the result type of the collector and the returned {@code Streamamble}
+     * @param collector the Java collector instance to use
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code collector} is {@code null}
+     */
+    default <A, R> Streamable<R> collect(Collector<T, A, R> collector) {
+        Objects.requireNonNull(collector, "collector is null");
+        return RxJavaPlugins.onAssembly(new StreamableCollector<>(this, collector));
+    }
+
+    /**
+     * Delays the delivery of each upstream item by the given time amount.
+     * @param time the delay time
+     * @param unit the time unit
+     * @param scheduler the scheduler where the timed wait is happening
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code unit} or {@code scheduler} is {@code null}
+     */
+    default Streamable<T> delay(long time, TimeUnit unit, Scheduler scheduler) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
+        return RxJavaPlugins.onAssembly(new StreamableDelay<>(this, time, unit, scheduler));
+    }
 
     /**
      * Calls the given consumer whenever an upstream item becomes available.
@@ -668,6 +714,19 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
+     * When the upstream fails, the sequence is resumed by the {@code Streamable} that is returned for the
+     * failure {@link Throwable}.
+     * @param fallbackMapper the function that receives the upstream error and should return a
+     *                       {@code Streamable} to resume the sequence with
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code fallbackMapper} is {@code null}
+     */
+    default Streamable<T> onErrorResumeNext(Function<? super Throwable, ? extends Streamable<? extends T>> fallbackMapper) {
+        Objects.requireNonNull(fallbackMapper, "fallbackMapper is null");
+        return RxJavaPlugins.onAssembly(new StreamableOnErrorResumeNext<>(this, fallbackMapper));
+    }
+
+    /**
      * Takes at most the given number of items from the upstream and relays it to the downstream,
      * then cancels the rest of the sequence.
      * @param n the maximum number of items to relay
@@ -690,6 +749,21 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
+     * Relays items from this {@code Streamable} until the other {@code Streamable} signals
+     * an item or completes.
+     * @param <U> the element type of the other {@code Streamable}
+     * @param other the {@code Streamable} expected to signal when to stop taking items from this {@code Streamable}
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code other} is {@code null}
+     */
+    @CheckReturnValue
+    @NonNull
+    default <U> Streamable<T> takeUntil(@NonNull Streamable<U> other) {
+        Objects.requireNonNull(other, "other is null");
+        return RxJavaPlugins.onAssembly(new StreamableTakeUntil<>(this, other));
+    }
+
+    /**
      * Relays items from this {@code Streamable} while the predicate returns {@code true}
      * @param predicate the predicate to test if the sequence should keep going
      * @return the new {@code Streamable} instance
@@ -703,18 +777,21 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
-     * Relays items from this {@code Streamable} until the other {@code Streamable} signals
-     * an item or completes.
-     * @param <U> the element type of the other {@code Streamable}
-     * @param other the {@code Streamable} expected to signal when to stop taking items from this {@code Streamable}
+     * Applies a timeout to each upstream item and switches to the fallback {@code Streamable}
+     * if the upstream doesn't produce an item within the given timeout period.
+     * @param timeout the time to wait for each upstream item
+     * @param unit the time unit
+     * @param scheduler the scheduler where to wait for the next upstream item
+     * @param fallback the {@code Streamable} to switch to if the upstream doesn't produce an item
+     *                 within the time limit
      * @return the new {@code Streamable} instance
-     * @throws NullPointerException if {@code other} is {@code null}
+     * @throws NullPointerException if {@code unit} or {@code scheduler} or {@code fallback} is {@code null}
      */
-    @CheckReturnValue
-    @NonNull
-    default <U> Streamable<T> takeUntil(@NonNull Streamable<U> other) {
-        Objects.requireNonNull(other, "other is null");
-        return RxJavaPlugins.onAssembly(new StreamableTakeUntil<>(this, other));
+    default Streamable<T> timeout(long timeout, TimeUnit unit, Scheduler scheduler, Streamable<T> fallback) {
+        Objects.requireNonNull(unit, "unit is null");
+        Objects.requireNonNull(scheduler, "scheduler is null");
+        Objects.requireNonNull(fallback, "fallback is null");
+        return RxJavaPlugins.onAssembly(new StreamableTimeout<>(this, timeout, unit, scheduler, fallback));
     }
 
     /**
@@ -891,8 +968,8 @@ public interface Streamable<@NonNull T> {
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber, @NonNull ExecutorService executor) {
         final Streamable<T> me = this;
         Flowable.<T>virtualCreate(emitter -> {
-            me.forEach(emitter::emit, emitter.canceller().derive(), executor)
-            .await();
+            var cf = me.forEach(emitter::emit, emitter.canceller().derive(), executor);
+            cf.await();
         }, executor)
         .subscribe(subscriber);
     }

--- a/src/main/java/io/reactivex/rxjava4/core/StreamerInput.java
+++ b/src/main/java/io/reactivex/rxjava4/core/StreamerInput.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.core;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow.Subscriber;
+
+import io.reactivex.rxjava4.annotations.*;
+
+/**
+ * An interface to submit items and terminal events to a consumer that indacates when the processing of
+ * said item or terminal event has completed, similar to how {@link Subscriber} can receive events.
+ * <p>
+ * The general contract is to call {@link #next(Object)} zero or more times, then
+ * call {@link #finish(Throwable)} at most once, all in a non-overlapping fashion and only if the
+ * returned {@link CompletionStage} has completed in some fashion.
+ * @param <T> the item type to be offered
+ * @since 4.0.0
+ */
+public interface StreamerInput<@NonNull T> {
+
+    /**
+     * Offer the next item.
+     * @param item the item being offered
+     * @return a {@link CompletionStage} that should complete with {@code true} if the
+     *         item was accepted, or {@code false} if the item could not be accepted at this time,
+     *         or via a {@code Throwable} indicating some error.
+     */
+    CompletionStage<Boolean> next(T item);
+
+    /**
+     * Offer the final, terminal event.
+     * @param throwable the optional throwable to signal error, null to signal normal completion
+     * @return the {@link CompletionStage} that should complete normally if the terminal event was accepted,
+     *         or via a {@code Throwable} indicating an error
+     */
+    CompletionStage<Void> finish(@Nullable Throwable throwable);
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableCollector.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableCollector.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
+import java.util.stream.Collector;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamStreamableSource;
+
+public record StreamableCollector<T, A, R>(
+        Streamable<T> source,
+        Collector<T, A, R> collector
+) implements Streamable<R>, HasUpstreamStreamableSource<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull R> stream(@NonNull DisposableContainer cancellation) {
+        return new CollectorStreamable<>(
+                source.stream(cancellation),
+                collector.supplier().get(),
+                collector.accumulator(),
+                collector.finisher());
+    }
+
+    static final class CollectorStreamable<T, A, R>
+    implements Streamer<R>, BiConsumer<Object, Throwable> {
+
+        final AtomicInteger wip;
+
+        final Streamer<T> upstream;
+
+        final A storage;
+
+        final BiConsumer<A, T> accumulator;
+
+        final Function<A, R> finisher;
+
+        final CompletableFuture<Boolean> nextReady;
+
+        final CompletableFuture<Void> finishReady;
+
+        R current;
+
+        int stage;
+
+        volatile boolean done;
+
+        CollectorStreamable(Streamer<T> upstream, A storage, BiConsumer<A, T> accumulator, Function<A, R> finisher) {
+            this.upstream = upstream;
+            this.wip = new AtomicInteger();
+            this.storage = storage;
+            this.accumulator = accumulator;
+            this.finisher = finisher;
+            this.nextReady = new CompletableFuture<>();
+            this.finishReady = new CompletableFuture<>();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            if (stage++ == 0) {
+                drain();
+                return nextReady;
+            }
+            return NEXT_FALSE;
+        }
+
+        @Override
+        public @NonNull R current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            done = true;
+            drain();
+            return finishReady;
+        }
+
+        void drain() {
+            if (wip.getAndIncrement() != 0) {
+                return;
+            }
+
+            do {
+                if (done) {
+                    upstream.finish().whenComplete(this);
+                    break;
+                } else {
+                    upstream.next().whenComplete(this);
+                }
+            } while (wip.decrementAndGet() != 0);
+        }
+
+        @Override
+        public void accept(Object t, Throwable u) {
+            if (done) {
+                if (u != null) {
+                    finishReady.completeExceptionally(u);
+                } else {
+                    finishReady.complete(null);
+                }
+            } else {
+                if (u != null) {
+                    nextReady.completeExceptionally(u);
+                } else
+                if ((Boolean)t) {
+                    accumulator.accept(storage, upstream.current());
+                    drain();
+                } else {
+                    current = finisher.apply(storage);
+                    nextReady.complete(true);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDelay.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDelay.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.Scheduler.Worker;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamStreamableSource;
+
+public record StreamableDelay<T>(
+        Streamable<T> source,
+        long delay, TimeUnit unit, Scheduler scheduler
+) implements Streamable<T>, HasUpstreamStreamableSource<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        var worker = scheduler.createWorker();
+        cancellation.add(worker);
+        return new DelayStreamer<>(source.stream(cancellation), delay, unit, worker, cancellation);
+    }
+
+    static final class DelayStreamer<T> implements Streamer<T>, BiConsumer<Boolean, Throwable>, Runnable {
+
+        final Worker worker;
+
+        final Streamer<T> upstream;
+
+        final long delay;
+
+        final TimeUnit unit;
+
+        final DisposableContainer cancellation;
+
+        CompletableFuture<Boolean> nextReady;
+
+        Disposable onDisposed;
+
+        DelayStreamer(Streamer<T> upstream, long delay, TimeUnit unit, Worker worker, DisposableContainer cancellation) {
+            this.upstream = upstream;
+            this.delay = delay;
+            this.unit = unit;
+            this.worker = worker;
+            this.cancellation = cancellation;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            nextReady = new CompletableFuture<Boolean>();
+            onDisposed = Disposable.fromFuture(nextReady, true);
+            cancellation.add(onDisposed);
+            upstream.next().whenComplete(this);
+            return nextReady;
+        }
+
+        @Override
+        public void accept(Boolean t, Throwable u) {
+            if (u != null) {
+                cancellation.delete(onDisposed);
+                nextReady.completeExceptionally(u);
+            } else {
+                if (t) {
+                    worker.schedule(this, delay, unit);
+                } else {
+                    cancellation.delete(onDisposed);
+                    nextReady.complete(false);
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            cancellation.delete(onDisposed);
+            nextReady.complete(true);
+        }
+
+        @Override
+        public @NonNull T current() {
+            return upstream.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            cancellation.delete(worker);
+            nextReady = null;
+            onDisposed = null;
+            return FINISHED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
@@ -47,5 +47,10 @@ public enum StreamableEmpty implements Streamable<Object> {
         public @NonNull CompletionStage<Void> finish() {
             return FINISHED;
         }
+
+        @SuppressWarnings("unchecked")
+        public static <T> Streamer<T> cast() {
+            return (Streamer<T>)INSTANCE;
+        }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEach.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableForEach.java
@@ -34,6 +34,7 @@ public record StreamableForEach() {
             @NonNull DisposableContainer canceller,
             @NonNull ExecutorService executor) {
         var future = CompletableFuture.<Void>supplyAsync(() -> {
+            Throwable finallyCrash = null;
             var str = me.stream(canceller);
             try {
                 try {
@@ -47,14 +48,19 @@ public record StreamableForEach() {
                         }
                     }
                 } finally {
-                    str.awaitFinish();
+                    try {
+                        str.awaitFinish();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        finallyCrash = ex;
+                    }
                 }
-            } catch (final Throwable crash) {
+            } catch (Throwable crash) {
                 Exceptions.throwIfFatal(crash);
-                if (crash instanceof CompletionException ce) {
-                    throw ExceptionHelper.wrapOrThrow(ce.getCause());
-                }
-                throw ExceptionHelper.wrapOrThrow(crash);
+                finallyCrash = ExceptionHelper.unwrapAndCombine(crash, finallyCrash);
+            }
+            if (finallyCrash != null) {
+                throw ExceptionHelper.wrapOrThrow(finallyCrash);
             }
             return null;
         }, executor);
@@ -69,9 +75,10 @@ public record StreamableForEach() {
             @NonNull ExecutorService executor) {
         var future = CompletableFuture.<Void>supplyAsync(() -> {
             var str = me.stream(canceller);
+            Throwable finallyCrash = null;
             try {
                 try {
-                var stopper = Disposable.empty();
+                    var stopper = Disposable.empty();
                     while (!canceller.isDisposed() && !stopper.isDisposed()) {
                         if (str.awaitNext()) {
                             // System.out.println("Received " + str.current());
@@ -83,14 +90,19 @@ public record StreamableForEach() {
                         }
                     }
                 } finally {
-                    str.awaitFinish();
+                    try {
+                        str.awaitFinish();
+                    } catch (Throwable ex) {
+                        Exceptions.throwIfFatal(ex);
+                        finallyCrash = ex;
+                    }
                 }
             } catch (final Throwable crash) {
                 Exceptions.throwIfFatal(crash);
-                if (crash instanceof CompletionException ce) {
-                    throw ExceptionHelper.wrapOrThrow(ce.getCause());
-                }
-                throw ExceptionHelper.wrapOrThrow(crash);
+                throw ExceptionHelper.wrapOrThrow(ExceptionHelper.unwrapAndCombine(crash, finallyCrash));
+            }
+            if (finallyCrash != null) {
+                throw ExceptionHelper.wrapOrThrow(ExceptionHelper.unwrap(finallyCrash));
             }
             return null;
         });

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
@@ -126,7 +126,7 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
                 if (u != null) {
                     done = true;
                     for (var g : groups.values()) {
-                        g.terminate(u); // TODO whenComplete
+                        g.finish(u); // TODO whenComplete
                     }
                     groups.clear();
                     mainNext.ready().completeExceptionally(u);
@@ -143,12 +143,12 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
                             currentGroup = g;
                             mainNext.ready().complete(true);
                         }
-                        g.send(c).whenComplete((_, _) -> drain());
+                        g.next(c).whenComplete((_, _) -> drain());
                     } catch (Throwable ex) {
                         Exceptions.throwIfFatal(ex);
                         done = true;
                         for (var g : groups.values()) {
-                            g.terminate(ex);
+                            g.finish(ex);
                         }
                         groups.clear();
                         mainNext.ready().completeExceptionally(ex);
@@ -156,7 +156,7 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
                 } else {
                     done = true;
                     for (var g : groups.values()) {
-                        g.terminate(null);
+                        g.finish(null);
                     }
                     groups.clear();
                     mainNext.ready().complete(false);
@@ -175,14 +175,15 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
         }
     }
 
-    static abstract class BasicGroupedStreamable<K, T> extends GroupedStreamable<K, T> {
+    static abstract class BasicGroupedStreamable<K, T> extends GroupedStreamable<K, T>
+    implements StreamerInput<T> {
         BasicGroupedStreamable(K key) {
             super(key);
         }
 
-        abstract CompletionStage<Void> send(@NonNull T value);
+        public abstract CompletionStage<Boolean> next(@NonNull T value);
 
-        abstract CompletionStage<Void> terminate(@Nullable Throwable throwable);
+        public abstract CompletionStage<Void> finish(@Nullable Throwable throwable);
     }
 
     static final class AsyncGroup<K, T> extends BasicGroupedStreamable<K, T>
@@ -221,15 +222,16 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
         }
 
         @Override
-        CompletionStage<Void> send(T value) {
-            return sendCanProgress.await().thenAccept(_ -> {
+        public CompletionStage<Boolean> next(T value) {
+            return sendCanProgress.await().thenApply(_ -> {
                 item = value;
                 nextCanProgress.ready().complete(true);
+                return true;
             });
         }
 
         @Override
-        CompletionStage<Void> terminate(@Nullable Throwable throwable) {
+        public CompletionStage<Void> finish(@Nullable Throwable throwable) {
             return sendCanProgress.await().thenAccept(_ -> {
                 if (throwable == null) {
                     nextCanProgress.ready().complete(false);
@@ -291,12 +293,12 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
         }
 
         @Override
-        CompletionStage<Void> send(Object value) {
-            return Streamer.FINISHED;
+        public CompletionStage<Boolean> next(Object value) {
+            return Streamer.NEXT_TRUE;
         }
 
         @Override
-        CompletionStage<Void> terminate(@Nullable Throwable throwable) {
+        public CompletionStage<Void> finish(@Nullable Throwable throwable) {
             return Streamer.FINISHED;
         }
     }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java
@@ -35,7 +35,7 @@ public enum StreamableHelper {
      * then terminates the resulting {@link CompletableFuture} with said terminal event.
      * <p>
      * Use the {@code thenAcceptor} to do something about the winner and/or loser before the terminal
-     * signal is propagated further
+     * signal is propagated further.
      * @param <T> the common element type of the stages
      * @param first the first stage to wait for
      * @param second the second stage to wait for
@@ -69,6 +69,42 @@ public enum StreamableHelper {
         });
 
         return result;
+    }
+
+    /**
+     * Checks which source completes first, calls the given acceptor with 1 or 2 indicating the winner.
+     * <p>
+     * Use the {@code thenAcceptor} to do something about the winner and/or loser.
+     * @param <T> the common element type of the stages
+     * @param first the first stage to wait for
+     * @param second the second stage to wait for
+     * @param thenAcceptor the callback that receives who won
+     */
+    @CheckReturnValue
+    @NonNull
+    public static <T> void whenEither(CompletionStage<T> first, CompletionStage<T> second, IntConsumer thenAcceptor) {
+        var result = new CompletableFuture<T>();
+        var winner = new AtomicInteger();
+        first.whenComplete((v, e) -> {
+            if (winner.compareAndSet(0, 1)) {
+                thenAcceptor.accept(1);
+                if (e != null) {
+                    result.completeExceptionally(e);
+                } else {
+                    result.complete(v);
+                }
+            }
+        });
+        second.whenComplete((v, e) -> {
+            if (winner.compareAndSet(0, 2)) {
+                thenAcceptor.accept(2);
+                if (e != null) {
+                    result.completeExceptionally(e);
+                } else {
+                    result.complete(v);
+                }
+            }
+        });
     }
 
     /**
@@ -186,18 +222,16 @@ public enum StreamableHelper {
      * Use it to suppress expected cancellation errors and any source value.
      * @param <T> the element type of the stage
      * @param stage the original stage to gate the cancellation exception of
-     * @param disposable the {@code Disposable} to check
      * @param defaultValue to signal if the cancellation exception was gated
      * @return the new {@code CompletableFuture} instance
      */
     @CheckReturnValue
     @NonNull
     public static <T> CompletableFuture<T> suppressValueAndCancel(
-            @NonNull CompletionStage<T> stage,
-            @NonNull Disposable disposable, T defaultValue) {
+            @NonNull CompletionStage<T> stage, T defaultValue) {
         var result = new CompletableFuture<T>();
         stage.whenComplete((_, e) -> {
-            if (disposable.isDisposed() && isCancellation(e)) { // FIXME coverage possible even?
+            if (isCancellation(e)) { // FIXME coverage possible even?
                 result.complete(defaultValue);
             } else
             if (e != null) {
@@ -207,5 +241,21 @@ public enum StreamableHelper {
             }
         });
         return result;
+    }
+
+    /**
+     * When the stage completes, the future is completed with the very same value or exception.
+     * @param <T> the element type
+     * @param stage the stage to forward its completion signals
+     * @param future the future to receive the completion signals
+     */
+    public static <T> void forward(CompletionStage<T> stage, CompletableFuture<T> future) {
+        stage.whenComplete((u, e) -> {
+            if (e != null) {
+                future.completeExceptionally(e);
+            } else {
+                future.complete(u);
+            }
+        });
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableOnErrorResumeNext.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableOnErrorResumeNext.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.Objects;
+import java.util.concurrent.*;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.functions.Function;
+
+public record StreamableOnErrorResumeNext<T>(
+        Streamable<T> source,
+        Function<? super Throwable, ? extends Streamable<? extends T>> fallbackMapper
+) implements Streamable<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        return new OnErrorResumeNextStreamer<>(source.stream(cancellation), fallbackMapper, cancellation);
+    }
+
+    static final class OnErrorResumeNextStreamer<T> implements Streamer<T> {
+
+        final DisposableContainer downstreamDisposable;
+
+        final Function<? super Throwable, ? extends Streamable<? extends T>> fallbackMapper;
+
+        Streamer<T> mainStreamer;
+
+        Streamer<? extends T> fallbackStreamer;
+
+        public OnErrorResumeNextStreamer(Streamer<T> mainStreamer,
+                Function<? super Throwable, ? extends Streamable<? extends T>> fallbackMapper,
+                        DisposableContainer downstreamDisposable) {
+            this.mainStreamer = mainStreamer;
+            this.fallbackMapper = fallbackMapper;
+            this.downstreamDisposable = downstreamDisposable;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.next();
+            }
+            var cf = new CompletableFuture<Boolean>();
+            mainStreamer.next().whenComplete((v, e) -> {
+                if (e != null) {
+                    var ms = mainStreamer;
+                    mainStreamer = null;
+                    ms.finish().whenComplete((_, e1) -> {
+                        if (e1 != null) {
+                            e.addSuppressed(e1);
+                        }
+                        try {
+                            var fallback = Objects.requireNonNull(fallbackMapper.apply(e), "The fallbackMapper returned a null Streamable");
+                            fallbackStreamer = fallback.stream(downstreamDisposable);
+                            StreamableHelper.forward(fallbackStreamer.next(), cf);
+                        } catch (Throwable ex) {
+                            Exceptions.throwIfFatal(ex);
+                            ex.addSuppressed(e);
+                            cf.completeExceptionally(ex);
+                        }
+                    });
+                } else {
+                    cf.complete(v);
+                }
+            });
+            return cf;
+        }
+
+        @Override
+        public @NonNull T current() {
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.current();
+            }
+            return mainStreamer.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.finish();
+            }
+            if (mainStreamer != null) {
+                return mainStreamer.finish();
+            }
+            return FINISHED;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTakeUntil.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTakeUntil.java
@@ -36,7 +36,7 @@ public record StreamableTakeUntil<T, U>(
 
         var streamer = new TakeUntilMainStreamer<>(
                 mainStreamer, otherStreamer, mainCancellation, otherCancellation,
-                suppressValueAndCancel(otherStreamer.next(), otherCancellation, false)
+                suppressValueAndCancel(otherStreamer.next(), false)
             );
 
         return streamer;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTimeout.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTimeout.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.Scheduler.Worker;
+import io.reactivex.rxjava4.disposables.*;
+
+public record StreamableTimeout<T>(
+        Streamable<T> source,
+        long timeout, TimeUnit unit, Scheduler scheduler,
+        Streamable<T> fallback)
+implements Streamable<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        var worker = scheduler.createWorker();
+        cancellation.add(worker);
+        var dc = cancellation.derive();
+        var streamer = new TimeoutStreamer<>(
+                source.stream(dc), dc, cancellation,
+                timeout, unit, worker, fallback);
+        return streamer;
+    }
+
+    static final class TimeoutStreamer<T> implements Streamer<T> {
+
+        final long timeout;
+
+        final TimeUnit unit;
+
+        final Worker worker;
+
+        final Streamable<T> fallback;
+
+        final Disposable mainDisposable;
+
+        final DisposableContainer downstreamDisposable;
+
+        Streamer<T> mainStreamer;
+
+        Streamer<T> fallbackStreamer;
+
+        TimeoutStreamer(
+                Streamer<T> mainStreamer, Disposable mainDisposable, DisposableContainer downstreamDisposable,
+                long timeout, TimeUnit unit, Worker worker, Streamable<T> fallback) {
+            this.timeout = timeout;
+            this.unit = unit;
+            this.worker = worker;
+            this.fallback = fallback;
+            this.mainStreamer = mainStreamer;
+            this.mainDisposable = mainDisposable;
+            this.downstreamDisposable = downstreamDisposable;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.next();
+            }
+
+            var mainNextResume = new CompletableFuture<Boolean>();
+            var mainNext = mainStreamer.next();
+            var mainNextTimeout = new CompletableFuture<Boolean>();
+            Disposable d = worker.schedule(() -> mainNextTimeout.complete(false), timeout, unit);
+            StreamableHelper.whenEither(mainNext, mainNextTimeout, winner -> {
+                if (winner == 1) {
+                    d.dispose();
+                    StreamableHelper.forward(mainNext, mainNextResume);
+                } else {
+                    mainDisposable.dispose();
+                    StreamableHelper.andThenSupply(
+                            StreamableHelper.suppressValueAndCancel(mainNext, false),
+                            () -> mainStreamer.finish()
+                    ).whenComplete((_, e) -> {
+                        if (e != null) {
+                            mainNextResume.completeExceptionally(e);
+                        } else {
+                            fallbackStreamer = fallback.stream(downstreamDisposable);
+                            StreamableHelper.forward(fallbackStreamer.next(), mainNextResume);
+                        }
+                    })
+                    ;
+                }
+            });
+            return mainNextResume;
+        }
+
+        @Override
+        public @NonNull T current() {
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.current();
+            }
+            return mainStreamer.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            worker.dispose();
+            if (fallbackStreamer != null) {
+                return fallbackStreamer.finish();
+            }
+            return mainStreamer.finish();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZip.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.DisposableContainer;
+import io.reactivex.rxjava4.internal.util.AtomicThrowable;
+
+public record StreamableZip<T>(
+        Iterable<? extends Streamable<? extends T>> sources
+) implements Streamable<List<T>> {
+
+    @Override
+    public @NonNull Streamer<@NonNull List<T>> stream(@NonNull DisposableContainer cancellation) {
+        var dc = cancellation.derive();
+
+        var sourcesList = new ArrayList<Streamer<? extends T>>();
+        int i = 0;
+        for (var inner : sources) {
+            if (inner == null) {
+                return StreamableError.createFailed(new NullPointerException("The item at index " + i + " is null"));
+            }
+            sourcesList.add(inner.stream(dc));
+            i++;
+        }
+
+        if (sourcesList.isEmpty()) {
+            return StreamableEmpty.EmptyStreamer.cast();
+        }
+        return new ZipStreamer<T>(sourcesList, dc);
+    }
+
+    static final class ZipStreamer<T>
+    implements Streamer<List<T>>, BiConsumer<Object, Throwable> {
+
+        final DisposableContainer innerCancellation;
+
+        final List<? extends Streamer<? extends T>> streamers;
+
+        final AtomicInteger wip;
+
+        final AtomicInteger endWip;
+
+        final CompletableFuture<Void> finishReady;
+
+        final AtomicThrowable errors;
+
+        CompletableFuture<Boolean> nextReady;
+
+        Object[] working;
+
+        List<T> current;
+
+        final List<CompletionStage<Boolean>> nexts;
+
+        volatile boolean done;
+
+        ZipStreamer(List<? extends Streamer<? extends T>> streamers, DisposableContainer innerCancellation) {
+            this.streamers = streamers;
+            this.innerCancellation = innerCancellation;
+            this.wip = new AtomicInteger();
+            this.finishReady = new CompletableFuture<>();
+            this.errors = new AtomicThrowable();
+            this.working =  new Object[streamers.size()];
+            this.endWip = new AtomicInteger();
+            nexts = new ArrayList<CompletionStage<Boolean>>(streamers.size());
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            nextReady = new CompletableFuture<>();
+            wip.set(streamers.size());
+            Arrays.fill(working, null);
+            nexts.clear();
+            for (var innerStreamer : streamers) {
+                var n = innerStreamer.next();
+                nexts.add(n);
+            }
+            int i = 0;
+            for (var stage : nexts) {
+                var j = i++;
+                stage.whenComplete((b, e) -> whenComplete(j, b, e));
+            }
+            return nextReady;
+        }
+
+        @Override
+        public @NonNull List<T> current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            working = null;
+            current = null;
+            nexts.clear();
+            wip.set(streamers.size());
+            errors.set(null);
+            done = true;
+            for (var innerStreamer : streamers) {
+                innerStreamer.finish().whenComplete(this);
+            }
+            return finishReady;
+        }
+
+        void whenComplete(int index, Boolean b, Throwable t) {
+            if (t != null) {
+                if (wip.getAndSet(0) != 0) {
+                    errors.tryAddThrowableOrReport(t);
+                    innerCancellation.dispose();
+                    endWip.set(streamers.size());
+                    int i = 0;
+                    for (var next : nexts) {
+                        if (index != i++) {
+                            next.whenComplete(this);
+                        } else {
+                            accept(null, null);
+                        }
+                    }
+                }
+            } else
+            if (b) {
+                working[index] = streamers.get(index).current();
+                if (wip.decrementAndGet() == 0) {
+                    @SuppressWarnings("unchecked")
+                    T[] result = (T[])working;
+                    current = List.of(result);
+                    nextReady.complete(true);
+                }
+            } else {
+                if (wip.getAndSet(0) != 0) {
+                    innerCancellation.dispose();
+                    endWip.set(streamers.size());
+                    int i = 0;
+                    for (var next : nexts) {
+                        if (index != i++) {
+                            next.whenComplete(this);
+                        } else {
+                            accept(null, null);
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void accept(Object t, Throwable u) {
+            if (done) {
+                if (u != null) {
+                    errors.tryAddThrowableOrReport(u);
+                }
+                if (wip.decrementAndGet() == 0) {
+                    var err = errors.terminate();
+                    if (err != null) {
+                        finishReady.completeExceptionally(err);
+                    } else {
+                        finishReady.complete(null);
+                    }
+                }
+            } else {
+                if (u !=  null && !StreamableHelper.isCancellation(u)) {
+                    errors.tryAddThrowableOrReport(u);
+                }
+                if (endWip.decrementAndGet() == 0) {
+                    var err = errors.terminate();
+                    if (err != null) {
+                        nextReady.completeExceptionally(err);
+                    } else {
+                        nextReady.complete(false);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/util/ExceptionHelper.java
@@ -199,12 +199,24 @@ public final class ExceptionHelper {
         if (secondary instanceof CompletionException || secondary instanceof ThrowableWrapper) {
             secondary = secondary.getCause();
         }
-        if (main != null && secondary != null) {
+        if (main != null && secondary != null && main != secondary) {
             main.addSuppressed(secondary);
         }
         if (main != null) {
             return main;
         }
         return secondary;
+    }
+
+    /**
+     * Unwraps the given {@link CompletionException} or {@link ThrowableWrapper}
+     * @param t the possible throwable to unwrap
+     * @return the unwrapped Throwable
+     */
+    public static Throwable unwrap(@Nullable Throwable t) {
+        if (t instanceof CompletionException || t instanceof ThrowableWrapper) {
+            t = t.getCause();
+        }
+        return t;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
+++ b/src/test/java/io/reactivex/rxjava4/core/RxJavaTest.java
@@ -74,6 +74,11 @@ public abstract class RxJavaTest {
                 }
                 error.addSuppressed(ex);
             }
+            try {
+                Thread.sleep(10 * new Random().nextInt(10));
+            } catch (InterruptedException ex) {
+                throw new AssertionError(ex);
+            }
         }
         if (error != null) {
             throw error;

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableCollectorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableCollectorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public class StreamableCollectorTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .collect(Collectors.toList())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Streamable.empty()
+        .collect(Collectors.toList())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of());
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.error(new TestException())
+        .collect(Collectors.toList())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void finishCrash() throws Throwable {
+        StreamableFailingFinish.MAIN_COMPLETES
+        .collect(Collectors.toList())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDelayTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDelayTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+public class StreamableDelayTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .delay(1, TimeUnit.MILLISECONDS, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.error(new TestException())
+        .delay(1, TimeUnit.MILLISECONDS, Schedulers.single())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void timeoutOnDelay() throws Throwable {
+        Streamable.just(1)
+        .delay(10, TimeUnit.SECONDS, Schedulers.single())
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.single(), Streamable.error(new TimeoutException()))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFailingFinish.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFailingFinish.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public enum StreamableFailingFinish implements Streamable<Integer> {
+
+    NEVER(0),
+    MAIN_FAILS(1),
+    MAIN_COMPLETES(1)
+    ;
+
+    private final class StreamableFailingFinishStreamer implements Streamer<Integer> {
+        private final @NonNull DisposableContainer dc;
+
+        private StreamableFailingFinishStreamer(@NonNull DisposableContainer dc) {
+            this.dc = dc;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            var cf = new CompletableFuture<Boolean>();
+            var d = Disposable.fromFuture(cf, true);
+            dc.add(d);
+            if (mode == 1) {
+                cf.completeExceptionally(new TestException("StreamableFailingFinish(true)"));
+            } else
+            if (mode == 2) {
+                cf.complete(false);
+            }
+            return cf;
+        }
+
+        @Override
+        public @NonNull Integer current() {
+            return null;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            return CompletableFuture.failedFuture(new TestException());
+        }
+    }
+
+    final int mode;
+
+    StreamableFailingFinish(int mode) {
+        this.mode = mode;
+    }
+
+    @Override
+    public @NonNull Streamer<@NonNull Integer> stream(@NonNull DisposableContainer dc) {
+        return new StreamableFailingFinishStreamer(dc);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
@@ -19,9 +19,8 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Test;
 
-import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.config.StandardConcurrentConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
@@ -138,8 +137,8 @@ public class StreamableGroupByTest extends StreamableBaseTest {
 
     @Test
     public void tombstone2() {
-        assertSame(Streamer.FINISHED, StreamableGroupBy.TombstoneGroup.INSTANCE.send(true), "send");
-        assertSame(Streamer.FINISHED, StreamableGroupBy.TombstoneGroup.INSTANCE.terminate(null), "terminate");
+        assertSame(Streamer.NEXT_TRUE, StreamableGroupBy.TombstoneGroup.INSTANCE.next(true), "send");
+        assertSame(Streamer.FINISHED, StreamableGroupBy.TombstoneGroup.INSTANCE.finish(null), "terminate");
     }
 
     @Test
@@ -256,28 +255,34 @@ public class StreamableGroupByTest extends StreamableBaseTest {
 
     @Test
     public void finishFails() {
-        Streamable<Integer> str = _ -> new Streamer<>() /* NFI */ {
-            @Override
-            public @NonNull CompletionStage<Boolean> next() {
-                return NEXT_FALSE;
-            }
-
-            @Override
-            public @NonNull Integer current() {
-                return null;
-            }
-
-            @Override
-            public @NonNull CompletionStage<Void> finish() {
-                return CompletableFuture.failedFuture(new TestException());
-            }
-        };
-
-        str
+        StreamableFailingFinish.MAIN_COMPLETES
         .groupBy(v -> v)
         .flatMap(v -> v, StandardConcurrentConfig.DEFAULT)
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void finishFailsDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            StreamableFailingFinish.MAIN_COMPLETES
+            .groupBy(v -> v)
+            .flatMap(v -> v, StandardConcurrentConfig.DEFAULT)
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(TestException.class);
+        });
+    }
+
+    @Test
+    public void finishFails2Debug() throws Throwable {
+        withCachedExecutor(exec -> {
+            StreamableFailingFinish.MAIN_COMPLETES
+            .groupBy(v -> v)
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertFailure(TestException.class);
+        });
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.config.StandardConcurrentConfig;
@@ -218,39 +218,53 @@ public class StreamableGroupByTest extends StreamableBaseTest {
 
     @Test
     public void groupDisposeTest() throws Throwable {
-        var pp = PublishProcessor.<Integer>create();
-        var gr = new AtomicReference<GroupedStreamable<Integer, Integer>>();
+        withCachedExecutor(exec -> {
+            var pp = PublishProcessor.<Integer>create();
+            var gr = new AtomicReference<GroupedStreamable<Integer, Integer>>();
 
-        var ts = pp.toStreamable()
-        .groupBy(v -> v)
-        .map(g -> {
-            gr.lazySet(g);
-            return g.test();
-        })
-        .test();
+            var ts = pp.toStreamable()
+            .groupBy(v -> v)
+            .map(g -> {
+                gr.lazySet(g);
+                return g.test(exec);
+            })
+            .test(exec);
 
-        while (!ts.hasSubscription()) {
-            Thread.sleep(1);
-        }
+            int n = 1000;
+            while (!ts.hasSubscription()) {
+                Thread.sleep(1);
+                if (n-- < 0) {
+                    throw new TimeoutException("hasSubscription");
+                }
+            }
 
-        while (!pp.hasSubscribers()) {
-            Thread.sleep(1);
-        }
+            n = 1000;
+            while (!pp.hasSubscribers()) {
+                Thread.sleep(1);
+                if (n-- < 0) {
+                    throw new TimeoutException("hasSubscribers");
+                }
+            }
 
-        pp.onNext(1);
+            pp.onNext(1);
 
-        while (gr.get() == null) {
-            Thread.sleep(1);
-        }
+            n = 1000;
+            while (gr.get() == null) {
+                Thread.sleep(1);
+                if (n-- < 0) {
+                    throw new TimeoutException("gr.get");
+                }
+            }
 
-        assertFalse(((Disposable)gr.get()).isDisposed(), "Group already disposed?");
+            assertFalse(((Disposable)gr.get()).isDisposed(), "Group already disposed?");
 
-        pp.onComplete();
+            pp.onComplete();
 
-        ts.awaitDone(5, TimeUnit.SECONDS)
-        .assertValueCount(1);
+            ts.awaitDone(5, TimeUnit.SECONDS)
+            .assertValueCount(1);
 
-        assertTrue(((Disposable)gr.get()).isDisposed(), "Group not disposed");
+            assertTrue(((Disposable)gr.get()).isDisposed(), "Group not disposed");
+        });
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
@@ -217,12 +217,13 @@ public class StreamableGroupByTest extends StreamableBaseTest {
     }
 
     @Test
+    @Disabled("TimeoutException(\"gr.get\"), not sure why sometimes it doesn't emit that first group")
     public void groupDisposeTest() throws Throwable {
         withCachedExecutor(exec -> {
             var pp = PublishProcessor.<Integer>create();
             var gr = new AtomicReference<GroupedStreamable<Integer, Integer>>();
 
-            var ts = pp.toStreamable()
+            var ts = pp.toStreamable(exec)
             .groupBy(v -> v)
             .map(g -> {
                 gr.lazySet(g);
@@ -252,7 +253,7 @@ public class StreamableGroupByTest extends StreamableBaseTest {
             while (gr.get() == null) {
                 Thread.sleep(1);
                 if (n-- < 0) {
-                    throw new TimeoutException("gr.get");
+                    throw new TimeoutException("gr.get"); // FIXME why sometimes we get here bc gr.set never runs?
                 }
             }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableOnErrorResumeNextTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableOnErrorResumeNextTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public class StreamableOnErrorResumeNextTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .onErrorResumeNext(_ -> Streamable.range(6, 5))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        Streamable.error(new TestException("1"))
+        .onErrorResumeNext(t -> Streamable.range(Integer.parseInt(t.getMessage()), 5))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void errorDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            Streamable.error(new TestException("1"))
+            .onErrorResumeNext(t -> Streamable.range(Integer.parseInt(t.getMessage()), 5))
+            .test(exec)
+            .awaitDone(500, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5);
+        });
+    }
+
+    @Test
+    public void errorToError() throws Throwable {
+        Streamable.error(new TestException("1"))
+        .onErrorResumeNext(t -> Streamable.error(new IOException(t.getMessage() + "2")))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(IOException.class)
+        .assertError(e -> e.getMessage().equals("12"));
+    }
+
+    @Test
+    public void errorNull() throws Throwable {
+        Streamable.error(new TestException("1"))
+        .onErrorResumeNext(_ -> null)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class)
+        .assertError(t -> t.getSuppressed()[0] instanceof TestException);
+    }
+
+    @Test
+    public void errorCrash() throws Throwable {
+        Streamable.error(new TestException("1"))
+        .onErrorResumeNext(_ -> { throw new IOException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(IOException.class)
+        .assertError(t -> t.getSuppressed()[0] instanceof TestException);
+    }
+
+    @Test
+    public void finishFails() {
+        StreamableFailingFinish.MAIN_FAILS
+        .onErrorResumeNext(_ -> { throw new IOException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(IOException.class)
+        .assertError(e -> e.getSuppressed()[0] instanceof TestException);
+    }
+
+    @Test
+    public void finishFailsDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            StreamableFailingFinish.MAIN_FAILS
+            .onErrorResumeNext(_ -> { throw new IOException(); })
+            .test(exec)
+            .awaitDone(5, TimeUnit.MINUTES)
+            .assertFailure(IOException.class)
+            .assertError(e -> e.getSuppressed()[0] instanceof TestException);
+        });
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTest.java
@@ -357,4 +357,14 @@ public class StreamableTest extends StreamableBaseTest {
         .awaitDone(5, TimeUnit.SECONDS)
         .assertResult(1, 2, 3, 4, 5);
     }
+
+    @Test
+    public void finishFails2Debug() throws Throwable {
+        withCachedExecutor(exec -> {
+            StreamableFailingFinish.MAIN_COMPLETES
+            .test(exec)
+            .awaitDone(5, TimeUnit.MINUTES)
+            .assertFailure(TestException.class);
+        });
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTimeoutTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableTimeoutTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.schedulers.Schedulers;
+
+public class StreamableTimeoutTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .timeout(1, TimeUnit.MINUTES, Schedulers.single(), Streamable.empty())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.error(new TestException())
+        .timeout(1, TimeUnit.MINUTES, Schedulers.single(), Streamable.empty())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void timesOut() throws Throwable {
+        Streamable.<Integer>never()
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.single(), Streamable.range(6, 5))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(6, 7, 8, 9, 10);
+    }
+
+    @Test
+    public void timesOutError() throws Throwable {
+        Streamable.<Integer>never()
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.single(), Streamable.error(new TimeoutException()))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TimeoutException.class);
+    }
+
+    @Test
+    public void timesOutDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            Streamable.<Integer>never()
+            .timeout(100, TimeUnit.MILLISECONDS, Schedulers.single(), Streamable.range(6, 5))
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(6, 7, 8, 9, 10);
+        });
+    }
+
+    @Test
+    public void finishFails() {
+        StreamableFailingFinish.MAIN_COMPLETES
+        .timeout(100, TimeUnit.MILLISECONDS, Schedulers.single(), Streamable.empty())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZipTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.*;
+
+public class StreamableZipTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.zip(List.of(Streamable.range(1, 5), Streamable.range(6, 5)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1, 6), List.of(2, 7), List.of(3, 8), List.of(4, 9), List.of(5, 10));
+    }
+
+    @Test
+    public void single() throws Throwable {
+        Streamable.zip(List.of(Streamable.range(1, 5)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1), List.of(2), List.of(3), List.of(4), List.of(5));
+    }
+
+    @Test
+    public void singleDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            Streamable.zip(List.of(Streamable.range(1, 5)))
+            .test(exec)
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(List.of(1), List.of(2), List.of(3), List.of(4), List.of(5));
+        });
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.zip(List.of(Streamable.error(new TestException()), Streamable.range(6, 5)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void differentSizes() throws Throwable {
+        Streamable.zip(List.of(Streamable.range(1, 4), Streamable.range(6, 5)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1, 6), List.of(2, 7), List.of(3, 8), List.of(4, 9));
+    }
+
+    @Test
+    public void differentSizes2() throws Throwable {
+        Streamable.zip(List.of(Streamable.range(1, 5), Streamable.range(6, 4)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1, 6), List.of(2, 7), List.of(3, 8), List.of(4, 9));
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Streamable.zip(List.of())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void oneIsNull() throws Throwable {
+        Streamable.zip(Arrays.asList(Streamable.just(1), null))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void just() throws Throwable {
+        Streamable.zip(List.of(Streamable.just(1), Streamable.just(6)))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(List.of(1, 6));
+    }
+
+    @Test
+    public void finishCrash() throws Throwable {
+        Streamable.zip(List.of(Streamable.just(1), StreamableFailingFinish.MAIN_COMPLETES))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void finishCrash2() throws Throwable {
+        Streamable.zip(List.of(StreamableFailingFinish.MAIN_COMPLETES, StreamableFailingFinish.MAIN_COMPLETES))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(CompositeException.class);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
+++ b/src/test/java/io/reactivex/rxjava4/testsupport/TestHelper.java
@@ -35,7 +35,7 @@ import io.reactivex.rxjava4.core.Observable;
 import io.reactivex.rxjava4.core.Observer;
 import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.*;
-import io.reactivex.rxjava4.functions.*;
+import io.reactivex.rxjava4.functions.Function;
 import io.reactivex.rxjava4.internal.operators.completable.CompletableToFlowable;
 import io.reactivex.rxjava4.internal.operators.maybe.MaybeToFlowable;
 import io.reactivex.rxjava4.internal.operators.single.SingleToFlowable;
@@ -3517,7 +3517,7 @@ public enum TestHelper {
             return f;
         }
 
-        System.out.println("Can't read " + p);
+        new Exception("Can't read " + p).printStackTrace(System.out);
         return null;
     }
 

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckJavadocCodesAndLinksTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckJavadocCodesAndLinksTest.java
@@ -68,12 +68,12 @@ public class CheckJavadocCodesAndLinksTest extends RxJavaTest {
 
     @Test
     public void checkConnectableFlowable() throws Exception {
-        checkSource("ConnectableFlowable", "io.reactivex.rxjava4.flowables");
+        checkSource("ConnectableFlowable", "io.reactivex.rxjava4.core");
     }
 
     @Test
     public void checkConnectableObservable() throws Exception {
-        checkSource("ConnectableObservable", "io.reactivex.rxjava4.observables");
+        checkSource("ConnectableObservable", "io.reactivex.rxjava4.core");
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckJavadocConfigAndArgumentTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckJavadocConfigAndArgumentTest.java
@@ -68,12 +68,12 @@ public class CheckJavadocConfigAndArgumentTest extends RxJavaTest {
 
     @Test
     public void checkConnectableFlowable() throws Exception {
-        checkSource("ConnectableFlowable", "io.reactivex.rxjava4.flowables");
+        checkSource("ConnectableFlowable", "io.reactivex.rxjava4.core");
     }
 
     @Test
     public void checkConnectableObservable() throws Exception {
-        checkSource("ConnectableObservable", "io.reactivex.rxjava4.observables");
+        checkSource("ConnectableObservable", "io.reactivex.rxjava4.core");
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -498,6 +498,8 @@ public class CheckParamValidationTest extends RxJavaTest {
 
         addOverride(new ParamOverride(Streamable.class, 0, ParamMode.ANY, "timer", Long.TYPE, TimeUnit.class, Scheduler.class));
         addOverride(new ParamOverride(Streamable.class, 0, ParamMode.ANY, "timer", Long.TYPE, TimeUnit.class, ExecutorService.class));
+        addOverride(new ParamOverride(Streamable.class, 0, ParamMode.ANY, "timeout", Long.TYPE, TimeUnit.class, Scheduler.class, Streamable.class));
+        addOverride(new ParamOverride(Streamable.class, 0, ParamMode.ANY, "delay", Long.TYPE, TimeUnit.class, Scheduler.class));
 
         // -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
# `Streamable` Operators 

- `delay`
- `onErrorResumeNext`
- `timeout`
- `zip`

# New types

- `StreamProcessor` ~ analogous to the `Flow.Processor`
- `StreamerInput` ~ the push side of a processor in the `Streamable` world

# Other

Internal cleanups and fixes.