### PR TITLE
4.x: Streamable API: DispatchStreamProcessor & other improvements

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/StreamProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/core/StreamProcessor.java
@@ -16,7 +16,7 @@ package io.reactivex.rxjava4.core;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Flow.Processor;
 
-import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.annotations.*;
 
 /**
  * A {@link Processor}-like interface combining the {@code Streamable} interface and the
@@ -28,4 +28,29 @@ import io.reactivex.rxjava4.annotations.NonNull;
  */
 public interface StreamProcessor<@NonNull In, @NonNull Out> extends Streamable<Out>, StreamerInput<In> {
 
+    /**
+     * Returns {@code true} if this {@link StreamProcessor} has {@link Streamer}s.
+     * @return {@code true} if this {@link StreamProcessor} has {@link Streamer}s.
+     */
+    boolean hasStreamers();
+
+    /**
+     * Returns {@code true} if this {@code StreamProcessor} was completed normally via {@link #finish(Throwable)}.
+     * @return {@code true} if this {@code StreamProcessor} was completed normally via {@link #finish(Throwable)}.
+     */
+    boolean hasComplete();
+
+    /**
+     * Returns {@code true} if this {@code StreamProcessor} was completed with a {@link Throwable} via {@link #finish(Throwable)}.
+     * @return {@code true} if this {@code StreamProcessor} was completed with a {@link Throwable} via {@link #finish(Throwable)}.
+     */
+    boolean hasThrowable();
+
+    /**
+     * Returns the terminal {@link Throwable} if this {@code StreamProcessor} was completed
+     * with a {@code Throwable} via {@link #finish(Throwable)}.
+     * @return the {@link Throwable} if any
+     */
+    @Nullable
+    Throwable getThrowable();
 }

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -655,7 +655,7 @@ public interface Streamable<@NonNull T> {
     @NonNull
     default Streamable<T> intercept(StreamableInterceptConfig<T> config) {
         Objects.requireNonNull(config, "config is null");
-        return RxJavaPlugins.onAssembly(new StreamableIntercept<>(this,
+        return RxJavaPlugins.onAssembly(new StreamableIntercept<T>(this,
                 config.onStream(), config.onNext(), config.onCurrent(), config.onFinish()));
     }
 
@@ -975,15 +975,12 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
-     * Consume this {@code Streamable} via the given flow-reactive-streams subscriber.
+     * Consume this {@code Streamable} via the given flow-reactive-streams subscriber
+     * on a virtual thread backed executor service.
      * @param subscriber the subscriber to consume with.
      */
     default void subscribe(@NonNull Flow.Subscriber<? super T> subscriber) {
-        final Streamable<T> me = this;
-        Flowable.<T>virtualCreate(emitter -> {
-            me.forEach(emitter::emit).await();
-        })
-        .subscribe(subscriber);
+        subscribe(subscriber, Executors.newVirtualThreadPerTaskExecutor());
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/core/StreamerInput.java
+++ b/src/main/java/io/reactivex/rxjava4/core/StreamerInput.java
@@ -33,17 +33,16 @@ public interface StreamerInput<@NonNull T> {
     /**
      * Offer the next item.
      * @param item the item being offered
-     * @return a {@link CompletionStage} that should complete with {@code true} if the
-     *         item was accepted, or {@code false} if the item could not be accepted at this time,
-     *         or via a {@code Throwable} indicating some error.
+     * @return a {@link CompletionStage} that completes with {@code true} if the value was successfully consumed,
+     *         {@code false} if the value was rejected or exceptionally on error
      */
     CompletionStage<Boolean> next(T item);
 
     /**
      * Offer the final, terminal event.
      * @param throwable the optional throwable to signal error, null to signal normal completion
-     * @return the {@link CompletionStage} that should complete normally if the terminal event was accepted,
-     *         or via a {@code Throwable} indicating an error
+     * @return a {@link CompletionStage} that completes with {@code null} if the call succeeded
+     *         or exceptionally on error
      */
     CompletionStage<Void> finish(@Nullable Throwable throwable);
 }

--- a/src/main/java/io/reactivex/rxjava4/core/config/StreamableInterceptConfig.java
+++ b/src/main/java/io/reactivex/rxjava4/core/config/StreamableInterceptConfig.java
@@ -38,7 +38,7 @@ public record StreamableInterceptConfig<T>(
 ) {
 
     /**
-     * Constructs a configuration with a custom {@link #onNext} intercept and everything else is pass-through.
+     * Constructs a configuration with a custom {@link #onNext()} intercept and everything else is pass-through.
      * @param onNext the callback for intercepting the {@code next()} calls
      */
     public StreamableInterceptConfig(@NonNull BiFunction<? super DisposableContainer, ? super CompletionStage<Boolean>, ? extends CompletionStage<Boolean>> onNext) {
@@ -46,7 +46,7 @@ public record StreamableInterceptConfig<T>(
     }
 
     /**
-     * Constructs a configuration with a custom {@link #onCurrent} intercept and everything else is pass-through.
+     * Constructs a configuration with a custom {@link #onCurrent()} intercept and everything else is pass-through.
      * @param onCurrent the callback for when an item is ready
      */
     public StreamableInterceptConfig(@NonNull Function<? super T, ? extends T> onCurrent) {

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StageResumable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StageResumable.java
@@ -20,6 +20,12 @@ import java.util.function.BiConsumer;
 
 import io.reactivex.rxjava4.annotations.*;
 
+/**
+ * Represents a reusable ping-pong style notification exchange where
+ * one use/thread can signal {@link #ready()} to wake up another use/thread
+ * on a {@link #await()} call.
+ * @param <T> the element type of the notification pass-around
+ */
 public final class StageResumable<T> extends AtomicReference<CompletableFuture<T>>
 implements BiConsumer<T, Throwable> {
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableEmpty.java
@@ -29,6 +29,11 @@ public enum StreamableEmpty implements Streamable<Object> {
         return EmptyStreamer.INSTANCE;
     }
 
+    @SuppressWarnings("unchecked")
+    public static <T> Streamer<T> createEmpty() {
+        return (Streamer<T>)EmptyStreamer.INSTANCE;
+    }
+
     enum EmptyStreamer implements Streamer<Object> {
 
         INSTANCE;
@@ -46,11 +51,6 @@ public enum StreamableEmpty implements Streamable<Object> {
         @Override
         public @NonNull CompletionStage<Void> finish() {
             return FINISHED;
-        }
-
-        @SuppressWarnings("unchecked")
-        public static <T> Streamer<T> cast() {
-            return (Streamer<T>)INSTANCE;
         }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
@@ -292,6 +292,7 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
             return StreamableError.createFailed(new CancellationException("TOMBSTONE"));
         }
 
+        // This is what happens with generics without co- and contravariance support
         @Override
         public CompletionStage<Boolean> next(Object value) {
             return Streamer.NEXT_TRUE;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupBy.java
@@ -272,7 +272,6 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
 
         @Override
         public boolean isDisposed() {
-            // TODO Auto-generated method stub
             return parent.isDeleted(getKey());
         }
     }
@@ -292,7 +291,6 @@ implements Streamable<GroupedStreamable<K, T>>, HasUpstreamStreamableSource<T> {
             return StreamableError.createFailed(new CancellationException("TOMBSTONE"));
         }
 
-        // This is what happens with generics without co- and contravariance support
         @Override
         public CompletionStage<Boolean> next(Object value) {
             return Streamer.NEXT_TRUE;

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelper.java
@@ -13,15 +13,17 @@
 
 package io.reactivex.rxjava4.internal.operators.streamable;
 
+import java.io.Serial;
+import java.util.Collection;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 import java.util.function.*;
 
 import io.reactivex.rxjava4.annotations.*;
-import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.CompositeException;
-import io.reactivex.rxjava4.internal.util.AtomicThrowable;
+import io.reactivex.rxjava4.internal.util.*;
 
 /**
  * Helper static methods for {@link Streamable}s, {@link CompletableFuture}s and {@link CompletionStage}s.
@@ -257,5 +259,118 @@ public enum StreamableHelper {
                 future.complete(u);
             }
         });
+    }
+
+    /**
+     * Awaits all the stages to complete in any form, then completes the returned {@link CompletableFuture} normally,
+     * or via the possible {@link CompositeException}s of all the failed stages.
+     * @param stages the collection of {@link CompletionStage}s to await
+     * @return the new {@code CompletableFuture} that gets completed
+     */
+    public static CompletableFuture<Void> awaitAllVoid(Collection<? extends CompletionStage<?>> stages) {
+        int size = stages.size();
+        if (size == 0) {
+            return Streamer.FINISHED;
+        }
+        var cf = new CompletableFuture<Void>();
+        var wip = new AtomicIntegerCompleter(cf, size);
+
+        for (var stage : stages) {
+            stage.whenComplete(wip);
+        }
+
+        return cf;
+    }
+
+    public static CompletableFuture<Boolean> awaitAllBoolean(Collection<? extends CompletionStage<Boolean>> stages) {
+        int size = stages.size();
+        if (size == 0) {
+            return Streamer.NEXT_FALSE;
+        }
+        var cf = new CompletableFuture<Boolean>();
+        var wip = new AtomicIntegerBooleanCompleter(cf, size);
+
+        for (var stage : stages) {
+            stage.whenComplete(wip);
+        }
+
+        return cf;
+    }
+
+    /**
+     * A counter and callback composite to save on allocation cost for awaiting many stages via
+     * {@link #awaitAll}.
+     */
+    static final class AtomicIntegerCompleter extends AtomicInteger implements BiConsumer<Object, Throwable> {
+
+        @Serial
+        private static final long serialVersionUID = 1598649149973711008L;
+
+        final CompletableFuture<Void> future;
+
+        final AtomicThrowable errors;
+
+        public AtomicIntegerCompleter(CompletableFuture<Void> future, int count) {
+            super(count);
+            this.future = future;
+            this.errors = new AtomicThrowable();
+        }
+
+        @Override
+        public void accept(Object t, Throwable u) {
+            if (u != null && !isCancellation(u)) {
+                errors.tryAddThrowable(ExceptionHelper.unwrap(u));
+            }
+            if (decrementAndGet() == 0) {
+                var err = errors.terminate();
+                if (err != null) {
+                    future.completeExceptionally(err);
+                } else {
+                    future.complete(null);
+                }
+            }
+        }
+    }
+    /**
+     * A counter and callback composite to save on allocation cost for awaiting many stages via
+     * {@link #awaitAll}.
+     */
+    static final class AtomicIntegerBooleanCompleter extends AtomicInteger implements BiConsumer<Boolean, Throwable> {
+
+        @Serial
+        private static final long serialVersionUID = 1598649149973711008L;
+
+        final CompletableFuture<Boolean> future;
+
+        final AtomicThrowable errors;
+
+        final AtomicBoolean outcome;
+
+        public AtomicIntegerBooleanCompleter(CompletableFuture<Boolean> future, int count) {
+            super(count);
+            this.future = future;
+            this.errors = new AtomicThrowable();
+            this.outcome = new AtomicBoolean(true);
+        }
+
+        @Override
+        public void accept(Boolean t, Throwable u) {
+            if (u != null && !isCancellation(u)) {
+                errors.tryAddThrowable(ExceptionHelper.unwrap(u));
+            }
+            if (t != null && !t) {
+                if (outcome.get()) {
+                    outcome.getAndSet(false);
+                }
+            }
+            if (decrementAndGet() == 0) {
+                var err = errors.terminate();
+                if (err != null) {
+                    future.completeExceptionally(err);
+                } else {
+                    future.complete(outcome.get());
+                }
+            }
+        }
     }
 }

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableZip.java
@@ -42,7 +42,7 @@ public record StreamableZip<T>(
         }
 
         if (sourcesList.isEmpty()) {
-            return StreamableEmpty.EmptyStreamer.cast();
+            return StreamableEmpty.createEmpty();
         }
         return new ZipStreamer<T>(sourcesList, dc);
     }

--- a/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/BaseTestConsumer.java
@@ -55,12 +55,19 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     protected boolean timeout;
 
     /**
+     * The latch that indicates the onSubscribe has been called and completed within this test consumer.
+     * @since 4.0.0
+     */
+    protected final CountDownLatch onSubscribeReady;
+
+    /**
      * Constructs a {@code BaseTestConsumer} with {@code CountDownLatch} set to 1.
      */
     public BaseTestConsumer() {
         this.values = new VolatileSizeArrayList<>();
         this.errors = new VolatileSizeArrayList<>();
         this.done = new CountDownLatch(1);
+        this.onSubscribeReady = new CountDownLatch(1);
     }
 
     /**
@@ -671,11 +678,25 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
      * @return this
      * @since 2.1
      */
-    @SuppressWarnings("unchecked")
     @NonNull
     public final U awaitCount(int atLeast) {
+        return awaitCount(atLeast, 5000, 10);
+    }
+
+    /**
+     * Wait until the {@code TestObserver}/{@code TestSubscriber} receives the given
+     * number of items or terminates by sleeping {@code sleepMillis} at a time
+     * up to a total of {@code timeoutMillis}.
+     * @param atLeast the number of items expected at least
+     * @param timeoutMillis the maximum amount to wait for the count
+     * @param sleepMillis how much to sleep at once when waiting for the items
+     * @return this
+     * @since 4.0.0
+     */
+    @SuppressWarnings("unchecked")
+    @NonNull
+    public final U awaitCount(int atLeast, long timeoutMillis, long sleepMillis) {
         long start = System.currentTimeMillis();
-        long timeoutMillis = 5000;
         for (;;) {
             if (System.currentTimeMillis() - start >= timeoutMillis) {
                 timeout = true;
@@ -689,7 +710,7 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
             }
 
             try {
-                Thread.sleep(10);
+                Thread.sleep(sleepMillis);
             } catch (InterruptedException ex) {
                 throw new RuntimeException(ex);
             }
@@ -743,6 +764,23 @@ public abstract class BaseTestConsumer<T, U extends BaseTestConsumer<T, U>> {
     public final U assertNoTimeout() {
         if (timeout) {
             throw fail("Timeout?!");
+        }
+        return (U)this;
+    }
+
+    /**
+     * Waits at most the given amount of time for the upstream to call {@code #onSubscribe(Subscription)}.
+     * @param timeout the amout to wait for the call
+     * @param unit the time unit
+     * @throws InterruptedException if the wait is interrupted
+     * @throws TimeoutException if the wait timed out on its own
+     * @return this
+     * @since 4.0.0
+     */
+    @SuppressWarnings("unchecked")
+    public final U awaitOnSubscribe(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        if (!onSubscribeReady.await(timeout, unit)) {
+            throw new TimeoutException("TestSubscriber.awaitOnSubscribe timed out");
         }
         return (U)this;
     }

--- a/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
+++ b/src/main/java/io/reactivex/rxjava4/observers/TestObserver.java
@@ -85,21 +85,25 @@ implements Observer<T>, MaybeObserver<T>, SingleObserver<T>, CompletableObserver
 
     @Override
     public void onSubscribe(@NonNull Disposable d) {
-        lastThread = Thread.currentThread();
+        try {
+            lastThread = Thread.currentThread();
 
-        if (d == null) {
-            errors.add(new NullPointerException("onSubscribe received a null Subscription"));
-            return;
-        }
-        if (!upstream.compareAndSet(null, d)) {
-            d.dispose();
-            if (upstream.get() != DisposableHelper.DISPOSED) {
-                errors.add(new IllegalStateException("onSubscribe received multiple subscriptions: " + d));
+            if (d == null) {
+                errors.add(new NullPointerException("onSubscribe received a null Subscription"));
+                return;
             }
-            return;
-        }
+            if (!upstream.compareAndSet(null, d)) {
+                d.dispose();
+                if (upstream.get() != DisposableHelper.DISPOSED) {
+                    errors.add(new IllegalStateException("onSubscribe received multiple subscriptions: " + d));
+                }
+                return;
+            }
 
-        downstream.onSubscribe(d);
+            downstream.onSubscribe(d);
+        } finally {
+            onSubscribeReady.countDown();
+        }
     }
 
     @Override

--- a/src/main/java/io/reactivex/rxjava4/processors/DispatchStreamProcessor.java
+++ b/src/main/java/io/reactivex/rxjava4/processors/DispatchStreamProcessor.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.processors;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.internal.operators.streamable.*;
+import io.reactivex.rxjava4.internal.util.ExceptionHelper;
+
+/**
+ * Signals the various {@link #next(Object)} and {@link #finish(Throwable)} events to one or more
+ * downstream {@link Streamer}s.
+ * <p>
+ * This is equivalent with to a {@link PublishProcessor} or {@link MulticastProcessor}, adapted to
+ * the {@link Streamable} world.
+ * @param <T> the element type of the input and output values
+ * @since 4.0.0
+ */
+public final class DispatchStreamProcessor<T> implements StreamProcessor<T, T> {
+
+    static final DispatchStreamer<?>[] TERMINATED = new DispatchStreamer<?>[0];
+
+    static final DispatchStreamer<?>[] EMPTY = new DispatchStreamer<?>[0];
+
+    final AtomicReference<DispatchStreamer<?>[]> streamers = new AtomicReference<>(EMPTY);
+
+    volatile Throwable terminalEvent;
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull DisposableContainer cancellation) {
+        var result = new DispatchStreamer<T>(this);
+        cancellation.add(result);
+        if (add(result)) {
+            return result;
+        }
+        var t = terminalEvent;
+        if (t != ExceptionHelper.TERMINATED) {
+            return StreamableError.createFailed(t);
+        }
+        return StreamableEmpty.createEmpty();
+    }
+
+    @Override
+    public CompletionStage<Boolean> next(@NonNull T item) {
+        @SuppressWarnings("unchecked")
+        var currentStreamers = (DispatchStreamer<T>[])streamers.get();
+        if (currentStreamers.length == 0) {
+            return Streamer.NEXT_FALSE;
+        }
+        List<CompletionStage<Boolean>> waiters = new ArrayList<>();
+        for (var str : currentStreamers) {
+            waiters.add(str.send(item));
+        }
+        return StreamableHelper.awaitAllBoolean(waiters);
+    }
+
+    @Override
+    public CompletionStage<Void> finish(@Nullable Throwable throwable) {
+        terminalEvent = throwable == null ? ExceptionHelper.TERMINATED : throwable;
+        @SuppressWarnings("unchecked")
+        var currentStreamers = (DispatchStreamer<T>[])streamers.getAndSet(TERMINATED);
+        if (currentStreamers.length == 0) {
+            return Streamer.FINISHED;
+        }
+        List<CompletionStage<Void>> waiters = new ArrayList<>();
+        for (var str : currentStreamers) {
+            waiters.add(str.error(throwable));
+        }
+        return StreamableHelper.awaitAllVoid(waiters);
+    }
+
+    boolean add(DispatchStreamer<T> streamer) {
+        for (;;) {
+            var currentStreamers = streamers.get();
+            if (currentStreamers == TERMINATED) {
+                return false;
+            }
+            var length = currentStreamers.length;
+            var nextStreamers = Arrays.copyOf(currentStreamers, length + 1);
+            nextStreamers[length] = streamer;
+            if (streamers.compareAndSet(currentStreamers, nextStreamers)) {
+                return true;
+            }
+        }
+    }
+
+    boolean remove(DispatchStreamer<T> streamer) {
+        for (;;) {
+            var currentStreamers = streamers.get();
+            var length = currentStreamers.length;
+            if (length == 0) {
+                return false;
+            }
+            int j = -1;
+            for (var i = 0; i < length; i++) {
+                if (currentStreamers[i] == streamer) {
+                    j = i;
+                    break;
+                }
+            }
+            if (j < 0) {
+                return false;
+            }
+            DispatchStreamer<?>[] nextStreamers;
+            if (length == 1) {
+                nextStreamers = EMPTY;
+            } else {
+                nextStreamers = new DispatchStreamer<?>[length - 1];
+                System.arraycopy(currentStreamers, 0, nextStreamers, 0, j);
+                System.arraycopy(currentStreamers, j + 1, nextStreamers, j, length - j - 1);
+            }
+            if (streamers.compareAndSet(currentStreamers, nextStreamers)) {
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public boolean hasStreamers() {
+        return streamers.get().length != 0;
+    }
+
+    @Override
+    public boolean hasComplete() {
+        return terminalEvent == ExceptionHelper.TERMINATED;
+    }
+
+    @Override
+    public boolean hasThrowable() {
+        var te = terminalEvent;
+        return te != null && te != ExceptionHelper.TERMINATED;
+    }
+
+    @Override
+    public @Nullable Throwable getThrowable() {
+        var te = terminalEvent;
+        if (te != null && te != ExceptionHelper.TERMINATED) {
+            return te;
+        }
+        return null;
+    }
+
+    static final class DispatchStreamer<T>
+    implements Streamer<T>, Function<Boolean, Boolean>, Disposable {
+
+        final DispatchStreamProcessor<T> parent;
+
+        final StageResumable<Boolean> consumerReady;
+
+        final StageResumable<Boolean> producerReady;
+
+        T current;
+
+        T incoming;
+
+        volatile boolean disposed;
+
+        DispatchStreamer(DispatchStreamProcessor<T> parent) {
+            this.parent = parent;
+            consumerReady = new StageResumable<>();
+            producerReady = new StageResumable<>();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            // I O.println("DispatchStreamer.next()");
+            consumerReady.ready().complete(true);
+            return producerReady.await().thenApply(this);
+        }
+
+        @Override
+        public Boolean apply(Boolean t) {
+            // I O.println("DispatchStreamer.apply(" + incoming + ")");
+            current = incoming;
+            incoming = null;
+            return t;
+        }
+
+        @Override
+        public @NonNull T current() {
+            // I O.println("DispatchStreamer.current(" + current + ")");
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            // I O.println("DispatchStreamer.finish()");
+            // new Exception().printStackTrace(System.out);
+            current = null;
+            parent.remove(this);
+            consumerReady.ready().complete(false);
+            return FINISHED;
+        }
+
+        CompletionStage<Boolean> send(T item) {
+            // I O.println("DispatchStreamer.send(" + item + ") // <-----------------------");
+            return consumerReady.await().thenApply(v -> {
+                // I O.println("DSP: consumerReady.await().thenAccept(" + v + ", " + item + ")");
+                incoming = item;
+                producerReady.ready().complete(true);
+                return v;
+            });
+        }
+
+        CompletionStage<Void> error(Throwable t) {
+            // I O.println("DispatchStreamer.error(" + t + ") // <-------------------------");
+            return consumerReady.await().thenAccept(_ -> {
+                if (t != null) {
+                    producerReady.ready().completeExceptionally(t);
+                } else {
+                    producerReady.ready().complete(false);
+                }
+            });
+        }
+
+        @Override
+        public void dispose() {
+            // I O.println("DispatchStreamer.dispose()");
+            disposed = true;
+            if (parent.remove(this)) {
+                var ce = new CancellationException();
+                producerReady.ready().completeExceptionally(ce);
+            }
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed;
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
+++ b/src/main/java/io/reactivex/rxjava4/subscribers/TestSubscriber.java
@@ -14,9 +14,8 @@
 package io.reactivex.rxjava4.subscribers;
 
 import java.util.Objects;
+import java.util.concurrent.Flow.*;
 import java.util.concurrent.atomic.*;
-
-import static java.util.concurrent.Flow.*;
 
 import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.FlowableSubscriber;
@@ -127,28 +126,32 @@ implements FlowableSubscriber<T>, Subscription {
 
     @Override
     public void onSubscribe(@NonNull Subscription s) {
-        lastThread = Thread.currentThread();
+        try {
+            lastThread = Thread.currentThread();
 
-        if (s == null) {
-            errors.add(new NullPointerException("onSubscribe received a null Subscription"));
-            return;
-        }
-        if (!upstream.compareAndSet(null, s)) {
-            s.cancel();
-            if (upstream.get() != SubscriptionHelper.CANCELLED) {
-                errors.add(new IllegalStateException("onSubscribe received multiple subscriptions: " + s));
+            if (s == null) {
+                errors.add(new NullPointerException("onSubscribe received a null Subscription"));
+                return;
             }
-            return;
+            if (!upstream.compareAndSet(null, s)) {
+                s.cancel();
+                if (upstream.get() != SubscriptionHelper.CANCELLED) {
+                    errors.add(new IllegalStateException("onSubscribe received multiple subscriptions: " + s));
+                }
+                return;
+            }
+
+            downstream.onSubscribe(s);
+
+            long mr = missedRequested.getAndSet(0L);
+            if (mr != 0L) {
+                s.request(mr);
+            }
+
+            onStart();
+        } finally {
+            onSubscribeReady.countDown();
         }
-
-        downstream.onSubscribe(s);
-
-        long mr = missedRequested.getAndSet(0L);
-        if (mr != 0L) {
-            s.request(mr);
-        }
-
-        onStart();
     }
 
     /**

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/DispatchStreamProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/DispatchStreamProcessorTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.*;
 
 import org.junit.jupiter.api.Test;
 
+import io.reactivex.rxjava4.disposables.*;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.processors.DispatchStreamProcessor;
 import io.reactivex.rxjava4.subscribers.TestSubscriber;
@@ -480,5 +481,29 @@ public class DispatchStreamProcessorTest extends StreamableBaseTest {
         assertFalse(dsp.hasComplete(), "dsp has completed?");
         assertFalse(dsp.hasThrowable(), "dsp has throwable?");
         assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void isDisposed() {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        var str = dsp.stream(new CompositeDisposable());
+
+        assertTrue(str instanceof Disposable, "Does not implement disposable?");
+
+        var d = (Disposable)str;
+
+        assertFalse(d.isDisposed());
+        assertTrue(dsp.hasStreamers());
+
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+        assertFalse(dsp.hasStreamers());
+
+        d.dispose();
+
+        assertTrue(d.isDisposed());
+        assertFalse(dsp.hasStreamers());
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/DispatchStreamProcessorTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/DispatchStreamProcessorTest.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.processors.DispatchStreamProcessor;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+public class DispatchStreamProcessorTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            Thread.sleep(1);
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+        }
+
+        for (int i = 1; i < 6; i++) {
+            dsp.next(i).toCompletableFuture().join();
+        }
+        dsp.finish(null).toCompletableFuture().join();
+
+        ts.awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertTrue(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void endsInError() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            Thread.sleep(1);
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+        }
+
+        for (int i = 1; i < 6; i++) {
+            dsp.next(i).toCompletableFuture().join();
+        }
+        var te = new TestException();
+        dsp.finish(te).toCompletableFuture().join();
+
+        ts.awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class, 1, 2, 3, 4, 5);
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertTrue(dsp.hasThrowable(), "dsp has no throwable?");
+        assertSame(te, dsp.getThrowable(), "dsp has the wrong throwable?");
+    }
+
+    @Test
+    public void normalDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            var dsp = new DispatchStreamProcessor<Integer>();
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertFalse(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+            var ts = dsp.intercept(debugIntercept()).test(exec);
+
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+            int timeout = 1000;
+            while (!dsp.hasStreamers()) {
+                Thread.sleep(1);
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+            }
+
+            assertTrue(dsp.hasStreamers(), "dsp has no streamers?");
+
+            for (int i = 1; i < 6; i++) {
+                dsp.next(i).toCompletableFuture().join();
+            }
+            dsp.finish(null).toCompletableFuture().join();
+
+            ts.awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3, 4, 5);
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertTrue(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+        });
+    }
+
+    @Test
+    public void alreadyCompleted() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        dsp.finish(null);
+
+        dsp.test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertTrue(dsp.hasComplete(), "dsp has not completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void alreadyFailed() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var te = new TestException();
+        dsp.finish(te);
+
+        dsp.test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertTrue(dsp.hasThrowable(), "dsp has no throwable?");
+        assertSame(te, dsp.getThrowable(), "dsp has a different throwable?");
+    }
+
+    @Test
+    public void normalTake3AltDebug() throws Throwable {
+        withCachedExecutor(exec -> {
+            var dsp = new DispatchStreamProcessor<Integer>();
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertFalse(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+            var ts = dsp.take(3).intercept(debugIntercept()).test(exec);
+
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+            int timeout = 1000;
+            while (!dsp.hasStreamers()) {
+                Thread.sleep(1);
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+            }
+
+            for (int i = 1; i < 4; i++) {
+                IO.println(i + " -> next");
+                dsp.next(i).toCompletableFuture().join();
+            }
+
+            timeout = 1000;
+            while (dsp.hasStreamers()) {
+                Thread.sleep(1);
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+            }
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+
+            for (int i = 4; i < 6; i++) {
+                IO.println(i + " -> next");
+                dsp.next(i).toCompletableFuture().join();
+            }
+
+            IO.println("() -> finish");
+            dsp.finish(null).toCompletableFuture().join();
+
+            IO.println("awaitDone");
+            ts.awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3);
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertTrue(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+        });
+    }
+
+    @Test
+    public void normalTake3Debug() throws Throwable {
+        withCachedExecutor(exec -> {
+            var dsp = new DispatchStreamProcessor<Integer>();
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertFalse(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+            var ts = dsp.take(3).test(exec);
+
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+            int timeout = 1000;
+            while (!dsp.hasStreamers()) {
+                Thread.sleep(1);
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+            }
+
+            for (int i = 1; i < 6; i++) {
+                dsp.next(i).toCompletableFuture().join();
+            }
+
+            IO.println("() -> finish");
+            dsp.finish(null).toCompletableFuture().join();
+
+            IO.println("awaitDone");
+            ts.awaitDone(5, TimeUnit.SECONDS)
+            .assertResult(1, 2, 3);
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertTrue(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+        });
+    }
+
+    @Test
+    public void normalMulti() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+        var ts2 = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+        ts2.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            Thread.sleep(1);
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+        }
+
+        for (int i = 1; i < 6; i++) {
+            dsp.next(i).toCompletableFuture().join();
+        }
+        dsp.finish(null).toCompletableFuture().join();
+
+        ts.awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        ts2.awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertTrue(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void normalMultiOtherCancels() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+        var ts2 = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+        ts2.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            Thread.sleep(1);
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+        }
+
+        ts2.cancel();
+
+        for (int i = 1; i < 6; i++) {
+            dsp.next(i).toCompletableFuture().join();
+        }
+        dsp.finish(null).toCompletableFuture().join();
+
+        ts.awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        ts2.assertEmpty();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertTrue(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void normalMultiFirstCancels() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+        var ts2 = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+        ts2.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            Thread.sleep(1);
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+        }
+
+        ts.cancel();
+
+        for (int i = 1; i < 6; i++) {
+            dsp.next(i).toCompletableFuture().join();
+        }
+        dsp.finish(null).toCompletableFuture().join();
+
+        ts2.awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+
+        ts.assertEmpty();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertTrue(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+
+    @Test
+    public void raceToStream() throws Throwable {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            var dsp = new DispatchStreamProcessor<Integer>();
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertFalse(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+            var ts = new TestSubscriber<>();
+            var ts2 = new TestSubscriber<>();
+
+            Runnable r1 = () -> dsp.subscribe(ts);
+            Runnable r2 = () -> dsp.subscribe(ts2);
+
+            TestHelper.race(r1, r2);
+
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+            ts2.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+            int timeout = 1000;
+            while (!dsp.hasStreamers()) {
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+                Thread.sleep(0, 1000);
+            }
+
+            ts.cancel();
+            ts2.cancel();
+
+            timeout = 1000;
+            while (dsp.hasStreamers()) {
+                if (timeout-- < 0) {
+                    throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+                }
+                Thread.sleep(0, 1000);
+            }
+
+            assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+            assertFalse(dsp.hasComplete(), "dsp has completed?");
+            assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+            assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+        }
+    }
+
+    @Test
+    public void comeAndGo() throws Throwable {
+        var dsp = new DispatchStreamProcessor<Integer>();
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+
+        var ts = dsp.test();
+
+        ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        int timeout = 1000;
+        while (!dsp.hasStreamers()) {
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+            Thread.sleep(1);
+        }
+
+        ts.cancel();
+
+        timeout = 1000;
+        while (dsp.hasStreamers()) {
+            if (timeout-- < 0) {
+                throw new TimeoutException("hasStreamers = " + dsp.hasStreamers());
+            }
+            Thread.sleep(1);
+        }
+
+        assertFalse(dsp.hasStreamers(), "dsp has streamers?");
+        assertFalse(dsp.hasComplete(), "dsp has completed?");
+        assertFalse(dsp.hasThrowable(), "dsp has throwable?");
+        assertNull(dsp.getThrowable(), "dsp has a non-null throwable?");
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
@@ -15,10 +15,12 @@ package io.reactivex.rxjava4.internal.operators.streamable;
 
 import java.lang.ref.Cleaner;
 import java.util.*;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.*;
 
 import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.core.config.StreamableInterceptConfig;
 import io.reactivex.rxjava4.exceptions.CompositeException;
 import io.reactivex.rxjava4.functions.Consumer;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
@@ -69,5 +71,38 @@ public abstract class StreamableBaseTest extends RxJavaTest {
 
     protected final void setUndeliverablesExpected(boolean isExpected) {
         undeliverablesExpected = isExpected;
+    }
+
+    static final BiConsumer<Object, Throwable> DEBUG_WHEN_COMPLETE_NEXT = (v, e) -> {
+        if (e != null) {
+            IO.println("OnError  : " + e.toString());
+            e.printStackTrace(System.out);
+        } else {
+            IO.println("OnNext   : " + v);
+        }
+    };
+    static final BiConsumer<Object, Throwable> DEBUG_WHEN_COMPLETE_FINISH = (v, e) -> {
+        if (e != null) {
+            IO.println("OnFinish : " + e.toString());
+            e.printStackTrace(System.out);
+        } else {
+            IO.println("OnFinish : " + v);
+        }
+    };
+
+    static final StreamableInterceptConfig<Object> DEBUG_INTERCEPT = new StreamableInterceptConfig<>(
+            (_, v) -> { IO.println("OnStream"); return v; },
+            (_, v) -> { IO.println("OnNext"); return v.whenComplete(DEBUG_WHEN_COMPLETE_NEXT); },
+            (v)    -> { IO.println("OnCurrent: " + v); return v; },
+            (_, v) -> { IO.println("OnFinish"); return v.whenComplete(DEBUG_WHEN_COMPLETE_FINISH); }
+    );
+
+    /**
+     * An intercept config that prints out the lifecycle events, values and completion signals.
+     * @return the type-appropriate {@link StreamableInterceptConfig}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> StreamableInterceptConfig<T> debugIntercept() {
+        return (StreamableInterceptConfig<T>)DEBUG_INTERCEPT;
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisherTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFromPublisherTest.java
@@ -77,11 +77,9 @@ public class StreamableFromPublisherTest extends StreamableBaseTest {
             var ts = pp.toStreamable(exec)
             .test(exec);
 
-            IO.println("hasSubscription()");
+            IO.println("awaitOnSubscribe()");
 
-            while (!ts.hasSubscription()) {
-                Thread.sleep(1);
-            }
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
 
             IO.println("hasSubscribers()");
 
@@ -113,11 +111,9 @@ public class StreamableFromPublisherTest extends StreamableBaseTest {
             var ts = pp.toStreamable(exec)
             .test(exec);
 
-            IO.println("hasSubscription()");
+            IO.println("awaitOnSubscribe()");
 
-            while (!ts.hasSubscription()) {
-                Thread.sleep(1);
-            }
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
 
             IO.println("hasSubscribers()");
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableGroupByTest.java
@@ -231,15 +231,9 @@ public class StreamableGroupByTest extends StreamableBaseTest {
             })
             .test(exec);
 
-            int n = 1000;
-            while (!ts.hasSubscription()) {
-                Thread.sleep(1);
-                if (n-- < 0) {
-                    throw new TimeoutException("hasSubscription");
-                }
-            }
+            ts.awaitOnSubscribe(1, TimeUnit.SECONDS);
 
-            n = 1000;
+            int n = 1000;
             while (!pp.hasSubscribers()) {
                 Thread.sleep(1);
                 if (n-- < 0) {

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelperTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableHelperTest.java
@@ -15,10 +15,12 @@ package io.reactivex.rxjava4.internal.operators.streamable;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
 import java.util.concurrent.*;
 
 import org.junit.jupiter.api.Test;
 
+import io.reactivex.rxjava4.core.Streamer;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -45,5 +47,69 @@ public class StreamableHelperTest extends StreamableBaseTest {
         assertTrue(StreamableHelper.isCancellation(new CompletionException(new CancellationException())), "complete-cancel");
         assertTrue(StreamableHelper.isCancellation(new CancellationException()), "cancel");
         assertFalse(StreamableHelper.isCancellation(new CompletionException(new TestException())), "complete-test");
+    }
+
+    @Test
+    public void awaitAllVoidEmpty() {
+        assertSame(Streamer.FINISHED, StreamableHelper.awaitAllVoid(List.of()));
+    }
+
+    @Test
+    public void awaitAllBooleanEmpty() {
+        assertSame(Streamer.NEXT_FALSE, StreamableHelper.awaitAllBoolean(List.of()));
+    }
+
+    @Test
+    public void awaitAllVoidError() {
+        assertThrows(TestException.class, () -> {
+            try {
+                StreamableHelper.awaitAllVoid(List.of(CompletableFuture.failedFuture(new TestException())))
+                .toCompletableFuture().join();
+            } catch (CompletionException ex) {
+                throw ex.getCause();
+            }
+        });
+    }
+
+    @Test
+    public void awaitAllVoidErrorCancel() {
+        StreamableHelper.awaitAllVoid(List.of(CompletableFuture.failedFuture(new CancellationException())))
+        .toCompletableFuture().join();
+    }
+
+    @Test
+    public void awaitAllBooleanError() {
+        assertThrows(TestException.class, () -> {
+            try {
+                StreamableHelper.awaitAllBoolean(List.of(CompletableFuture.failedFuture(new TestException())))
+                .toCompletableFuture().join();
+            } catch (CompletionException ex) {
+                throw ex.getCause();
+            }
+        });
+    }
+
+    @Test
+    public void awaitAllBooleanErrorCancel() {
+        StreamableHelper.awaitAllBoolean(List.of(CompletableFuture.failedFuture(new CancellationException())))
+        .toCompletableFuture().join();
+    }
+
+    @Test
+    public void awaitAllBooleanAllTrue() {
+        assertTrue(StreamableHelper.awaitAllBoolean(List.of(Streamer.NEXT_TRUE, Streamer.NEXT_TRUE)).join(), "should have been true");
+    }
+
+    @Test
+    public void awaitAllBooleanAllFalse() {
+        assertFalse(StreamableHelper.awaitAllBoolean(List.of(Streamer.NEXT_FALSE, Streamer.NEXT_FALSE)).join(), "should have been false");
+    }
+
+    @Test
+    public void awaitAllBooleanMixed() {
+        assertFalse(StreamableHelper.awaitAllBoolean(List.of(Streamer.NEXT_TRUE, Streamer.NEXT_FALSE)).join(),
+                "should have been (true, false) -> false");
+        assertFalse(StreamableHelper.awaitAllBoolean(List.of(Streamer.NEXT_FALSE, Streamer.NEXT_TRUE)).join(),
+                "should have been (false, true) -> false");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableToObservableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableToObservableTest.java
@@ -80,7 +80,7 @@ public class StreamableToObservableTest extends StreamableBaseTest {
     @Test
     public void subject() throws Throwable {
         var pp = PublishProcessor.create();
-        var ts = pp.toStreamable()
+        var to = pp.toStreamable()
         .toObservable()
         .test();
 
@@ -88,11 +88,9 @@ public class StreamableToObservableTest extends StreamableBaseTest {
             Thread.sleep(1);
         }
 
-        while (!ts.hasSubscription()) {
-            Thread.sleep(1);
-        }
+        to.awaitOnSubscribe(1, TimeUnit.SECONDS);
 
-        ts.dispose();
+        to.dispose();
 
         while (pp.hasSubscribers()) {
             Thread.sleep(1);

--- a/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
+++ b/src/test/java/io/reactivex/rxjava4/subscribers/TestSubscriberTest.java
@@ -18,8 +18,8 @@ import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.concurrent.Flow.*;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
@@ -1666,7 +1666,7 @@ public class TestSubscriberTest extends RxJavaTest {
     public void awaitCountTimeout() {
         TestSubscriber<Integer> ts = new TestSubscriber<>();
         ts.onSubscribe(new BooleanSubscription());
-        ts.awaitCount(1);
+        ts.awaitCount(1, 10, 1);
         assertTrue(ts.isTimeout());
     }
 
@@ -1718,5 +1718,45 @@ public class TestSubscriberTest extends RxJavaTest {
         ts.onComplete();
 
         assertEquals("TestSubscriber (latch = 0, values = 3, errors = 0, completions = 1)", ts.toString());
+    }
+
+    @Test
+    public void awaitOnSubscribeSuccess() throws Throwable {
+        var ts = new TestSubscriber<>();
+
+        assertFalse(ts.hasSubscription(), "TestSubscriber has a subscription?");
+
+        ts.onSubscribe(new BooleanSubscription());
+
+        assertTrue(ts.hasSubscription(), "TestSubscriber has no subscription?");
+
+        ts.awaitOnSubscribe(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void awaitOnSubscribeTimeout() throws Throwable {
+        assertThrows(TimeoutException.class, () -> {
+            var ts = new TestSubscriber<>();
+
+            assertFalse(ts.hasSubscription(), "TestSubscriber has a subscription?");
+
+            ts.awaitOnSubscribe(10, TimeUnit.MILLISECONDS);
+        });
+    }
+
+    @Test
+    public void awaitOnSubscribeInterrupted() throws Throwable {
+        assertThrows(InterruptedException.class, () -> {
+            var ts = new TestSubscriber<>();
+
+            assertFalse(ts.hasSubscription(), "TestSubscriber has a subscription?");
+
+            var thread = Thread.currentThread();
+
+            CompletableFuture.runAsync(() -> { thread.interrupt(); },
+                    CompletableFuture.delayedExecutor(10, TimeUnit.MILLISECONDS));
+
+            ts.awaitOnSubscribe(10, TimeUnit.SECONDS);
+        });
     }
 }


### PR DESCRIPTION
# New types

## `StreamerInput`

Represents an awaitable push side of signaling items and terminal states.

ℹ️ We might rename this to `StreamObserver` or `StreamSubscriber`?

## `StreamProcessor`

Combines a `Streamable` and a `StreamerInput` to provide a similar interface to `Subject` and `Flow.Processor`s for the `Streamable` world.

## `DispatchStreamProcessor`

A publishing / multicasting processor where pushing events have to be awaited until they go through to all current `Streamer`s (or fall through if there are none).

# Test API improvements

## `TestSubscriber` / `TestObserver` + `awaitOnSubscribe`

Created a latched await for receiving `onSubscribe` events because in the `Streamable` world, `subscribe` and `test` run on a background thread and thus the whole lifecycle is shifted in time. This call will make sure the upstream reached a point where it called `onSubscribe`.

Tests updated accordingly.

## `TestSubscriber` / `TestObserver` + `awaitCount(int atLeast, long timeoutMillis, long sleepMillis)`

The plain `awaitCount(int atLeast)` was introduced a while ago with predefined 5000 milliseconds timeout and 10 sleeps. This overload makes the times configurable for faster test execution, especially if the call was supposed to fail.

# Bugfixes

- `Streamable.subscribe(Subscriber)` did not properly wire up the cancellation mechanisms.