### PR TITLE
4.x: Move TestHelper.race tests into @Isolated classes (flatMap/mergeWith batch) (#8075)

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapIsolatedTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.plugins.RxJavaPlugins;
+import io.reactivex.rxjava4.processors.PublishProcessor;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableFlatMapIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void innerCompleteCancelRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+
+            final TestSubscriber<Integer> ts = Flowable.merge(Flowable.just(pp)).test();
+
+            Runnable r1 = pp::onComplete;
+
+            Runnable r2 = ts::cancel;
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void cancelScalarDrainRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+
+                final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
+
+                final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
+
+                Runnable r1 = ts::cancel;
+                Runnable r2 = pp::onComplete;
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void cancelDrainRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            for (int j = 1; j < 50; j += 5) {
+                List<Throwable> errors = TestHelper.trackPluginErrors();
+                try {
+
+                    final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
+
+                    final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
+
+                    final PublishProcessor<Integer> just = PublishProcessor.create();
+                    pp.onNext(just);
+
+                    Runnable r1 = () -> {
+                        ts.request(1);
+                        ts.cancel();
+                    };
+                    Runnable r2 = () -> just.onNext(1);
+
+                    TestHelper.race(r1, r2);
+
+                    assertTrue(errors.isEmpty(), errors.toString());
+                } finally {
+                    RxJavaPlugins.reset();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeIsolatedTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.Maybe;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.subjects.MaybeSubject;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableFlatMapMaybeIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void requestCancelRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
+            .flatMapMaybe(Functions.justFunction(Maybe.just(2))).test(0);
+
+            Runnable r1 = () -> ts.request(1);
+            Runnable r2 = ts::cancel;
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void successRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            MaybeSubject<Integer> ms1 = MaybeSubject.create();
+            MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+            TestSubscriber<Integer> ts = Flowable.just(ms1, ms2).flatMapMaybe(v -> v)
+            .test();
+
+            TestHelper.race(
+                    () -> ms1.onSuccess(1),
+                    () -> ms2.onSuccess(1)
+            );
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void successCompleteRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            MaybeSubject<Integer> ms1 = MaybeSubject.create();
+            MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+            TestSubscriber<Integer> ts = Flowable.just(ms1, ms2).flatMapMaybe(v -> v)
+            .test();
+
+            TestHelper.race(
+                    () -> ms1.onSuccess(1),
+                    ms2::onComplete
+            );
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapMaybeTest.java
@@ -472,19 +472,6 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     }
 
     @Test
-    public void requestCancelRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
-            .flatMapMaybe(Functions.justFunction(Maybe.just(2))).test(0);
-
-            Runnable r1 = () -> ts.request(1);
-            Runnable r2 = ts::cancel;
-
-            TestHelper.race(r1, r2);
-        }
-    }
-
-    @Test
     public void undeliverableUponCancel() {
         TestHelper.checkUndeliverableUponCancel((FlowableConverter<Integer, Flowable<Integer>>) upstream ->
             upstream.flatMapMaybe((Function<Integer, Maybe<Integer>>) v -> Maybe.just(v).hide()));
@@ -500,42 +487,6 @@ public class FlowableFlatMapMaybeTest extends RxJavaTest {
     @Test
     public void badRequest() {
         TestHelper.assertBadRequestReported(Flowable.never().flatMapMaybe(_ -> Maybe.never()));
-    }
-
-    @Test
-    public void successRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            MaybeSubject<Integer> ms1 = MaybeSubject.create();
-            MaybeSubject<Integer> ms2 = MaybeSubject.create();
-
-            TestSubscriber<Integer> ts = Flowable.just(ms1, ms2).flatMapMaybe(v -> v)
-            .test();
-
-            TestHelper.race(
-                    () -> ms1.onSuccess(1),
-                    () -> ms2.onSuccess(1)
-            );
-
-            ts.assertResult(1, 1);
-        }
-    }
-
-    @Test
-    public void successCompleteRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            MaybeSubject<Integer> ms1 = MaybeSubject.create();
-            MaybeSubject<Integer> ms2 = MaybeSubject.create();
-
-            TestSubscriber<Integer> ts = Flowable.just(ms1, ms2).flatMapMaybe(v -> v)
-            .test();
-
-            TestHelper.race(
-                    () -> ms1.onSuccess(1),
-                    ms2::onComplete
-            );
-
-            ts.assertResult(1);
-        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleIsolatedTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Flowable;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.core.Single;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.subjects.SingleSubject;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableFlatMapSingleIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void requestCancelRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
+            .flatMapSingle(Functions.justFunction(Single.just(2))).test(0);
+
+            Runnable r1 = () -> ts.request(1);
+            Runnable r2 = ts::cancel;
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void successRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            SingleSubject<Integer> ss1 = SingleSubject.create();
+            SingleSubject<Integer> ss2 = SingleSubject.create();
+
+            TestSubscriber<Integer> ts = Flowable.just(ss1, ss2).flatMapSingle(v -> v)
+            .test();
+
+            TestHelper.race(
+                    () -> ss1.onSuccess(1),
+                    () -> ss2.onSuccess(1)
+            );
+
+            ts.assertResult(1, 1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapSingleTest.java
@@ -383,19 +383,6 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void requestCancelRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final TestSubscriber<Integer> ts = Flowable.just(1).concatWith(Flowable.<Integer>never())
-            .flatMapSingle(Functions.justFunction(Single.just(2))).test(0);
-
-            Runnable r1 = () -> ts.request(1);
-            Runnable r2 = ts::cancel;
-
-            TestHelper.race(r1, r2);
-        }
-    }
-
-    @Test
     public void asyncFlattenErrorMaxConcurrency() {
         Flowable.range(1, 1000)
         .flatMapMaybe((Function<Integer, MaybeSource<Integer>>) _ ->
@@ -423,24 +410,6 @@ public class FlowableFlatMapSingleTest extends RxJavaTest {
     @Test
     public void badRequest() {
         TestHelper.assertBadRequestReported(Flowable.never().flatMapSingle(_ -> Single.never()));
-    }
-
-    @Test
-    public void successRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            SingleSubject<Integer> ss1 = SingleSubject.create();
-            SingleSubject<Integer> ss2 = SingleSubject.create();
-
-            TestSubscriber<Integer> ts = Flowable.just(ss1, ss2).flatMapSingle(v -> v)
-            .test();
-
-            TestHelper.race(
-                    () -> ss1.onSuccess(1),
-                    () -> ss2.onSuccess(1)
-            );
-
-            ts.assertResult(1, 1);
-        }
     }
 
     @Test

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableFlatMapTest.java
@@ -649,21 +649,6 @@ public class FlowableFlatMapTest extends RxJavaTest {
     }
 
     @Test
-    public void innerCompleteCancelRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-
-            final TestSubscriber<Integer> ts = Flowable.merge(Flowable.just(pp)).test();
-
-            Runnable r1 = pp::onComplete;
-
-            Runnable r2 = ts::cancel;
-
-            TestHelper.race(r1, r2);
-        }
-    }
-
-    @Test
     public void fusedInnerThrows() {
         Flowable.just(1).hide()
         .flatMap((Function<Integer, Flowable<Object>>) _ -> Flowable.range(1, 2).map(_ -> {
@@ -712,58 +697,6 @@ public class FlowableFlatMapTest extends RxJavaTest {
 
             assertTrue(list.contains("RxSi"), list.toString());
             assertTrue(list.contains("RxCo"), list.toString());
-        }
-    }
-
-    @Test
-    public void cancelScalarDrainRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            List<Throwable> errors = TestHelper.trackPluginErrors();
-            try {
-
-                final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
-
-                final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
-
-                Runnable r1 = ts::cancel;
-                Runnable r2 = pp::onComplete;
-
-                TestHelper.race(r1, r2);
-
-                assertTrue(errors.isEmpty(), errors.toString());
-            } finally {
-                RxJavaPlugins.reset();
-            }
-        }
-    }
-
-    @Test
-    public void cancelDrainRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            for (int j = 1; j < 50; j += 5) {
-                List<Throwable> errors = TestHelper.trackPluginErrors();
-                try {
-
-                    final PublishProcessor<Flowable<Integer>> pp = PublishProcessor.create();
-
-                    final TestSubscriber<Integer> ts = pp.flatMap(Functions.<Flowable<Integer>>identity()).test(0);
-
-                    final PublishProcessor<Integer> just = PublishProcessor.create();
-                    pp.onNext(just);
-
-                    Runnable r1 = () -> {
-                        ts.request(1);
-                        ts.cancel();
-                    };
-                    Runnable r2 = () -> just.onNext(1);
-
-                    TestHelper.race(r1, r2);
-
-                    assertTrue(errors.isEmpty(), errors.toString());
-                } finally {
-                    RxJavaPlugins.reset();
-                }
-            }
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableIsolatedTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.processors.PublishProcessor;
+import io.reactivex.rxjava4.subjects.CompletableSubject;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableMergeWithCompletableIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final CompletableSubject cs = CompletableSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                pp.onNext(1);
+                pp.onComplete();
+            };
+
+            Runnable r2 = cs::onComplete;
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithCompletableTest.java
@@ -99,27 +99,6 @@ public class FlowableMergeWithCompletableTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 1000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final CompletableSubject cs = CompletableSubject.create();
-
-            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                pp.onNext(1);
-                pp.onComplete();
-            };
-
-            Runnable r2 = cs::onComplete;
-
-            TestHelper.race(r1, r2);
-
-            ts.assertResult(1);
-        }
-    }
-
-    @Test
     public void cancelOtherOnMainError() {
         PublishProcessor<Integer> pp = PublishProcessor.create();
         CompletableSubject cs = CompletableSubject.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeIsolatedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.processors.PublishProcessor;
+import io.reactivex.rxjava4.subjects.MaybeSubject;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableMergeWithMaybeIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                pp.onNext(1);
+                pp.onComplete();
+            };
+
+            Runnable r2 = () -> cs.onSuccess(1);
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onSuccessFastPathBackpressuredRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
+
+            Runnable r1 = () -> cs.onSuccess(1);
+
+            Runnable r2 = () -> ts.request(2);
+
+            TestHelper.race(r1, r2);
+
+            pp.onNext(2);
+            pp.onComplete();
+
+            ts.assertResult(1, 2);
+        }
+    }
+
+    @Test
+    public void onNextRequestRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
+
+            pp.onNext(0);
+
+            Runnable r1 = () -> pp.onNext(1);
+
+            Runnable r2 = () -> ts.request(3);
+
+            TestHelper.race(r1, r2);
+
+            cs.onSuccess(1);
+            pp.onComplete();
+
+            ts.assertResult(0, 1, 1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithMaybeTest.java
@@ -124,27 +124,6 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final MaybeSubject<Integer> cs = MaybeSubject.create();
-
-            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                pp.onNext(1);
-                pp.onComplete();
-            };
-
-            Runnable r2 = () -> cs.onSuccess(1);
-
-            TestHelper.race(r1, r2);
-
-            ts.assertResult(1, 1);
-        }
-    }
-
-    @Test
     public void onNextSlowPath() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
         final MaybeSubject<Integer> cs = MaybeSubject.create();
