### PR TITLE
Move TestHelper.race tests into @Isolated classes: batch 2 (#8075)

### DIFF
--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapIsolatedTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.internal.functions.Functions;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.plugins.RxJavaPlugins;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableFlatMapIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void innerCompleteCancelRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+
+            final TestObserver<Integer> to = Observable.merge(Observable.just(ps)).test();
+
+            Runnable r1 = ps::onComplete;
+
+            Runnable r2 = to::dispose;
+
+            TestHelper.race(r1, r2);
+        }
+    }
+
+    @Test
+    public void cancelScalarDrainRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            List<Throwable> errors = TestHelper.trackPluginErrors();
+            try {
+
+                final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
+
+                final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
+
+                Runnable r1 = to::dispose;
+                Runnable r2 = ps::onComplete;
+
+                TestHelper.race(r1, r2);
+
+                assertTrue(errors.isEmpty(), errors.toString());
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+    }
+
+    @Test
+    public void cancelDrainRace() {
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            for (int j = 1; j < 50; j += 5) {
+                List<Throwable> errors = TestHelper.trackPluginErrors();
+                try {
+
+                    final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
+
+                    final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
+
+                    final PublishSubject<Integer> just = PublishSubject.create();
+                    final PublishSubject<Integer> just2 = PublishSubject.create();
+                    ps.onNext(just);
+                    ps.onNext(just2);
+
+                    Runnable r1 = () -> {
+                        just2.onNext(1);
+                        to.dispose();
+                    };
+                    Runnable r2 = () -> just.onNext(1);
+
+                    TestHelper.race(r1, r2);
+
+                    assertTrue(errors.isEmpty(), errors.toString());
+                } finally {
+                    RxJavaPlugins.reset();
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeIsolatedTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.Observable;
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.subjects.MaybeSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableFlatMapMaybeIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void successCompleteRace() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            MaybeSubject<Integer> ms1 = MaybeSubject.create();
+            MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+            TestObserver<Integer> to = Observable.just(1, 2)
+            .flatMapMaybe(v -> v == 1 ? ms1 : ms2)
+            .test();
+
+            TestHelper.race(
+                    ms1::onComplete,
+                    () -> ms2.onSuccess(1)
+            );
+
+            to.assertResult(1);
+        }
+    }
+
+    @Test
+    public void successCompleteRace2() {
+        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
+            MaybeSubject<Integer> ms1 = MaybeSubject.create();
+            MaybeSubject<Integer> ms2 = MaybeSubject.create();
+
+            TestObserver<Integer> to = Observable.just(1, 2)
+            .flatMapMaybe(v -> v == 1 ? ms1 : ms2)
+            .test();
+
+            TestHelper.race(
+                    () -> ms2.onSuccess(1),
+                    ms1::onComplete
+            );
+
+            to.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapMaybeTest.java
@@ -394,42 +394,4 @@ public class ObservableFlatMapMaybeTest extends RxJavaTest {
             cdl.await();
         }
     }
-
-    @Test
-    public void successCompleteRace() {
-        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            MaybeSubject<Integer> ms1 = MaybeSubject.create();
-            MaybeSubject<Integer> ms2 = MaybeSubject.create();
-
-            TestObserver<Integer> to = Observable.just(1, 2)
-            .flatMapMaybe(v -> v == 1 ? ms1 : ms2)
-            .test();
-
-            TestHelper.race(
-                    ms1::onComplete,
-                    () -> ms2.onSuccess(1)
-            );
-
-            to.assertResult(1);
-        }
-    }
-
-    @Test
-    public void successCompleteRace2() {
-        for (int i = 0; i < TestHelper.RACE_LONG_LOOPS; i++) {
-            MaybeSubject<Integer> ms1 = MaybeSubject.create();
-            MaybeSubject<Integer> ms2 = MaybeSubject.create();
-
-            TestObserver<Integer> to = Observable.just(1, 2)
-            .flatMapMaybe(v -> v == 1 ? ms1 : ms2)
-            .test();
-
-            TestHelper.race(
-                    () -> ms2.onSuccess(1),
-                    ms1::onComplete
-            );
-
-            to.assertResult(1);
-        }
-    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleIsolatedTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.exceptions.TestException;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.subjects.SingleSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableFlatMapSingleIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void innerErrorOuterCompleteRace() {
+        TestException ex = new TestException();
+        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
+            PublishSubject<Integer> ps1 = PublishSubject.create();
+            SingleSubject<Integer> ps2 = SingleSubject.create();
+
+            TestObserver<Integer> to = ps1.flatMapSingle(_ -> ps2)
+            .test();
+
+            ps1.onNext(1);
+
+            TestHelper.race(
+                    ps1::onComplete,
+                    () -> ps2.onError(ex)
+            );
+
+            to.assertFailure(TestException.class);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapSingleTest.java
@@ -310,27 +310,6 @@ public class ObservableFlatMapSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void innerErrorOuterCompleteRace() {
-        TestException ex = new TestException();
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            PublishSubject<Integer> ps1 = PublishSubject.create();
-            SingleSubject<Integer> ps2 = SingleSubject.create();
-
-            TestObserver<Integer> to = ps1.flatMapSingle(_ -> ps2)
-            .test();
-
-            ps1.onNext(1);
-
-            TestHelper.race(
-                    ps1::onComplete,
-                    () -> ps2.onError(ex)
-            );
-
-            to.assertFailure(TestException.class);
-        }
-    }
-
-    @Test
     public void cancelWhileMapping() throws Throwable {
         for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
             PublishSubject<Integer> ps1 = PublishSubject.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -537,21 +537,6 @@ public class ObservableFlatMapTest extends RxJavaTest {
     }
 
     @Test
-    public void innerCompleteCancelRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            final PublishSubject<Integer> ps = PublishSubject.create();
-
-            final TestObserver<Integer> to = Observable.merge(Observable.just(ps)).test();
-
-            Runnable r1 = ps::onComplete;
-
-            Runnable r2 = to::dispose;
-
-            TestHelper.race(r1, r2);
-        }
-    }
-
-    @Test
     public void fusedInnerThrows() {
         Observable.just(1).hide()
         .flatMap((Function<Integer, ObservableSource<Object>>) _ -> Observable.range(1, 2).map(_ -> {
@@ -592,60 +577,6 @@ public class ObservableFlatMapTest extends RxJavaTest {
 
             assertTrue(list.contains("RxSi"), list.toString());
             assertTrue(list.contains("RxCo"), list.toString());
-        }
-    }
-
-    @Test
-    public void cancelScalarDrainRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            List<Throwable> errors = TestHelper.trackPluginErrors();
-            try {
-
-                final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
-
-                final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
-
-                Runnable r1 = to::dispose;
-                Runnable r2 = ps::onComplete;
-
-                TestHelper.race(r1, r2);
-
-                assertTrue(errors.isEmpty(), errors.toString());
-            } finally {
-                RxJavaPlugins.reset();
-            }
-        }
-    }
-
-    @Test
-    public void cancelDrainRace() {
-        for (int i = 0; i < TestHelper.RACE_DEFAULT_LOOPS; i++) {
-            for (int j = 1; j < 50; j += 5) {
-                List<Throwable> errors = TestHelper.trackPluginErrors();
-                try {
-
-                    final PublishSubject<Observable<Integer>> ps = PublishSubject.create();
-
-                    final TestObserver<Integer> to = ps.flatMap(Functions.<Observable<Integer>>identity()).test();
-
-                    final PublishSubject<Integer> just = PublishSubject.create();
-                    final PublishSubject<Integer> just2 = PublishSubject.create();
-                    ps.onNext(just);
-                    ps.onNext(just2);
-
-                    Runnable r1 = () -> {
-                        just2.onNext(1);
-                        to.dispose();
-                    };
-                    Runnable r2 = () -> just.onNext(1);
-
-                    TestHelper.race(r1, r2);
-
-                    assertTrue(errors.isEmpty(), errors.toString());
-                } finally {
-                    RxJavaPlugins.reset();
-                }
-            }
         }
     }
 

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableIsolatedTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.subjects.CompletableSubject;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableMergeWithCompletableIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 1000; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+            final CompletableSubject cs = CompletableSubject.create();
+
+            TestObserver<Integer> to = ps.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                ps.onNext(1);
+                ps.onComplete();
+            };
+
+            Runnable r2 = cs::onComplete;
+
+            TestHelper.race(r1, r2);
+
+            to.assertResult(1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithCompletableTest.java
@@ -84,27 +84,6 @@ public class ObservableMergeWithCompletableTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 1000; i++) {
-            final PublishSubject<Integer> ps = PublishSubject.create();
-            final CompletableSubject cs = CompletableSubject.create();
-
-            TestObserver<Integer> to = ps.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                ps.onNext(1);
-                ps.onComplete();
-            };
-
-            Runnable r2 = cs::onComplete;
-
-            TestHelper.race(r1, r2);
-
-            to.assertResult(1);
-        }
-    }
-
-    @Test
     public void isDisposed() {
         new Observable<Integer>() /* NFI */ {
             @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeIsolatedTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.subjects.MaybeSubject;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableMergeWithMaybeIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+            final MaybeSubject<Integer> cs = MaybeSubject.create();
+
+            TestObserver<Integer> to = ps.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                ps.onNext(1);
+                ps.onComplete();
+            };
+
+            Runnable r2 = () -> cs.onSuccess(1);
+
+            TestHelper.race(r1, r2);
+
+            to.assertResult(1, 1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithMaybeTest.java
@@ -99,27 +99,6 @@ public class ObservableMergeWithMaybeTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishSubject<Integer> ps = PublishSubject.create();
-            final MaybeSubject<Integer> cs = MaybeSubject.create();
-
-            TestObserver<Integer> to = ps.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                ps.onNext(1);
-                ps.onComplete();
-            };
-
-            Runnable r2 = () -> cs.onSuccess(1);
-
-            TestHelper.race(r1, r2);
-
-            to.assertResult(1, 1);
-        }
-    }
-
-    @Test
     public void onNextSlowPath() {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final MaybeSubject<Integer> cs = MaybeSubject.create();

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleIsolatedTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleIsolatedTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-present, RxJava Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License.
+ */
+
+package io.reactivex.rxjava4.internal.operators.observable;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import io.reactivex.rxjava4.core.RxJavaTest;
+import io.reactivex.rxjava4.observers.TestObserver;
+import io.reactivex.rxjava4.subjects.PublishSubject;
+import io.reactivex.rxjava4.subjects.SingleSubject;
+import io.reactivex.rxjava4.testsupport.TestHelper;
+
+@Isolated
+public class ObservableMergeWithSingleIsolatedTest extends RxJavaTest {
+
+    @Test
+    public void completeRace() {
+        for (int i = 0; i < 10000; i++) {
+            final PublishSubject<Integer> ps = PublishSubject.create();
+            final SingleSubject<Integer> cs = SingleSubject.create();
+
+            TestObserver<Integer> to = ps.mergeWith(cs).test();
+
+            Runnable r1 = () -> {
+                ps.onNext(1);
+                ps.onComplete();
+            };
+
+            Runnable r2 = () -> cs.onSuccess(1);
+
+            TestHelper.race(r1, r2);
+
+            to.assertResult(1, 1);
+        }
+    }
+}

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableMergeWithSingleTest.java
@@ -91,27 +91,6 @@ public class ObservableMergeWithSingleTest extends RxJavaTest {
     }
 
     @Test
-    public void completeRace() {
-        for (int i = 0; i < 10000; i++) {
-            final PublishSubject<Integer> ps = PublishSubject.create();
-            final SingleSubject<Integer> cs = SingleSubject.create();
-
-            TestObserver<Integer> to = ps.mergeWith(cs).test();
-
-            Runnable r1 = () -> {
-                ps.onNext(1);
-                ps.onComplete();
-            };
-
-            Runnable r2 = () -> cs.onSuccess(1);
-
-            TestHelper.race(r1, r2);
-
-            to.assertResult(1, 1);
-        }
-    }
-
-    @Test
     public void onNextSlowPath() {
         final PublishSubject<Integer> ps = PublishSubject.create();
         final SingleSubject<Integer> cs = SingleSubject.create();


### PR DESCRIPTION
Continues the pattern from #8253 onto the Observable flatMap/mergeWith family, the direct counterpart to the Flowable batch already merged. Same shape: TestHelper.race( calls moved into new *IsolatedTest.java classes, @Isolated annotation, originals otherwise untouched.

9 methods moved across 6 classes (smaller than batch 1's 15, since Observable has no backpressure protocol, so the request based race variants don't apply here).

Tests: all 12 touched classes, run twice, 0 failures / 0 errors both rounds. Full tree compileTestJava and checkstyleTest both clean. JDK 26.

179 to 173 files with the pattern remain.
