### PR TITLE
Fix Observable.take scheduler annotation

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/core/Observable.java
+++ b/src/main/java/io/reactivex/rxjava4/core/Observable.java
@@ -11489,7 +11489,7 @@ public abstract class Observable<@NonNull T> implements ObservableSource<T> {
      * @see <a href="http://reactivex.io/documentation/operators/take.html">ReactiveX operators documentation: Take</a>
      */
     @CheckReturnValue
-    @SchedulerSupport(SchedulerSupport.NONE)
+    @SchedulerSupport(SchedulerSupport.COMPUTATION)
     @NonNull
     public final Observable<T> take(long time, @NonNull TimeUnit unit) {
         return takeUntil(timer(time, unit));


### PR DESCRIPTION
## Summary

- change the scheduler support for `Observable.take(long, TimeUnit)` from `NONE` to `COMPUTATION`
- align the annotation with the default `timer(time, unit)` implementation, its Javadoc, and the equivalent `Flowable` overload

Fixes #8288

## Validation

- `./gradlew test --tests "io.reactivex.rxjava4.validators.CheckBaseTypeAnnotationsTest" --tests "io.reactivex.rxjava4.validators.CheckJavadocForAnnotationsTest"`
- `./gradlew test --tests "io.reactivex.rxjava4.validators.*" --stacktrace --no-daemon`
- `./gradlew build --stacktrace`
- `./gradlew javadoc --stacktrace`

## AI disclosure

This contribution was made with OpenAI Codex assistance. Codex inspected the current `4.x` implementation and contribution policy, applied the one-line annotation correction, and ran the validation listed above. The reasoning was that this overload delegates to the default computation-scheduler `timer`, its Javadoc already documents computation scheduling, and the equivalent `Flowable` overload already uses `SchedulerSupport.COMPUTATION`.