### PR TITLE
4.x: Fix consumer retention in cache() upon subscribe-cancel race

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCache.java
@@ -83,6 +83,9 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
         CacheSubscription<T> consumer = new CacheSubscription<>(t, multicaster, head);
         t.onSubscribe(consumer);
         multicaster.add(consumer);
+        if (consumer.isCancelled()) {
+            multicaster.remove(consumer);
+        }
 
         if (!once.get() && once.compareAndSet(false, true)) {
             source.subscribe(multicaster);
@@ -414,6 +417,10 @@ public final class FlowableCache<T> extends AbstractFlowableWithUpstream<T, T> {
             if (requested.getAndSet(Long.MIN_VALUE) != Long.MIN_VALUE) {
                 parent.remove(this);
             }
+        }
+
+        public boolean isCancelled() {
+            return requested.get() == Long.MIN_VALUE;
         }
     }
 

--- a/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCache.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCache.java
@@ -48,7 +48,7 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
     /**
      * Responsible caching events from the source and multicasting them to each downstream.
      */
-    final Multicaster<T>  multicaster;
+    final Multicaster<T> multicaster;
 
     /**
      * The first node in a singly linked list. Each node has the capacity to hold a specific number of events, and each
@@ -79,6 +79,9 @@ public final class ObservableCache<T> extends AbstractObservableWithUpstream<T, 
         CacheDisposable<T> consumer = new CacheDisposable<>(t, multicaster, head);
         t.onSubscribe(consumer);
         multicaster.add(consumer);
+        if (consumer.isDisposed()) {
+            multicaster.remove(consumer);
+        }
 
         if (!once.get() && once.compareAndSet(false, true)) {
             source.subscribe(multicaster);

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/flowable/FlowableCacheTest.java
@@ -16,13 +16,10 @@ package io.reactivex.rxjava4.internal.operators.flowable;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
+import java.lang.management.*;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.*;
 
 import org.junit.jupiter.api.Test;
 
@@ -513,5 +510,19 @@ public class FlowableCacheTest extends RxJavaTest {
             fail("Bounded Replay Leak check: Memory leak detected: " + (initial / 1024.0 / 1024.0)
                     + " -> " + after.get() / 1024.0 / 1024.0);
         }
+    }
+
+    @Test
+    public void noRetentionOnImmediateSelfCancel() {
+        var source = (FlowableCache<Integer>)Flowable.<Integer>never().cache();
+
+        var consumer = new TestSubscriber<Integer>();
+        consumer.cancel();
+
+        source.subscribe(consumer);
+
+        consumer.assertNoValues().assertNoErrors().assertNotComplete();
+
+        assertEquals(0, source.multicaster.get().length, "Retention error!");
     }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableCacheTest.java
@@ -370,4 +370,29 @@ public class ObservableCacheTest extends RxJavaTest {
                     + " -> " + after.get() / 1024.0 / 1024.0);
         }
     }
+
+    @Test
+    public void cancelledUpFrontConnectAnyway() {
+        final AtomicInteger call = new AtomicInteger();
+        Observable.fromCallable(call::incrementAndGet)
+        .cache()
+        .test(true)
+        .assertNoValues();
+
+        assertEquals(1, call.get());
+    }
+
+    @Test
+    public void noRetentionOnImmediateSelfCancel() {
+        var source = (ObservableCache<Integer>)Observable.<Integer>never().cache();
+
+        var consumer = new TestObserver<Integer>();
+        consumer.dispose();
+
+        source.subscribe(consumer);
+
+        consumer.assertNoValues().assertNoErrors().assertNotComplete();
+
+        assertEquals(0, source.multicaster.get().length, "Retention error!");
+    }
 }

--- a/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/operators/observable/ObservableFlatMapTest.java
@@ -32,7 +32,6 @@ import io.reactivex.rxjava4.core.config.StandardConcurrentBufferedConfig;
 import io.reactivex.rxjava4.disposables.Disposable;
 import io.reactivex.rxjava4.exceptions.*;
 import io.reactivex.rxjava4.functions.*;
-import io.reactivex.rxjava4.internal.functions.Functions;
 import io.reactivex.rxjava4.observers.TestObserver;
 import io.reactivex.rxjava4.plugins.RxJavaPlugins;
 import io.reactivex.rxjava4.schedulers.Schedulers;


### PR DESCRIPTION
When the incoming `Subscriber` or `Observer` cancels while in their respective `onSubscribe` or race it afterwards, the operator could retain it in its consumer tracking array indefinitely, depending on the cached source.

The fix is, like many other place is to after add, check if the consumer cancelled and then manually remove them for sure.

In addition, apparently the test `cancelledUpFrontConnectAnyway` was missing from `ObservableCacheTest` which is important because the `cache` operator is expected to connect, even with dead consumers.

## Privately reported as an ??? exploit ???

@August829 

RxJava-09: ObservableCache/FlowableCache Register Consumers Before Checking Disposed State — Self-Disposing Subscribers Permanently Retained

🛑 Do not report bugs as security exploits. 🛑