### PR TITLE
4.x: Streamable +blockingFirst, last[OrError], skip, Single.flattenAsStreamable

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Completable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Completable.java
@@ -3228,6 +3228,8 @@ public abstract class Completable implements CompletableSource {
      * <p>
      * <img width="640" height="293" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Completable.toStreamable.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Streamable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toStreamable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
@@ -3236,6 +3238,7 @@ public abstract class Completable implements CompletableSource {
      * @since 4.0.0
      */
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
     @CheckReturnValue
     @NonNull
     public final <@NonNull T> Streamable<T> toStreamable() {

--- a/src/main/java/io/reactivex/rxjava4/core/Maybe.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Maybe.java
@@ -3896,14 +3896,17 @@ public abstract class Maybe<@NonNull T> implements MaybeSource<T> {
      * <p>
      * <img width="640" height="346" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Maybe.toStreamable.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Streamable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toStreamable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new {@code Streamable} instance
      * @since 4.0.0
      */
-    @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    @CheckReturnValue
     @NonNull
     public final Streamable<T> toStreamable() {
         return RxJavaPlugins.onAssembly(new StreamableFromMaybe<>(this));

--- a/src/main/java/io/reactivex/rxjava4/core/Single.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Single.java
@@ -33,7 +33,7 @@ import io.reactivex.rxjava4.internal.operators.maybe.*;
 import io.reactivex.rxjava4.internal.operators.mixed.*;
 import io.reactivex.rxjava4.internal.operators.observable.ObservableSingleSingle;
 import io.reactivex.rxjava4.internal.operators.single.*;
-import io.reactivex.rxjava4.internal.operators.streamable.StreamableFromSingle;
+import io.reactivex.rxjava4.internal.operators.streamable.*;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.*;
@@ -2977,6 +2977,37 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
     }
 
     /**
+     * Maps the success value of the current {@code Single} into an {@link Iterable} and emits its items as a
+     * {@link Streamable} sequence.
+     * <p>
+     * <img width="640" height="373" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/flattenAsStreamable.png" alt="">
+     * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The operator honors backpressure from downstream.</dd>
+     *  <dt><b>Scheduler:</b></dt>
+     *  <dd>{@code flattenAsStreamable} does not operate by default on a particular {@link Scheduler}.</dd>
+     * </dl>
+     *
+     * @param <U>
+     *            the type of item emitted by the resulting {@code Iterable}
+     * @param mapper
+     *            a function that returns an {@code Iterable} sequence of values for when given an item emitted by the
+     *            current {@code Single}
+     * @return the new {@code Streamable} instance
+     * @throws NullPointerException if {@code mapper} is {@code null}
+     * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+     * @since 4.0.0
+     */
+    @BackpressureSupport(BackpressureKind.FULL)
+    @CheckReturnValue
+    @NonNull
+    @SchedulerSupport(SchedulerSupport.NONE)
+    public final <@NonNull U> Streamable<U> flattenAsStreamable(@NonNull Function<? super T, @NonNull ? extends Iterable<? extends U>> mapper) {
+        Objects.requireNonNull(mapper, "mapper is null");
+        return RxJavaPlugins.onAssembly(new StreamableSingleFlattenAs<>(this, mapper));
+    }
+
+    /**
      * Returns an {@link Observable} that is based on applying a specified function to the item emitted by the current {@code Single},
      * where that function returns an {@link ObservableSource}.
      * <p>
@@ -4894,14 +4925,17 @@ public abstract class Single<@NonNull T> implements SingleSource<T> {
      * <p>
      * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/Single.toStreamable.v3.png" alt="">
      * <dl>
+     *  <dt><b>Backpressure:</b></dt>
+     *  <dd>The returned {@code Streamable} honors the backpressure of the downstream consumer.</dd>
      *  <dt><b>Scheduler:</b></dt>
      *  <dd>{@code toStreamable} does not operate by default on a particular {@link Scheduler}.</dd>
      * </dl>
      * @return the new {@code Streamable} instance
      * @since 4.0.0
      */
-    @CheckReturnValue
     @SchedulerSupport(SchedulerSupport.NONE)
+    @BackpressureSupport(BackpressureKind.FULL)
+    @CheckReturnValue
     @NonNull
     public final Streamable<T> toStreamable() {
         return RxJavaPlugins.onAssembly(new StreamableFromSingle<>(this));

--- a/src/main/java/io/reactivex/rxjava4/core/Streamable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Streamable.java
@@ -612,6 +612,19 @@ public interface Streamable<@NonNull T> {
     // oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo
 
     /**
+     * Blocks the current thread until this {@code Streamable} produces one item, which is then returned
+     * @return the first item of this {@code Streamable}
+     * @throws NoSuchElementException if the this {@code Streamable} is empty
+     * @throws CancellationException if this {@code Streamable} failed with a checked exception
+     * @throws RuntimeException if this {@code Streamable} failed with an unchecked exception
+     */
+    @CheckReturnValue
+    @NonNull
+    default T blockingFirst() {
+        return StreamableBlocking.blockingFirst(this);
+    }
+
+    /**
      * Collects all upstream values via the use of a {@link Collector} configuration
      * and emits its resulting value as a single item of the returned {@code Streamable}.
      * <p>
@@ -733,6 +746,33 @@ public interface Streamable<@NonNull T> {
     }
 
     /**
+     * Signals the last item from the upstream {@code Streamable} or
+     * the provided {@code defaultItem} if the upstream is empty, as a
+     * {@link Single} instance.
+     * @param defaultItem the item to signal if the upstream turns out to be empty
+     * @return the new {@code Single} instance
+     * @throws NullPointerException if {@code defaultItem} is {@code null}
+     */
+    @CheckReturnValue
+    @NonNull
+    default Single<T> last(@NonNull T defaultItem) {
+        Objects.requireNonNull(defaultItem, "defaultItem is null");
+        return RxJavaPlugins.onAssembly(new StreamableLastAsSingle<>(this, defaultItem));
+    }
+
+    /**
+     * Signals the last item from the upstream {@code Streamable} or a
+     * {@link NoSuchElementException} if the upstream is empty, as a
+     * {@link Single} instance.
+     * @return the new {@code Single} instance
+     */
+    @CheckReturnValue
+    @NonNull
+    default Single<T> lastOrError() {
+        return RxJavaPlugins.onAssembly(new StreamableLastAsSingle<>(this, null));
+    }
+
+    /**
      * <strong>This method requires advanced knowledge about building operators, please consider
      * other standard composition methods first;</strong>
      * Returns a {@code Streamable} instance which when its {@link #stream(StreamerCancellation)} is invoked,
@@ -799,6 +839,21 @@ public interface Streamable<@NonNull T> {
     default Streamable<T> onErrorResumeNext(@NonNull Function<? super Throwable, ? extends Streamable<? extends T>> fallbackMapper) {
         Objects.requireNonNull(fallbackMapper, "fallbackMapper is null");
         return RxJavaPlugins.onAssembly(new StreamableOnErrorResumeNext<>(this, fallbackMapper));
+    }
+
+    /**
+     * Skips the first {@code count} items and relays the rest to the downstream.
+     * @param count the number of items to skip
+     * @return the new {@Streamable} instance
+     * @throws IllegalArgumentException if {@code count} is negative
+     */
+    @CheckReturnValue
+    @NonNull
+    default Streamable<T> skip(long count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count >= 0 expected but it was " + count);
+        }
+        return RxJavaPlugins.onAssembly(new StreamableSkip<>(this, count));
     }
 
     /**

--- a/src/main/java/io/reactivex/rxjava4/internal/disposables/DisposableOnly.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/disposables/DisposableOnly.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.disposables;
+
+import io.reactivex.rxjava4.disposables.Disposable;
+
+/**
+ * An extension to {@link Disposable} that allows not
+ * implementing the {@link Disposable#isDisposed()} as it
+ * is practically never needed or cannot be observed anyways.
+ * @since 4.0.0
+ */
+public interface DisposableOnly extends Disposable {
+
+    @Override
+    default boolean isDisposed() {
+        throw new UnsupportedOperationException("The class " + this.getClass() + " does not support isDisposed");
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StageResumable.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StageResumable.java
@@ -25,6 +25,7 @@ import io.reactivex.rxjava4.annotations.*;
  * one use/thread can signal {@link #ready()} to wake up another use/thread
  * on a {@link #await()} call.
  * @param <T> the element type of the notification pass-around
+ * @since 4.0.0
  */
 public final class StageResumable<T> extends AtomicReference<CompletableFuture<T>>
 implements BiConsumer<T, Throwable> {
@@ -32,6 +33,13 @@ implements BiConsumer<T, Throwable> {
     @Serial
     private static final long serialVersionUID = -7518852864146380895L;
 
+    /**
+     * When the producer has arranged the item transfer via some field or queue,
+     * call this method and call {@link CompletableFuture#complete(Object)}
+     * or {@link CompletableFuture#completeExceptionally(Throwable)} to
+     * signal resumption for any current or upcoming {@link #await()} caller.
+     * @return the {@code CompletableFuture} to complete in some way
+     */
     @CheckReturnValue
     @NonNull
     public CompletableFuture<T> ready() {
@@ -49,6 +57,12 @@ implements BiConsumer<T, Throwable> {
         return cf;
     }
 
+    /**
+     * When the consumer is ready to receive an item, call this method
+     * and apply a continuation function, such as {@link CompletableFuture#whenComplete(BiConsumer)}
+     * to it to handle the signal and process any external data made ready.
+     * @return the {@code CompletableFuture} to observe a completion value or exception
+     */
     @CheckReturnValue
     @NonNull
     public CompletableFuture<T> await() {
@@ -66,6 +80,10 @@ implements BiConsumer<T, Throwable> {
         return cf.whenComplete(this);
     }
 
+    /// Used to clear any waiting [CompletableFuture] when the await finishes
+    /// no concern to users and should not be called.
+    /// @param t the completion value if any, ignored
+    /// @param u the exception if any, ignored
     @Override
     public void accept(T t, Throwable u) {
         getAndSet(null);

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBlocking.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBlocking.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionException;
+
+import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.disposables.CompositeDisposable;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.internal.util.ExceptionHelper;
+
+public record StreamableBlocking() {
+
+    /**
+     * Consumes the first item and finishes the {@link Streamable},
+     * throwing {@link NoSuchElementException} if the source is empty.
+     * @param <T> the element type
+     * @param source the source {@code Streamable}
+     * @return the first item
+     * @throws RuntimeException if the source signals an unchecked exception
+     * @throws CompletionException if the source signals a checked exception
+     */
+    @CheckReturnValue
+    @NonNull
+    public static <T> T blockingFirst(Streamable<T> source) {
+        var streamer = source.stream(new CompositeDisposable());
+        Throwable nextException = null;
+        Throwable finishException = null;
+        T result = null;
+        try {
+            if (streamer.awaitNext()) {
+                result = streamer.current();
+            }
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            nextException = ex;
+        }
+        try {
+            streamer.awaitFinish();
+        } catch (Throwable ex) {
+            Exceptions.throwIfFatal(ex);
+            finishException = ex;
+        }
+
+        if (nextException != null || finishException != null) {
+            throw ExceptionHelper.wrapOrThrow(ExceptionHelper.unwrapAndCombine(nextException, finishException));
+        }
+        if (result == null) {
+            throw new NoSuchElementException();
+        }
+        return result;
+    }
+
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableLastAsSingle.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableLastAsSingle.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.io.Serial;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava4.annotations.*;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.internal.disposables.DisposableOnly;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamStreamableSource;
+import io.reactivex.rxjava4.internal.util.ExceptionHelper;
+
+public final class StreamableLastAsSingle<T>
+extends Single<T> implements HasUpstreamStreamableSource<T> {
+
+    final Streamable<T> source;
+
+    final T defaultItem;
+
+    public StreamableLastAsSingle(@Nullable Streamable<T> source, @Nullable T defaultItem) {
+        this.source = source;
+        this.defaultItem = defaultItem;
+    }
+
+    @Override
+    public @NonNull Streamable<@NonNull T> source() {
+        return source;
+    }
+
+    @Override
+    protected void subscribeActual(@NonNull SingleObserver<? super @NonNull T> observer) {
+        var cancellation = new CompositeDisposable();
+        var drainer = new LastStreamer<>(observer, defaultItem, cancellation);
+        observer.onSubscribe(drainer);
+        drainer.upstream = source.stream(cancellation);
+        drainer.drain();
+    }
+
+    static final class LastStreamer<T>
+    extends AtomicInteger
+    implements BiConsumer<Object, Throwable>, DisposableOnly {
+
+        @Serial
+        private static final long serialVersionUID = 2423155860070143815L;
+
+        final SingleObserver<? super T> downstream;
+
+        final DisposableStreamerCancellation cancellation;
+
+        final T defaultItem;
+
+        Streamer<T> upstream;
+
+        T current;
+
+        Throwable nextFailure;
+
+        volatile boolean done;
+
+        LastStreamer(
+                SingleObserver<? super T> downstream,
+                T defaultItem,
+                DisposableStreamerCancellation cancellation) {
+            this.downstream = downstream;
+            this.defaultItem = defaultItem;
+            this.cancellation = cancellation;
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+
+            do {
+                if (done) {
+                    upstream.finish().whenComplete(this);
+                    break;
+                } else {
+                    upstream.next().whenComplete(this);
+                }
+            } while (decrementAndGet() != 0);
+        }
+
+        @Override
+        public void accept(Object t, Throwable u) {
+            if (done) {
+                if (u != null || nextFailure != null) {
+                    downstream.onError(ExceptionHelper.unwrapAndCombine(nextFailure, u));
+                } else {
+                    if (current == null) {
+                        if (defaultItem != null) {
+                            downstream.onSuccess(defaultItem);
+                        } else {
+                            downstream.onError(new NoSuchElementException());
+                        }
+                    } else {
+                        downstream.onSuccess(current);
+                    }
+                }
+            } else {
+                if (u != null) {
+                    nextFailure = u;
+                    done = true;
+                    drain();
+                } else {
+                    if ((Boolean)t) {
+                        current = upstream.current();
+                    } else {
+                        done = true;
+                    }
+                    drain();
+                }
+            }
+        }
+
+        @Override
+        public void dispose() {
+            cancellation.dispose();
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSingleFlattenAs.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSingleFlattenAs.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.io.Serial;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.*;
+import io.reactivex.rxjava4.exceptions.Exceptions;
+import io.reactivex.rxjava4.functions.Function;
+import io.reactivex.rxjava4.internal.disposables.*;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamSingleSource;
+
+public record StreamableSingleFlattenAs<T, U>(
+        SingleSource<T> source,
+        Function<? super T, @NonNull ? extends Iterable<? extends U>> mapper
+) implements Streamable<U>, HasUpstreamSingleSource<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull U> stream(@NonNull StreamerCancellation cancellation) {
+        var observer = new FlattenAsSingleObserver<>(mapper, cancellation);
+        cancellation.add(observer);
+        source.subscribe(observer);
+        return observer;
+    }
+
+    static final class FlattenAsSingleObserver<T, U>
+    extends AtomicInteger
+    implements SingleObserver<T>, Streamer<U>, DisposableOnly, java.util.function.Function<Boolean, Boolean> {
+
+        @Serial
+        private static final long serialVersionUID = 796267562672678347L;
+
+        final StreamerCancellation cancellation;
+
+        final Function<? super T, @NonNull ? extends Iterable<? extends U>> mapper;
+
+        final SequentialDisposable upstream;
+
+        final CompletableFuture<Boolean> iteratorReady;
+
+        volatile Iterator<? extends U> iteratorHandover;
+
+        U current;
+
+        Iterator<? extends U> currentIterator;
+
+        FlattenAsSingleObserver(
+                Function<? super T, @NonNull ? extends Iterable<? extends U>> mapper,
+                StreamerCancellation cancellation) {
+            this.cancellation = cancellation;
+            this.mapper = mapper;
+            this.iteratorReady = new CompletableFuture<>();
+            this.upstream = new SequentialDisposable();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            var it = currentIterator;
+            if (it == null) {
+                return iteratorReady.thenApply(this);
+            }
+            if (it.hasNext()) {
+                current = it.next();
+                return NEXT_TRUE;
+            }
+            return NEXT_FALSE;
+        }
+
+        @Override
+        public Boolean apply(Boolean t) {
+            if (t) {
+                currentIterator = iteratorHandover;
+                iteratorHandover = null;
+                return true;
+            } else {
+                currentIterator = null;
+                iteratorHandover = null;
+            }
+            return false;
+        }
+
+        @Override
+        public @NonNull U current() {
+            return current;
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            currentIterator = null;
+            DisposableHelper.dispose(upstream);
+            return FINISHED;
+        }
+
+        @Override
+        public void dispose() {
+            DisposableHelper.dispose(upstream);
+            iteratorReady.completeExceptionally(new CancellationException());
+        }
+
+        @Override
+        public void onSubscribe(@NonNull Disposable d) {
+            DisposableHelper.setOnce(upstream, d);
+        }
+
+        @Override
+        public void onSuccess(@NonNull T t) {
+            try {
+                var iterator = Objects.requireNonNull(mapper.apply(t), "The mapper returned a null Iterable").iterator();
+                this.iteratorHandover = iterator;
+                if (iterator.hasNext()) {
+                    current = iterator.next();
+                    iteratorReady.complete(true);
+                } else {
+                    iteratorReady.complete(false);
+                }
+            } catch (Throwable ex) {
+                Exceptions.throwIfFatal(ex);
+                upstream.lazySet(DisposableHelper.DISPOSED);
+                iteratorReady.completeExceptionally(ex);
+                return;
+            }
+        }
+
+        @Override
+        public void onError(@NonNull Throwable e) {
+            upstream.lazySet(DisposableHelper.DISPOSED);
+            iteratorReady.completeExceptionally(e);
+        }
+    }
+}

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSkip.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSkip.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.io.Serial;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import io.reactivex.rxjava4.annotations.NonNull;
+import io.reactivex.rxjava4.core.*;
+import io.reactivex.rxjava4.disposables.StreamerCancellation;
+
+public record StreamableSkip<T>(Streamable<T> source, long count) implements Streamable<T> {
+
+    @Override
+    public @NonNull Streamer<@NonNull T> stream(@NonNull StreamerCancellation cancellation) {
+        return new SkipStreamer<>(source.stream(cancellation), count);
+    }
+
+    static final class SkipStreamer<T> extends AtomicInteger implements Streamer<T>, BiConsumer<Boolean, Throwable> {
+
+        @Serial
+        private static final long serialVersionUID = 1988154737845167665L;
+
+        final Streamer<T> upstream;
+
+        long remaining;
+
+        CompletableFuture<Boolean> waiter;
+
+        SkipStreamer(Streamer<T> upstream, long count) {
+            this.upstream = upstream;
+            this.remaining = count;
+            this.waiter = new CompletableFuture<>();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Boolean> next() {
+            if (remaining <= 0) {
+                return upstream.next();
+            }
+            drain();
+            return waiter;
+        }
+
+        void drain() {
+            if (getAndIncrement() != 0) {
+                return;
+            }
+            do {
+                upstream.next().whenComplete(this);
+            } while (decrementAndGet() != 0);
+        }
+
+        @Override
+        public void accept(Boolean t, Throwable u) {
+            if (u != null) {
+                waiter.completeExceptionally(u);
+            } else
+            if (t) {
+                if (remaining-- > 0) {
+                    drain();
+                } else {
+                    waiter.complete(true);
+                }
+            } else {
+                waiter.complete(false);
+            }
+        }
+
+        @Override
+        public @NonNull T current() {
+            return upstream.current();
+        }
+
+        @Override
+        public @NonNull CompletionStage<Void> finish() {
+            return upstream.finish();
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/disposables/DisposableTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import io.reactivex.rxjava4.core.RxJavaTest;
 import io.reactivex.rxjava4.exceptions.TestException;
 import io.reactivex.rxjava4.functions.Action;
-import io.reactivex.rxjava4.internal.disposables.DisposableHelper;
+import io.reactivex.rxjava4.internal.disposables.*;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.testsupport.TestHelper;
 
@@ -249,5 +249,20 @@ public class DisposableTest extends RxJavaTest {
         }
 
         assertTrue(d.isDisposed(), "d is not disposed");
+    }
+
+    @Test
+    public void disposableOnlyThrows() {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            enum Only implements DisposableOnly {
+                INSTANCE;
+                @Override
+                public void dispose() {
+                    // not used here
+                }
+            }
+
+            Only.INSTANCE.isDisposed();
+        });
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBaseTest.java
@@ -16,10 +16,11 @@ package io.reactivex.rxjava4.internal.operators.streamable;
 import java.lang.ref.Cleaner;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
-import java.util.function.BiConsumer;
+import java.util.function.*;
 
 import org.junit.jupiter.api.*;
 
+import io.reactivex.rxjava4.annotations.NonNull;
 import io.reactivex.rxjava4.core.*;
 import io.reactivex.rxjava4.core.config.StreamableInterceptConfig;
 import io.reactivex.rxjava4.exceptions.CompositeException;
@@ -164,6 +165,27 @@ public abstract class StreamableBaseTest extends RxJavaTest {
             Thread.sleep(0, 1000);
             if (--timeout <= 0L) {
                 throw new TimeoutException("hasStreamers still false");
+            }
+        }
+    }
+
+    /**
+     * Awaits a given {@link BooleanSupplier} to return the expected {@code value}
+     * within the given time period by sleeping in 1 microsecond increments until
+     * the timeout happens.
+     * @param value the expected value within the timeout period
+     * @param condition the condition to repeatedly call to assess the state
+     * @param timeoutMillis how long to wait for the condition to become as expected
+     * @throws InterruptedException if the sleep is interrupted
+     * @throws TimeoutException if the wait times out
+     */
+    public static void awaitCondition(boolean value, @NonNull BooleanSupplier condition, long timeoutMillis)
+            throws InterruptedException, TimeoutException {
+        long timeout = timeoutMillis * 1_000_000L;
+        while (condition.getAsBoolean() != value) {
+            Thread.sleep(0, 1000);
+            if (--timeout <= 0L) {
+                throw new TimeoutException("condition still " + (!value));
             }
         }
     }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBlockingTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableBlockingTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public class StreamableBlockingTest extends StreamableBaseTest {
+
+    @Test
+    public void blockingFirstNormal() throws Throwable {
+        assertEquals(1, Streamable.just(1).blockingFirst());
+    }
+
+    @Test
+    public void blockingFirstMany() throws Throwable {
+        assertEquals(1, Streamable.range(1, 5).blockingFirst());
+    }
+
+    @Test
+    public void blockingFirstEmpty() throws Throwable {
+        assertThrows(NoSuchElementException.class, () -> {
+            Streamable.empty().blockingFirst();
+        });
+    }
+
+    @Test
+    public void blockingFirstErrorUnchecked() throws Throwable {
+        assertThrows(TestException.class, () -> {
+            Streamable.error(new TestException()).blockingFirst();
+        });
+    }
+
+    @Test
+    public void blockingFirstErrorChecked() throws Throwable {
+        var ex = assertThrows(CompletionException.class, () -> {
+            Streamable.error(new IOException()).blockingFirst();
+        });
+
+        assertTrue(ex.getCause() instanceof IOException, "Wrong exception? " + ex.getCause());
+    }
+
+    @Test
+    public void blockingFirstFinishCrash() throws Throwable {
+        assertThrows(TestException.class, () -> {
+            StreamableFailingFinish.MAIN_COMPLETES.blockingFirst();
+        });
+    }
+
+    @Test
+    public void blockingFirstNextAndFinishCrash() throws Throwable {
+        var ex = assertThrows(TestException.class, () -> {
+            StreamableFailingFinish.MAIN_FAILS.blockingFirst();
+        });
+
+        assertTrue(ex.getSuppressed()[0] instanceof TestException, "Wrong exception? " + ex.getSuppressed()[0]);
+    }
+
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDeferTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableDeferTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+
 import io.reactivex.rxjava4.core.Streamable;
 import io.reactivex.rxjava4.exceptions.TestException;
 
@@ -41,6 +42,14 @@ public class StreamableDeferTest extends StreamableBaseTest {
     @Test
     public void crash() throws Throwable {
         Streamable.defer(() -> { throw new TestException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        Streamable.defer(() -> Streamable.error(new TestException()))
         .test()
         .awaitDone(5, TimeUnit.SECONDS)
         .assertFailure(TestException.class);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFailingFinish.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableFailingFinish.java
@@ -40,7 +40,7 @@ public enum StreamableFailingFinish implements Streamable<Integer> {
             var d = Disposable.fromFuture(cf, true);
             dc.add(d);
             if (mode == 1) {
-                cf.completeExceptionally(new TestException("StreamableFailingFinish(true)"));
+                cf.completeExceptionally(new TestException("StreamableFailingFinish.next()"));
             } else
             if (mode == 2) {
                 cf.complete(false);
@@ -55,7 +55,7 @@ public enum StreamableFailingFinish implements Streamable<Integer> {
 
         @Override
         public @NonNull CompletionStage<Void> finish() {
-            return CompletableFuture.failedFuture(new TestException());
+            return CompletableFuture.failedFuture(new TestException("StreamableFailingFinish.finish()"));
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableLastAsSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableLastAsSingleTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.internal.fuseable.HasUpstreamStreamableSource;
+import io.reactivex.rxjava4.processors.DispatchStreamProcessor;
+
+public class StreamableLastAsSingleTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .lastOrError()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(5);
+    }
+
+    @Test
+    public void emptyDefault() throws Throwable {
+        Streamable.empty()
+        .last(6)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(6);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        Streamable.error(new TestException())
+        .lastOrError()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void emptyNoDefault() throws Throwable {
+        Streamable.empty()
+        .lastOrError()
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NoSuchElementException.class);
+    }
+
+    @Test
+    public void nonEmptyDefault() throws Throwable {
+        Streamable.range(1, 5)
+        .last(7)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(5);
+    }
+
+    @Test
+    public void finallyCrash() throws Throwable {
+        StreamableFailingFinish.MAIN_COMPLETES
+        .last(7)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void cancelled() throws Throwable {
+        var dsp = new DispatchStreamProcessor<>();
+
+        var to = dsp.lastOrError()
+        .test();
+
+        to.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        awaitStreamers(dsp, 1000);
+
+        to.dispose();
+
+        awaitNoStreamers(dsp, 1000);
+    }
+
+    @Test
+    public void hasSource() {
+        var source = Streamable.range(1, 5);
+
+        var operator = source.lastOrError();
+
+        assertTrue(operator instanceof HasUpstreamStreamableSource<?> huss && source == huss.source(),
+                "HasUpstreamStreamableSource not supported or source() returns something unexpected: " + operator);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSingleFlattenAsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSingleFlattenAsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Single;
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.subjects.SingleSubject;
+
+public class StreamableSingleFlattenAsTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Single.just(1)
+        .flattenAsStreamable(v -> List.of(v * 10, v * 20, v * 30, v * 40, v * 50))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(10, 20, 30, 40, 50);
+    }
+
+    @Test
+    public void error() throws Throwable {
+        Single.<Integer>error(new TestException())
+        .flattenAsStreamable(v -> List.of(v * 10, v * 20, v * 30, v * 40, v * 50))
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void mapperNull() throws Throwable {
+        Single.just(1)
+        .flattenAsStreamable(_ -> null)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(NullPointerException.class);
+    }
+
+    @Test
+    public void mapperCrash() throws Throwable {
+        Single.just(1)
+        .flattenAsStreamable(_ -> { throw new TestException(); })
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void emptyInner() throws Throwable {
+        Single.just(1)
+        .flattenAsStreamable(_ -> List.of())
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void cancel() throws Throwable {
+        var ss = SingleSubject.create();
+
+        var to = ss.flattenAsStreamable(_ -> List.of())
+        .test();
+
+        to.awaitOnSubscribe(1, TimeUnit.SECONDS);
+
+        awaitCondition(true, () -> ss.hasObservers(), 1000);
+
+        to.cancel();
+
+        awaitCondition(false, () -> ss.hasObservers(), 1000);
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSkipTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/streamable/StreamableSkipTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.streamable;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava4.core.Streamable;
+import io.reactivex.rxjava4.exceptions.TestException;
+
+public class StreamableSkipTest extends StreamableBaseTest {
+
+    @Test
+    public void normal() throws Throwable {
+        Streamable.range(1, 5)
+        .skip(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(3, 4, 5);
+    }
+
+    @Test
+    public void doubleSkip() throws Throwable {
+        Streamable.range(1, 5)
+        .skip(2)
+        .skip(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(5);
+    }
+
+    @Test
+    public void crash() throws Throwable {
+        Streamable.error(new TestException())
+        .skip(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertFailure(TestException.class);
+    }
+
+    @Test
+    public void zeroSkip() throws Throwable {
+        Streamable.range(1, 5)
+        .skip(0)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void empty() throws Throwable {
+        Streamable.empty()
+        .skip(2)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void skipAll() throws Throwable {
+        Streamable.range(1, 5)
+        .skip(5)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+
+    @Test
+    public void skipMore() throws Throwable {
+        Streamable.range(1, 5)
+        .skip(6)
+        .test()
+        .awaitDone(5, TimeUnit.SECONDS)
+        .assertResult();
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckBaseTypeAnnotationsTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckBaseTypeAnnotationsTest.java
@@ -147,7 +147,8 @@ public class CheckBaseTypeAnnotationsTest extends RxJavaTest {
                     }
                 } else {
                     if (m.getReturnType() == Flowable.class
-                            || m.getReturnType() == ParallelFlowable.class) {
+                            || m.getReturnType() == ParallelFlowable.class
+                            || m.getReturnType() == Streamable.class) {
                         if (!m.isAnnotationPresent(BackpressureSupport.class)) {
                             b.append("No @BackpressureSupport annotation (having ")
                             .append(m.getReturnType().getSimpleName())

--- a/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
+++ b/src/test/java/io/reactivex/rxjava4/validators/CheckParamValidationTest.java
@@ -636,6 +636,8 @@ public class CheckParamValidationTest extends RxJavaTest {
         addIgnore(new ParamIgnore(Streamable.class, "intervalRange", Long.TYPE, Long.TYPE, Long.TYPE, Long.TYPE, TimeUnit.class, ExecutorService.class));
         // zero take is allowed
         addOverride(new ParamOverride(Streamable.class, 0, ParamMode.NON_NEGATIVE, "take", Long.TYPE));
+        // negative skip count is ignored
+        addOverride(new ParamOverride(Streamable.class, 0, ParamMode.NON_NEGATIVE, "skip", Long.TYPE));
 
         // -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Streamable

- `blockingFirst`
- `last`
- `lastOrError`
- `skip`

:information_source: Preparing minimal operators for the [Shakespeare Plays Scrabble benchmarks](https://github.com/akarnokd/akarnokd-misc/blob/master/src/jmh/java/hu/akarnokd/comparison/scrabble/ShakespearePlaysScrabbleWithRxJava4StreamableOpt.java).

# Single

- `flattenAsStreamable`

# Other

- `DisposableOnly` to avoid the need to cover a generally never called `isDisposable`. Operators will be updated later to use it.
- Fix documentation reported by the (updated) validator tests.