### PR TITLE
Fix timeout handling in SchedulerToExecutorService.awaitTermination

### DIFF
--- a/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
+++ b/src/main/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorService.java
@@ -84,13 +84,29 @@ public record SchedulerToExecutorService(@NonNull Scheduler scheduler,
     @Override
     public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
         // FIXME no idea how to passively wait, not really applicable in Rx
-        long totalTime = unit.convert(timeout, TimeUnit.MILLISECONDS);
-
-        while (!isTerminated() && totalTime > 0) {
-            totalTime--;
-            Thread.sleep(1);
+        long timeoutNanos = unit.toNanos(timeout);
+        if (isTerminated()) {
+            return true;
         }
-        return totalTime > 0;
+        if (timeoutNanos <= 0) {
+            return false;
+        }
+
+        long start = System.nanoTime();
+        for (;;) {
+            if (isTerminated()) {
+                return true;
+            }
+
+            long elapsed = System.nanoTime() - start;
+            long remaining = timeoutNanos - elapsed;
+            if (remaining <= 0) {
+                return isTerminated();
+            }
+
+            // There is no termination signal to await, so poll at a short interval.
+            TimeUnit.NANOSECONDS.sleep(Math.min(remaining, TimeUnit.MILLISECONDS.toNanos(1)));
+        }
     }
 
     @Override

--- a/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
+++ b/src/test/java/io/reactivex/rxjava4/internal/schedulers/SchedulerToExecutorServiceTest.java
@@ -216,4 +216,32 @@ public class SchedulerToExecutorServiceTest {
             assertTrue(f.isCancelled(), "Task was not cancelled: " + f);
         }
     }
+
+    @Test
+    public void awaitTerminationUsesRequestedTimeUnit() throws Exception {
+        Scheduler scheduler = Schedulers.computation();
+        Scheduler.Worker worker = scheduler.createWorker();
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                scheduler, new AtomicReference<>(worker));
+
+        try {
+            scheduler.scheduleDirect(worker::dispose, 50, TimeUnit.MILLISECONDS);
+
+            assertTrue(executor.awaitTermination(1, TimeUnit.SECONDS));
+        } finally {
+            worker.dispose();
+        }
+    }
+
+    @Test
+    public void awaitTerminationReturnsTrueIfAlreadyTerminated() throws Exception {
+        SchedulerToExecutorService executor = new SchedulerToExecutorService(
+                Schedulers.computation(), new AtomicReference<>(null));
+
+        assertFalse(executor.awaitTermination(0, TimeUnit.MILLISECONDS));
+
+        executor.shutdown();
+
+        assertTrue(executor.awaitTermination(0, TimeUnit.MILLISECONDS));
+    }
 }


### PR DESCRIPTION
This PR fixes timeout handling in SchedulerToExecutorService.awaitTermination().

The previous implementation converted the timeout in the wrong direction:

    unit.convert(timeout, TimeUnit.MILLISECONDS)

For example, awaitTermination(1, TimeUnit.SECONDS) converted the value to zero and returned immediately without waiting.