@@ -216,27 +195,6 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
     }
 
     @Test
-    public void onSuccessFastPathBackpressuredRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final MaybeSubject<Integer> cs = MaybeSubject.create();
-
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
-
-            Runnable r1 = () -> cs.onSuccess(1);
-
-            Runnable r2 = () -> ts.request(2);
-
-            TestHelper.race(r1, r2);
-
-            pp.onNext(2);
-            pp.onComplete();
-
-            ts.assertResult(1, 2);
-        }
-    }
-
-    @Test
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -275,29 +233,6 @@ public class FlowableMergeWithMaybeTest extends RxJavaTest {
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    public void onNextRequestRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final MaybeSubject<Integer> cs = MaybeSubject.create();
-
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
-
-            pp.onNext(0);
-
-            Runnable r1 = () -> pp.onNext(1);
-
-            Runnable r2 = () -> ts.request(3);
-
-            TestHelper.race(r1, r2);
-
-            cs.onSuccess(1);
-            pp.onComplete();
-
-            ts.assertResult(0, 1, 1);
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleIsolatedTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.flowable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.processors.PublishProcessor;
+import io.reactivex.rxjava4.subjects.SingleSubject;
+import io.reactivex.rxjava4.subscribers.TestSubscriber;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class FlowableMergeWithSingleIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                pp.onNext(1);
+                pp.onComplete();
+            };
+
+            Runnable r2 = () -> cs.onSuccess(1);
+
+            TestHelper.race(r1, r2);
+
+            ts.assertResult(1, 1);
+        }
+    }
+
+    @Test
+    public void onSuccessFastPathBackpressuredRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
+
+            Runnable r1 = () -> cs.onSuccess(1);
+
+            Runnable r2 = () -> ts.request(2);
+
+            TestHelper.race(r1, r2);
+
+            pp.onNext(2);
+            pp.onComplete();
+
+            ts.assertResult(1, 2);
+        }
+    }
+
+    @Test
+    public void onNextRequestRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishProcessor<Integer> pp = PublishProcessor.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
+
+            pp.onNext(0);
+
+            Runnable r1 = () -> pp.onNext(1);
+
+            Runnable r2 = () -> ts.request(3);
+
+            TestHelper.race(r1, r2);
+
+            cs.onSuccess(1);
+            pp.onComplete();
+
+            ts.assertResult(0, 1, 1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableMergeWithSingleTest.java
@@ -120,27 +120,6 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final SingleSubject<Integer> cs = SingleSubject.create();
-
-            TestSubscriber<Integer> ts = pp.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                pp.onNext(1);
-                pp.onComplete();
-            };
-
-            Runnable r2 = () -> cs.onSuccess(1);
-
-            TestHelper.race(r1, r2);
-
-            ts.assertResult(1, 1);
-        }
-    }
-
-    @Test
     public void onNextSlowPath() {
         final PublishProcessor<Integer> pp = PublishProcessor.create();
         final SingleSubject<Integer> cs = SingleSubject.create();
@@ -212,27 +191,6 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void onSuccessFastPathBackpressuredRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final SingleSubject<Integer> cs = SingleSubject.create();
-
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).subscribeWith(new TestSubscriber<>(0));
-
-            Runnable r1 = () -> cs.onSuccess(1);
-
-            Runnable r2 = () -> ts.request(2);
-
-            TestHelper.race(r1, r2);
-
-            pp.onNext(2);
-            pp.onComplete();
-
-            ts.assertResult(1, 2);
-        }
-    }
-
-    @Test
     public void onErrorMainOverflow() {
         List<Throwable> errors = TestHelper.trackPluginErrors();
         try {
@@ -271,29 +229,6 @@ public class FlowableMergeWithSingleTest extends RxJavaTest {
             TestHelper.assertUndeliverable(errors, 0, TestException.class);
         } finally {
             RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    public void onNextRequestRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishProcessor<Integer> pp = PublishProcessor.create();
-            final SingleSubject<Integer> cs = SingleSubject.create();
-
-            final TestSubscriber<Integer> ts = pp.mergeWith(cs).test(0);
-
-            pp.onNext(0);
-
-            Runnable r1 = () -> pp.onNext(1);
-
-            Runnable r2 = () -> ts.request(3);
-
-            TestHelper.race(r1, r2);
-
-            cs.onSuccess(1);
-            pp.onComplete();
-
-            ts.assertResult(0, 1, 1);
         }
     }
 


### PR DESCRIPTION

**You set the work.** #8075, and your [go-ahead](https://github.com/ReactiveX/RxJava/issues/8075#issuecomment-5107720649): move `TestHelper.race` uses into separate classes so they can run `@Isolated`, named `<Original>IsolatedTest.java`, movements and conversions in separate PRs.

**It's done.** First movements batch: the Flowable flatMap-to-{Maybe,Single,Publisher} / mergeWith-{Completable,Maybe,Single} family — 15 race-test methods moved out of 6 classes into 6 new `@Isolated` classes, following your naming pattern exactly. Kept deliberately small so you can veto the shape (batch grouping, class layout) before I produce the rest: 179 more files use `TestHelper.race` and can follow in whatever batch size suits your review.

**Here's the evidence.**

- Fresh clone at `b7946f24`, patch applied, dependencies warmed, then the network was disconnected.
- Scoped suite in a clean `eclipse-temurin:26-jdk` container (pinned digest, linux/arm64), network off: **211 tests across all 12 touched classes, 0 failures, 0 errors** — per-class counts match the solve machine's run exactly. Full-tree `compileTestJava` clean.
- `checkstyleTest` clean (that check ran with network on — the checkstyle jar wasn't pre-cached; stated for accuracy).

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `b7946f24fc6ec1f6bc984bcc2810024efbad744e` |
| Container | `eclipse-temurin:26-jdk@sha256:939e3577…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f015512204d292ffaa8cc7fb6a55be950c1cb98b2ae88b6af6ea64934d9bca9689e366fe5) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f015512209542d5ce708004dec0750e070492aaa0b8a4fee8a28aa8d5d73513634da4a78b) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0xd65e6123a8b1bd0f1e500f0b8acc519e56b106215ebd0356698f3bb387f223f1) → [work delivered](https://sepolia.basescan.org/tx/0x76211d20b334ca68c0814d8de9b8154ef30788158484c0f675dfc1bd5fb9a064) → [checks passed](https://sepolia.basescan.org/tx/0x836bdf737bb089f6af768480ddf84acbda3380a7859dc8ca0800c8b8afa91ba4) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the change is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review — this one on your invitation in #8075.

---

## Everything below is written by Claude

Part of #8075 (movements category only; conversions of manual racing tests will come separately as you specified).

**Batch contents** — moved `TestHelper.race(` methods per class:

| Original | Moved | New class |
|---|---|---|
| `FlowableFlatMapMaybeTest` | 3 | `FlowableFlatMapMaybeIsolatedTest` |
| `FlowableFlatMapSingleTest` | 2 | `FlowableFlatMapSingleIsolatedTest` |
| `FlowableFlatMapTest` | 3 | `FlowableFlatMapIsolatedTest` |
| `FlowableMergeWithCompletableTest` | 1 | `FlowableMergeWithCompletableIsolatedTest` |
| `FlowableMergeWithMaybeTest` | 3 | `FlowableMergeWithMaybeIsolatedTest` |
| `FlowableMergeWithSingleTest` | 3 | `FlowableMergeWithSingleIsolatedTest` |

Each new class is `@Isolated`, extends `RxJavaTest`, keeps the license header and package, and takes only the imports the moved methods need. Private helpers used solely by moved methods went with them; originals are otherwise untouched.

### Notes for the reviewer

- **`@Isolated` is currently inert in this build**: `junit.jupiter.execution.parallel.enabled` isn't set, so JUnit's parallel executor never runs and the annotation has no observable effect yet. I read #8075 as prep for flipping that config later — if you'd rather this PR also enable parallel execution (or set it per-package), say so and I'll extend it.
- `TestHelper.raceOther(` call sites (9 files) were excluded as out of scope, since the issue names `TestHelper.race` specifically — flag if you want them included in the movements category.
- Batch grouping (one operator family per PR) is my choice, not something the issue specifies. Happy to switch to per-class PRs or bigger batches — 179 files remain.
